### PR TITLE
1373-the-latest-version-of-Moose-Algos-Graph-is-not-loaded

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -319,6 +319,7 @@ BaselineOfMoose >> baselineMocketry: spec [
 BaselineOfMoose >> baselineMooseAlgos: spec [ 
     
 	spec
+		package: 'Moose-Algos-Graph';
 		package: 'Moose-Algos-Graph-Tests';
 		package: 'Moose-Algos-FormalConceptAnalysis';
 		package: 'Moose-Algos-FormalConceptAnalysis-Tests';


### PR DESCRIPTION
https://github.com/moosetechnology/Moose/issues/1373add Moose-Algos-Graph to the baseline