### PR TITLE
1387-FAMIXEnumValue-doesnt-have-a-namespaceScope--

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
@@ -50,3 +50,8 @@ FAMIXEnumValue >> belongsTo: anObject [
 	self parentEnum: anObject
 
 ]
+
+{ #category : #'moosechef-scoping-filtering' }
+FAMIXEnumValue >> namespaceScope [
+	^ self parentType namespaceScope
+]


### PR DESCRIPTION
add namespaceScope implementation to the enum value. It should not be on the structural entity because not all subclasses understand parentTypefixes #1387