### PR TITLE
1300-split-hashtable-in-model-and-test-package

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -276,9 +276,18 @@ BaselineOfMoose >> baselineGrease: spec [
 { #category : #baseline }
 BaselineOfMoose >> baselineHashtable: spec [ 
     
-	self defineGroup: #'HashTable-Group' in: spec locatedIn: #HashTable with: #(
+	self defineGroup: #'HashTable-Base' in: spec locatedIn: #HashTable with: #(
 		'Hashtable'
-	) 
+	).
+	
+	self defineGroup: #'HashTable-Tests-Group' in: spec locatedIn: #HashTable with: #(
+		'Hashtable-Tests'
+	).
+	
+	spec group: 'HashTable-Group' with: #(
+		'HashTable-Base'
+		'HashTable-Tests-Group'
+	).
 ]
 
 { #category : #baseline }
@@ -475,7 +484,7 @@ BaselineOfMoose >> groups: spec [
 		'Ring2' 
 		'Grease' 
 		'CollectionExtensions-Group'
-		'HashTable-Group'
+		'HashTable'
 		'StateSpecs-Base'
 		'Fame'
 		'DeepTraverser-Base'
@@ -546,6 +555,7 @@ BaselineOfMoose >> groups: spec [
 		'Famix-Compatibility-Tests-Java'
 		'Famix-Compatibility-Tests-Extensions'
 		'DeepTraverser-Tests-Group'
+		'Hashtable-Tests-Group'
 	).	
 
 	spec group: 'BasicMetamodellingWithRoassal' with: #(

--- a/src/Hashtable-Tests/DictionarySpeedTest.class.st
+++ b/src/Hashtable-Tests/DictionarySpeedTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'stepsize',
 		'testsize'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #finding }

--- a/src/Hashtable-Tests/HashBagTest.class.st
+++ b/src/Hashtable-Tests/HashBagTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'bag'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }

--- a/src/Hashtable-Tests/HashSetTest.class.st
+++ b/src/Hashtable-Tests/HashSetTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'set'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Hashtable-Tests/HashTableTest.class.st
+++ b/src/Hashtable-Tests/HashTableTest.class.st
@@ -1,22 +1,22 @@
 Class {
-	#name : #WeakKeyHashTableTest,
+	#name : #HashTableTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'table',
 		'testsize'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }
-WeakKeyHashTableTest >> setUp [
+HashTableTest >> setUp [
 	super setUp.
-	table := WeakKeyHashTable new.
+	table := HashTable new.
 	testsize := 100.
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testAddAll [
+HashTableTest >> testAddAll [
 	"(self run: #testAddAll)"
 	
 	|  table2 |
@@ -34,7 +34,7 @@ WeakKeyHashTableTest >> testAddAll [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testAddAssoc [
+HashTableTest >> testAddAssoc [
 	0 to: testsize do: [ :each |
 		self assert: table size = each.
 		table add: each -> each asString ].
@@ -43,7 +43,7 @@ WeakKeyHashTableTest >> testAddAssoc [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testAddCopy [
+HashTableTest >> testAddCopy [
 	| table2 |
 	0 to: testsize do: [ :each |
 		table add: each -> each asString ].
@@ -54,7 +54,7 @@ WeakKeyHashTableTest >> testAddCopy [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testAddInteger [
+HashTableTest >> testAddInteger [
 	0 to: testsize do: [ :each |
 		self assert: table size = each.
 		table at: each put: each asString ].
@@ -63,26 +63,44 @@ WeakKeyHashTableTest >> testAddInteger [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testAddNil [
+HashTableTest >> testAddNil [
 	self deny: (table includesKey: nil).
-	self should: [ table at: nil put: 'nil' ] raise: Error.
-	self deny: (table includesKey: nil) = 'nil'.
+	table at: nil put: 'nil'.
+	self assert:(table at: nil) = 'nil'.
+	
+	self assert: (table includesKey: nil).
+	
+	table at: nil put: 'ok'.
+	self assert:(table at: nil) = 'ok'.
+	
+	table removeKey: nil.
+	self deny: (table includesKey: nil).
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testAddString [
+HashTableTest >> testAddString [
+	0 to: testsize do: [ :each |
+		self assert: table size = each.
+		table at: each asString put: each ].
+	0 to: testsize do: [ :each |
+		self assert: (table at: each asString ) = each ].
+]
+
+{ #category : #testing }
+HashTableTest >> testAssociactionssDo [
 	| keys |
-	keys := (0 to: testsize) collect: [ :each | each asString ].
+	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
-		self assert: table size = each asNumber.
-		table at: each put: each asNumber ].
-	keys := (0 to: testsize) collect: [ :each | each asString ].
-	keys do: [ :each |
-		self assert: (table at: each ) = each asNumber ].
+		table at: each put: each ].
+	table associationsDo: [ :assoc |
+		self assert: assoc key = assoc value.
+		self assert: (keys includes: assoc key).
+		keys remove: assoc key ifAbsent: [ self fail ] ].
+	self assert: keys isEmpty
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testComma [
+HashTableTest >> testComma [
 	"(self run: #testComma)"
 	
 	| table1 table2 |
@@ -100,7 +118,7 @@ WeakKeyHashTableTest >> testComma [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testEqualsDictionary [
+HashTableTest >> testEqualsDictionary [
 	| dictionary |
 	dictionary := Dictionary new.
 	0 to: testsize do: [ :each |
@@ -111,7 +129,7 @@ WeakKeyHashTableTest >> testEqualsDictionary [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testEqualsTransitive [
+HashTableTest >> testEqualsTransitive [
 	| table2 |
 	table2 := table species new.
 	0 to: testsize do: [ :each |
@@ -123,7 +141,7 @@ WeakKeyHashTableTest >> testEqualsTransitive [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testKeys [
+HashTableTest >> testKeys [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -132,7 +150,7 @@ WeakKeyHashTableTest >> testKeys [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testKeysAndValuesDo [
+HashTableTest >> testKeysAndValuesDo [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -145,7 +163,7 @@ WeakKeyHashTableTest >> testKeysAndValuesDo [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testKeysDo [
+HashTableTest >> testKeysDo [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -157,7 +175,18 @@ WeakKeyHashTableTest >> testKeysDo [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testRemoveInteger [
+HashTableTest >> testRemoveFromCopy [
+	| original copy |
+	original := HashTable new.
+	($a to: $z) do: [ :each |
+		original at: each put: each ].
+	copy := original copy.
+	copy removeKey: $b.
+	self assert: (original at: $b) = $b
+]
+
+{ #category : #testing }
+HashTableTest >> testRemoveInteger [
 	0 to: testsize do: [ :each |
 		self assert: table size = each.
 		table at: each put: each asString ].
@@ -172,15 +201,13 @@ WeakKeyHashTableTest >> testRemoveInteger [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testRemoveString [
-	| keys |
-	keys := (0 to: testsize) collect: [ :each | each asString ].
-	keys do: [ :each |
-		self assert: table size = each asNumber.
-		table at: each put: each asNumber ].
+HashTableTest >> testRemoveString [
+	0 to: testsize do: [ :each |
+		self assert: table size = each.
+		table at: each asString put: each ].
 	
 	0 to: testsize by: 2 do: [ :each |
-		self assert: (table includesKey: (keys at: each + 1)).
+		self assert: (table includesKey: each asString).
 		table removeKey: each asString.
 		self deny: (table includesKey: each asString) ].
 	
@@ -189,14 +216,12 @@ WeakKeyHashTableTest >> testRemoveString [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testSize [
-	| keys |
-	keys := (1 to: testsize) collect: [ :each | each asString ].
+HashTableTest >> testSize [
 	self assert: table size = 0.
 	
-	keys do: [ :each |		
-		table at: each put: each asNumber.
-		self assert: table size = each asNumber. ].
+	1 to: testsize do: [ :each |		
+		table at: each asString put: each.
+		self assert: table size = each. ].
 	
 	1 to: testsize do: [ :each |
 		self assert: table size = testsize.
@@ -210,16 +235,16 @@ WeakKeyHashTableTest >> testSize [
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testValues [
+HashTableTest >> testValues [
 	| keys |
-	keys := (1 to: 100) asOrderedCollection collect: [ :each | each asString ].
+	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
-		table at: each put: each ].
-	self assert: ((table values collect: [ :each | each asNumber ]) asArray sort = (1 to: 100) asArray)
+		table at: each asString put: each ].
+	self assert: table values asArray sort = (1 to: 100) asArray
 ]
 
 { #category : #testing }
-WeakKeyHashTableTest >> testValuesDo [
+HashTableTest >> testValuesDo [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -228,26 +253,4 @@ WeakKeyHashTableTest >> testValuesDo [
 		self assert: (keys includes: each).
 		keys remove: each ifAbsent: [ self fail ] ].
 	self assert: keys isEmpty
-]
-
-{ #category : #testing }
-WeakKeyHashTableTest >> testWeakInstance [
-	| createBlock string |
-	createBlock := [(String new: 3)
-		at: 1 put: $n;
-		at: 2 put: $e;
-		at: 3 put: $w;
-		yourself ].
-	string := createBlock value.
-	
-	table at: string put: true.
-	self assert: (table at: string).
-	self assert: (table at: createBlock value).
-	self assert: table size = 1.
-	string := nil.
-	Smalltalk garbageCollect.
-	
-	string := createBlock value.
-	self deny: (table includesKey: string).
-	self assert: table isEmpty.
 ]

--- a/src/Hashtable-Tests/IdentityHashBagTest.class.st
+++ b/src/Hashtable-Tests/IdentityHashBagTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'bag'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }

--- a/src/Hashtable-Tests/IdentityHashSetTest.class.st
+++ b/src/Hashtable-Tests/IdentityHashSetTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'set'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }

--- a/src/Hashtable-Tests/IdentityHashTableTest.class.st
+++ b/src/Hashtable-Tests/IdentityHashTableTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'table',
 		'testsize'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }

--- a/src/Hashtable-Tests/WeakHashSetTest.class.st
+++ b/src/Hashtable-Tests/WeakHashSetTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #WeakHashSetTest,
 	#superclass : #HashSetTest,
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }

--- a/src/Hashtable-Tests/WeakKeyHashTableTest.class.st
+++ b/src/Hashtable-Tests/WeakKeyHashTableTest.class.st
@@ -1,22 +1,22 @@
 Class {
-	#name : #HashTableTest,
+	#name : #WeakKeyHashTableTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'table',
 		'testsize'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }
-HashTableTest >> setUp [
+WeakKeyHashTableTest >> setUp [
 	super setUp.
-	table := HashTable new.
+	table := WeakKeyHashTable new.
 	testsize := 100.
 ]
 
 { #category : #testing }
-HashTableTest >> testAddAll [
+WeakKeyHashTableTest >> testAddAll [
 	"(self run: #testAddAll)"
 	
 	|  table2 |
@@ -34,7 +34,7 @@ HashTableTest >> testAddAll [
 ]
 
 { #category : #testing }
-HashTableTest >> testAddAssoc [
+WeakKeyHashTableTest >> testAddAssoc [
 	0 to: testsize do: [ :each |
 		self assert: table size = each.
 		table add: each -> each asString ].
@@ -43,7 +43,7 @@ HashTableTest >> testAddAssoc [
 ]
 
 { #category : #testing }
-HashTableTest >> testAddCopy [
+WeakKeyHashTableTest >> testAddCopy [
 	| table2 |
 	0 to: testsize do: [ :each |
 		table add: each -> each asString ].
@@ -54,7 +54,7 @@ HashTableTest >> testAddCopy [
 ]
 
 { #category : #testing }
-HashTableTest >> testAddInteger [
+WeakKeyHashTableTest >> testAddInteger [
 	0 to: testsize do: [ :each |
 		self assert: table size = each.
 		table at: each put: each asString ].
@@ -63,44 +63,26 @@ HashTableTest >> testAddInteger [
 ]
 
 { #category : #testing }
-HashTableTest >> testAddNil [
+WeakKeyHashTableTest >> testAddNil [
 	self deny: (table includesKey: nil).
-	table at: nil put: 'nil'.
-	self assert:(table at: nil) = 'nil'.
-	
-	self assert: (table includesKey: nil).
-	
-	table at: nil put: 'ok'.
-	self assert:(table at: nil) = 'ok'.
-	
-	table removeKey: nil.
-	self deny: (table includesKey: nil).
+	self should: [ table at: nil put: 'nil' ] raise: Error.
+	self deny: (table includesKey: nil) = 'nil'.
 ]
 
 { #category : #testing }
-HashTableTest >> testAddString [
-	0 to: testsize do: [ :each |
-		self assert: table size = each.
-		table at: each asString put: each ].
-	0 to: testsize do: [ :each |
-		self assert: (table at: each asString ) = each ].
-]
-
-{ #category : #testing }
-HashTableTest >> testAssociactionssDo [
+WeakKeyHashTableTest >> testAddString [
 	| keys |
-	keys := (1 to: 100) asOrderedCollection.
+	keys := (0 to: testsize) collect: [ :each | each asString ].
 	keys do: [ :each |
-		table at: each put: each ].
-	table associationsDo: [ :assoc |
-		self assert: assoc key = assoc value.
-		self assert: (keys includes: assoc key).
-		keys remove: assoc key ifAbsent: [ self fail ] ].
-	self assert: keys isEmpty
+		self assert: table size = each asNumber.
+		table at: each put: each asNumber ].
+	keys := (0 to: testsize) collect: [ :each | each asString ].
+	keys do: [ :each |
+		self assert: (table at: each ) = each asNumber ].
 ]
 
 { #category : #testing }
-HashTableTest >> testComma [
+WeakKeyHashTableTest >> testComma [
 	"(self run: #testComma)"
 	
 	| table1 table2 |
@@ -118,7 +100,7 @@ HashTableTest >> testComma [
 ]
 
 { #category : #testing }
-HashTableTest >> testEqualsDictionary [
+WeakKeyHashTableTest >> testEqualsDictionary [
 	| dictionary |
 	dictionary := Dictionary new.
 	0 to: testsize do: [ :each |
@@ -129,7 +111,7 @@ HashTableTest >> testEqualsDictionary [
 ]
 
 { #category : #testing }
-HashTableTest >> testEqualsTransitive [
+WeakKeyHashTableTest >> testEqualsTransitive [
 	| table2 |
 	table2 := table species new.
 	0 to: testsize do: [ :each |
@@ -141,7 +123,7 @@ HashTableTest >> testEqualsTransitive [
 ]
 
 { #category : #testing }
-HashTableTest >> testKeys [
+WeakKeyHashTableTest >> testKeys [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -150,7 +132,7 @@ HashTableTest >> testKeys [
 ]
 
 { #category : #testing }
-HashTableTest >> testKeysAndValuesDo [
+WeakKeyHashTableTest >> testKeysAndValuesDo [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -163,7 +145,7 @@ HashTableTest >> testKeysAndValuesDo [
 ]
 
 { #category : #testing }
-HashTableTest >> testKeysDo [
+WeakKeyHashTableTest >> testKeysDo [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -175,18 +157,7 @@ HashTableTest >> testKeysDo [
 ]
 
 { #category : #testing }
-HashTableTest >> testRemoveFromCopy [
-	| original copy |
-	original := HashTable new.
-	($a to: $z) do: [ :each |
-		original at: each put: each ].
-	copy := original copy.
-	copy removeKey: $b.
-	self assert: (original at: $b) = $b
-]
-
-{ #category : #testing }
-HashTableTest >> testRemoveInteger [
+WeakKeyHashTableTest >> testRemoveInteger [
 	0 to: testsize do: [ :each |
 		self assert: table size = each.
 		table at: each put: each asString ].
@@ -201,13 +172,15 @@ HashTableTest >> testRemoveInteger [
 ]
 
 { #category : #testing }
-HashTableTest >> testRemoveString [
-	0 to: testsize do: [ :each |
-		self assert: table size = each.
-		table at: each asString put: each ].
+WeakKeyHashTableTest >> testRemoveString [
+	| keys |
+	keys := (0 to: testsize) collect: [ :each | each asString ].
+	keys do: [ :each |
+		self assert: table size = each asNumber.
+		table at: each put: each asNumber ].
 	
 	0 to: testsize by: 2 do: [ :each |
-		self assert: (table includesKey: each asString).
+		self assert: (table includesKey: (keys at: each + 1)).
 		table removeKey: each asString.
 		self deny: (table includesKey: each asString) ].
 	
@@ -216,12 +189,14 @@ HashTableTest >> testRemoveString [
 ]
 
 { #category : #testing }
-HashTableTest >> testSize [
+WeakKeyHashTableTest >> testSize [
+	| keys |
+	keys := (1 to: testsize) collect: [ :each | each asString ].
 	self assert: table size = 0.
 	
-	1 to: testsize do: [ :each |		
-		table at: each asString put: each.
-		self assert: table size = each. ].
+	keys do: [ :each |		
+		table at: each put: each asNumber.
+		self assert: table size = each asNumber. ].
 	
 	1 to: testsize do: [ :each |
 		self assert: table size = testsize.
@@ -235,16 +210,16 @@ HashTableTest >> testSize [
 ]
 
 { #category : #testing }
-HashTableTest >> testValues [
+WeakKeyHashTableTest >> testValues [
 	| keys |
-	keys := (1 to: 100) asOrderedCollection.
+	keys := (1 to: 100) asOrderedCollection collect: [ :each | each asString ].
 	keys do: [ :each |
-		table at: each asString put: each ].
-	self assert: table values asArray sort = (1 to: 100) asArray
+		table at: each put: each ].
+	self assert: ((table values collect: [ :each | each asNumber ]) asArray sort = (1 to: 100) asArray)
 ]
 
 { #category : #testing }
-HashTableTest >> testValuesDo [
+WeakKeyHashTableTest >> testValuesDo [
 	| keys |
 	keys := (1 to: 100) asOrderedCollection.
 	keys do: [ :each |
@@ -253,4 +228,26 @@ HashTableTest >> testValuesDo [
 		self assert: (keys includes: each).
 		keys remove: each ifAbsent: [ self fail ] ].
 	self assert: keys isEmpty
+]
+
+{ #category : #testing }
+WeakKeyHashTableTest >> testWeakInstance [
+	| createBlock string |
+	createBlock := [(String new: 3)
+		at: 1 put: $n;
+		at: 2 put: $e;
+		at: 3 put: $w;
+		yourself ].
+	string := createBlock value.
+	
+	table at: string put: true.
+	self assert: (table at: string).
+	self assert: (table at: createBlock value).
+	self assert: table size = 1.
+	string := nil.
+	Smalltalk garbageCollect.
+	
+	string := createBlock value.
+	self deny: (table includesKey: string).
+	self assert: table isEmpty.
 ]

--- a/src/Hashtable-Tests/WeakKeyIdentityHashTableTest.class.st
+++ b/src/Hashtable-Tests/WeakKeyIdentityHashTableTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'table',
 		'testsize'
 	],
-	#category : #'Hashtable-Test'
+	#category : #'Hashtable-Tests'
 }
 
 { #category : #running }

--- a/src/Hashtable-Tests/package.st
+++ b/src/Hashtable-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Hashtable-Tests' }


### PR DESCRIPTION
Split Hashtable between core and tests.

Fixes #1300