### PR TITLE
1427-FIX-Loading-a-MSE-in-Moose-7-raise-a-warning

### DIFF
--- a/src/Moose-Finder/MooseModel.extension.st
+++ b/src/Moose-Finder/MooseModel.extension.st
@@ -112,12 +112,14 @@ MooseModel >> importFileStructure [
 
 { #category : #'*Moose-Finder' }
 MooseModel >> importFromMSE [
-	| stream |
-	stream := UITheme builder fileOpen: 'Import model from MSE file' extensions: #('mse').
-	stream
-		ifNotNil: [ 
-			self name: (stream localName copyUpToLast: Path extensionDelimiter).	"name without extension"
+	| file |
+	file := UIManager default chooseExistingFileReference: 'Import model from MSE file' extensions: #('mse') path: FileLocator home.
+	file
+		ifNotNil: [
+			| stream | 
+			stream := file readStream.
 			self importFromMSEStream: stream.
+			self name: (file basenameWithoutExtension).
 			stream close ]
 ]
 


### PR DESCRIPTION
Fix of the issue #1427 

Now we can use UIManager to import an mse file
I also simplify the computation of the name of the model and I put the line at the end (so it solve for this case the issue #1439)

~ fix warning when we load a mse file from the moose panel
~ fix the name of the model when it is loaded from the moose panel