### PR TITLE
1397-importing-of-AST-Core-Traits-produces-an-empty-model

### DIFF
--- a/src/Moose-SmalltalkImporter/MoosePharoImporterTask.class.st
+++ b/src/Moose-SmalltalkImporter/MoosePharoImporterTask.class.st
@@ -38,11 +38,8 @@ MoosePharoImporterTask >> addClasses: col [
 MoosePharoImporterTask >> addFromPackage: aRPackage [
 
 	"late-bound cache initialization for classes"
-	"PackageOrganizerCache default addClassesFromPackage: aPackageInfo.
-	packageDesc := PackageOrganizerCache default packageFor: aPackageInfo."
-	"SIMD 23/11/2009: We reject trait as entities to import for now."
-	self addClasses: aRPackage regularClasses.
-	self addClassExtensions: aRPackage regularClassExtensions
+	self addClasses: aRPackage definedClasses.
+	self addClassExtensions: aRPackage extensionMethods
 	
 ]
 

--- a/src/Moose-Tests-SmalltalkImporter-Core/MooseSqueakClassPackageImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MooseSqueakClassPackageImporterTest.class.st
@@ -10,8 +10,7 @@ MooseSqueakClassPackageImporterTest >> numberOfClassesIn: categories [
 	"SIMD 23/11/2009: We reject trait as entities to importer for now."
 	^ (SystemOrganization categories select: [ :each | categories anySatisfy: [:c | c match: each]]) 
 		inject: 0
-		into: [ :sum :each | sum + ((SystemOrganization classesInCategory: each)
-																		reject: [:cls | cls isTrait]) size ]
+		into: [ :sum :each | sum + (SystemOrganization classesInCategory: each) size ]
 ]
 
 { #category : #'testing collecting classes' }
@@ -84,7 +83,7 @@ MooseSqueakClassPackageImporterTest >> testImportClassUsingAddPackage [
 	importer run.
 	self
 		assert: model allClasses size
-		equals: 2 * (RPackage organizer packageNamed: #'Moose-TestResources-LAN') regularClasses size
+		equals: 2 * (RPackage organizer packageNamed: #'Moose-TestResources-LAN') definedClasses size
 ]
 
 { #category : #'test importing' }
@@ -102,5 +101,5 @@ MooseSqueakClassPackageImporterTest >> testImportClassUsingAddPackageNamed [
 	importer run.
 	self
 		assert: model allClasses size
-		equals: 2 * (RPackage organizer packageNamed: #'Moose-TestResources-LAN') regularClasses size
+		equals: 2 * (RPackage organizer packageNamed: #'Moose-TestResources-LAN') definedClasses size
 ]

--- a/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
@@ -123,7 +123,7 @@ LANImporterTest >> testCommonSuperClasses [
 	self
 		assert:
 			(self model allPackages entityNamed: #'Moose-TestResources-LAN') localClassesGroup commonExternalSuperclasses size
-		equals: 11
+		equals: 12
 ]
 
 { #category : #tests }
@@ -291,7 +291,7 @@ LANImporterTest >> testIsClassAbstract [
 LANImporterTest >> testLonely [
 	| lonely |
 	lonely := self model allModelClasses select: [ :each | each isLonelyWithin: self model allModelClasses ].
-	self assert: lonely size equals: 6
+	self assert: lonely size equals: 8
 ]
 
 { #category : #errors }
@@ -401,7 +401,7 @@ LANImporterTest >> testPackageReification [
 	self model allClasses do: [ :each | self assert: (each parentPackage usesTrait: FamixTPackage) ].
 	self model allPackages
 		do: [ :each | each localClasses do: [ :eachClass | self assert: eachClass parentPackage equals: each ] ].
-	self assert: (self model allPackages entityNamed: #'Moose-TestResources-LAN') localClasses size equals: 20
+	self assert: (self model allPackages entityNamed: #'Moose-TestResources-LAN') localClasses size equals: 22
 ]
 
 { #category : #tests }
@@ -426,7 +426,7 @@ LANImporterTest >> testStubClassesCreation [
 	self deny: (self model entityNamed: LANNode mooseName) isStub.
 	self assert: (self model entityNamed: #Smalltalk::Object) isStub.
 	self deny: (self model entityNamed: #Smalltalk::LANFileServer_class) isStub.
-	self assert: (self model allClasses select: [ :each | each isStub not ]) size equals: 20
+	self assert: (self model allClasses select: [ :each | each isStub not ]) size equals: 22
 ]
 
 { #category : #errors }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/LANMooseGroupTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/LANMooseGroupTest.class.st
@@ -219,5 +219,5 @@ LANMooseGroupTest >> testSelectTopTwentyForMetric [
 LANMooseGroupTest >> testSum [
 	| classes |
 	classes := self model allClasses.
-	self assert: (classes sumNumbers: #numberOfMethods) equals: 84 "was 54 before traits classes inclusion"
+	self assert: (classes sumNumbers: #numberOfMethods) equals: 112 "was 54 before traits classes inclusion"
 ]


### PR DESCRIPTION
do not ignore traits during importfixes #1397