### PR TITLE
1366-Test-resources-reference-extend-famix-tests

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -68,6 +68,7 @@ BaselineOfMoose >> baseline: spec [
 			package: 'Moose-Tests-SmalltalkImporter-KGB';
 			package: 'Famix-Compatibility-Tests-Core';
 			package: 'Famix-Compatibility-Tests-Extensions';
+			package: 'Moose-TestResources-Reference-External';
 			package: 'Moose-TestResources-Reference-Core';
 			package: 'Moose-TestResources-Reference-PackageOne';
 			package: 'Moose-TestResources-Reference-PackageTwo';
@@ -573,7 +574,10 @@ BaselineOfMoose >> groups: spec [
 		'Mocketry'
 			
 		'Moose-TestResources-LAN'
+		'Moose-TestResources-Reference-External'
 		'Moose-TestResources-Reference-Core'
+		'Moose-TestResources-Reference-PackageOne'
+		'Moose-TestResources-Reference-PackageTwo'
 		'Moose-TestResources-KGB-P4FullInteracted'
 		'Moose-TestResources-KGB-P6InteractedReferee'
 		'Moose-TestResources-KGB-P5FullReferee'
@@ -593,9 +597,7 @@ BaselineOfMoose >> groups: spec [
 		'Moose-TestResources-PackageBlueprint-P2'
 		'Moose-TestResources-PackageBlueprint-P3'
 		'Moose-TestResources-PackageBlueprint-P4'
-		'Moose-TestResources-Reference-PackageOne'
 		'Moose-Tests-SmalltalkImporter-Core'
-		'Moose-TestResources-Reference-PackageTwo'
 		'Moose-Tests-SmalltalkImporter-LAN'
 		'Moose-Tests-SmalltalkImporter-KGB'
 		'Moose-TestResources-KGB-PExtensions'

--- a/src/Moose-TestResources-Reference-External/ExternalReferenceClass.class.st
+++ b/src/Moose-TestResources-Reference-External/ExternalReferenceClass.class.st
@@ -1,0 +1,11 @@
+"
+Description
+--------------------
+
+I am a class that should not be in the model for test. I should be a stub.
+"
+Class {
+	#name : #ExternalReferenceClass,
+	#superclass : #Object,
+	#category : #'Moose-TestResources-Reference-External'
+}

--- a/src/Moose-TestResources-Reference-External/package.st
+++ b/src/Moose-TestResources-Reference-External/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Moose-TestResources-Reference-External' }

--- a/src/Moose-TestResources-Reference-PackageTwo/ExternalReferenceClass.extension.st
+++ b/src/Moose-TestResources-Reference-PackageTwo/ExternalReferenceClass.extension.st
@@ -1,0 +1,5 @@
+Extension { #name : #ExternalReferenceClass }
+
+{ #category : #'*Moose-TestResources-Reference-PackageTwo' }
+ExternalReferenceClass >> externalClassExtensionForTest [
+]

--- a/src/Moose-TestResources-Reference-PackageTwo/FamixReferenceModelNamespaceTestResource.extension.st
+++ b/src/Moose-TestResources-Reference-PackageTwo/FamixReferenceModelNamespaceTestResource.extension.st
@@ -1,5 +1,0 @@
-Extension { #name : #FamixReferenceModelNamespaceTestResource }
-
-{ #category : #'*Moose-TestResources-Reference-PackageTwo' }
-FamixReferenceModelNamespaceTestResource >> externalClassExtensionForTest [
-]

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
@@ -452,7 +452,7 @@ FamixReferenceModelImporterTest >> testExtensionPackage [
 	| normalClass extendedClass extensionPackage externalExtendedClass |
 	extensionPackage := self model allPackages entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
 	extendedClass := self model entityNamed: SubRootModelTwo mooseName.
-	externalExtendedClass := self model entityNamed: FamixReferenceModelNamespaceTestResource mooseName.
+	externalExtendedClass := self model entityNamed: ExternalReferenceClass mooseName.
 	normalClass := self model entityNamed: SubRootModelThree mooseName.
 	self assert: (extensionPackage classes includes: normalClass).
 	self deny: (extensionPackage classes includes: extendedClass).
@@ -469,7 +469,7 @@ FamixReferenceModelImporterTest >> testExtensionPackage [
 		assert:
 			(extensionPackage extensionMethods
 				includes:
-					(self model entityNamed: (FamixReferenceModelNamespaceTestResource >> #externalClassExtensionForTest) mooseName)).
+					(self model entityNamed: (ExternalReferenceClass >> #externalClassExtensionForTest) mooseName)).
 	self
 		assert:
 			(extensionPackage extensionMethods includes: (self model entityNamed: (SubRootModelTwo >> #extendedMethodOne) mooseName))
@@ -508,12 +508,12 @@ FamixReferenceModelImporterTest >> testExternalExtension [
 	| extensionPackage externalExtendedClass |
 	
 	extensionPackage := self model entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
-	externalExtendedClass := self model entityNamed: FamixReferenceModelNamespaceTestResource mooseName.
+	externalExtendedClass := self model entityNamed: ExternalReferenceClass mooseName.
 
 	self assert: (externalExtendedClass isStub).
 	self deny: (extensionPackage classes includes: externalExtendedClass).
 	self assert: (extensionPackage extensionMethods includes:
-		(self model entityNamed: (FamixReferenceModelNamespaceTestResource>>#externalClassExtensionForTest) mooseName)).
+		(self model entityNamed: (ExternalReferenceClass>>#externalClassExtensionForTest) mooseName)).
 
 ]
 


### PR DESCRIPTION
Test resources should be standalone.

Fixes #1366