### PR TITLE
1349-Cut-dependency-between-Famix-Compatibility-Groups-and-Famix-Support

### DIFF
--- a/src/Famix-Compatibility-Groups/FAMIXClassGroup.class.st
+++ b/src/Famix-Compatibility-Groups/FAMIXClassGroup.class.st
@@ -13,13 +13,3 @@ FAMIXClassGroup class >> annotation [
 	<package: #FAMIX>
 
 ]
-
-{ #category : #navigation }
-FAMIXClassGroup >> asSmalltalkClassCollection [
-	^(self
-		collect:
-			[:each | 
-			MooseUtilities
-				smalltalkClassFromFamixClassName: each mooseName
-				ifAbsent: [nil]]) select: #notNil
-]


### PR DESCRIPTION
Remove dead method to remove dependency.

Fixes #1349