### PR TITLE
1419-SmalltalkMetamodelFactory-uses-the-wrong-metamodel

### DIFF
--- a/src/Famix-PharoSmalltalk-Importer/SmalltalkMetamodelFactory.class.st
+++ b/src/Famix-PharoSmalltalk-Importer/SmalltalkMetamodelFactory.class.st
@@ -7,5 +7,5 @@ Class {
 { #category : #'as yet unclassified' }
 SmalltalkMetamodelFactory >> defaultMetamodelClass [
 
-	^ FamixCompatibilityGenerator
+	^ FamixPharoSmalltalkGenerator 
 ]


### PR DESCRIPTION
use FamixPharoSmalltalkGeneratorfixes #1419