### PR TITLE
1351-Famix-Compatibility-Entities-should-not-depend-on-Glamour-Roassal-and-SUnit

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -44,6 +44,7 @@ BaselineOfMoose >> baseline: spec [
 			package: 'Famix-Traits';
 				
 			package: 'Famix-BasicInfrastructure';
+			package: 'Famix-Utils';
 			
 			package: 'Famix-Compatibility-Generator';
 			package: 'Famix-Compatibility-Entities';
@@ -61,6 +62,7 @@ BaselineOfMoose >> baseline: spec [
 			package: 'Moose-SmalltalkImporter';
 			package: 'Moose-MonticelloImporter';
 			package: 'Moose-Tests-Core';
+			package: 'Famix-Utils-Tests';
 			package: 'Famix-Compatibility-Tests-Java';
 			package: 'Moose-Tests-SmalltalkImporter-LAN';
 			package: 'Moose-Tests-SmalltalkImporter-Core';
@@ -550,7 +552,8 @@ BaselineOfMoose >> groups: spec [
 			
 		'Famix-MetamodelGeneration'
 		'Famix-Traits'
-			
+		
+		'Famix-Utils'
 		'Famix-Compatibility-Generator' 
 		'Famix-Compatibility-Entities'
 		'Famix-Compatibility-Groups'
@@ -560,6 +563,7 @@ BaselineOfMoose >> groups: spec [
 	
 	spec group: 'BasicTests' with: #(
 		'Famix-MetamodelBuilder-Tests'
+		'Famix-Utils-Tests'
 
 		'StateSpecs-Additional'
 		'Ghost'

--- a/src/Famix-Utils-Tests/FAMIXNameResolverTest.class.st
+++ b/src/Famix-Utils-Tests/FAMIXNameResolverTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FAMIXNameResolverTest,
 	#superclass : #TestCase,
-	#category : #'Famix-Support'
+	#category : #'Famix-Utils-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-Utils-Tests/package.st
+++ b/src/Famix-Utils-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Utils-Tests' }

--- a/src/Famix-Utils/FAMIXNameResolver.class.st
+++ b/src/Famix-Utils/FAMIXNameResolver.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FAMIXNameResolver,
 	#superclass : #MooseUtilities,
-	#category : #'Famix-Support'
+	#category : #'Famix-Utils'
 }
 
 { #category : #private }

--- a/src/Famix-Utils/MooseUtilities.class.st
+++ b/src/Famix-Utils/MooseUtilities.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MooseUtilities,
 	#superclass : #Object,
-	#category : #'Famix-Support'
+	#category : #'Famix-Utils'
 }
 
 { #category : #private }
@@ -63,19 +63,6 @@ MooseUtilities class >> extractMethodSelectorFromMoose: aString [
 	"self extractMethodSelectorFromMoose: #'accept()' 'accept'"
 
 	^aString copyUpTo: $(
-]
-
-{ #category : #'encoding extraction' }
-MooseUtilities class >> extractMooseClassSymbolFrom: aString [
-	"returns the class name of a Moose  variable name"
-
-	"self extractMooseClassSymbolFrom: #'LanInterface.super'"
-
-	"self extractMooseClassSymbolFrom: #'LanInterface.self'"
-
-	"self extractMooseClassSymbolFrom: #'LanInterface.self.dddd'"
-
-	^aString classPart
 ]
 
 { #category : #'encoding extraction' }

--- a/src/Famix-Utils/RBVisitorForFAMIX.class.st
+++ b/src/Famix-Utils/RBVisitorForFAMIX.class.st
@@ -7,7 +7,7 @@ Class {
 		'importer',
 		'targetModel'
 	],
-	#category : #'Famix-Support'
+	#category : #'Famix-Utils'
 }
 
 { #category : #public }

--- a/src/Famix-Utils/RBVisitorForFAMIXMetrics.class.st
+++ b/src/Famix-Utils/RBVisitorForFAMIXMetrics.class.st
@@ -26,7 +26,7 @@ Class {
 		'booleanOperators',
 		'cyclomaticNumber2'
 	],
-	#category : #'Famix-Support'
+	#category : #'Famix-Utils'
 }
 
 { #category : #'private-accessing' }

--- a/src/Famix-Utils/package.st
+++ b/src/Famix-Utils/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Utils' }


### PR DESCRIPTION
Entities should not depend on Roassal and Glamour.

Not the best way to correct that, but it's good enough as a first step.

Fixes #1351