### PR TITLE
1377-Famix-MetamodelBuilder-Core-depens-on-GTToolkit-Example-

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -411,7 +411,7 @@ FmxMBBehavior >> slotDefinitions [
 
 	"check that all slots with the same name have the same properties"
 	slotGroups valuesDo: [ :similarSlots |
-		self assert: (similarSlots collect: #name) asSet size equals: 1. ].
+		self assert: (similarSlots collect: #name) asSet size = 1. ].
 		
 	^ slotGroups values collect: [ :each | each anyOne ].
 


### PR DESCRIPTION
Cut dependency on GTToolkit-Example

Fixes #1377