### PR TITLE
Look for the metamodel of the localmodel before looking for metamodel defined in instance side

### DIFF
--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -441,6 +441,12 @@ MooseEntity >> metamodel [
 
 ]
 
+{ #category : #accessing }
+MooseEntity >> mooseDescription [
+
+	^ self mooseModel ifNotNil: [:mooseModel | mooseModel metamodel descriptionOf: self class instanceSide ] ifNil: [ super mooseDescription ]  
+]
+
 { #category : #printing }
 MooseEntity >> mooseDisplayStringOn: stream [
 	self mooseNameOn: stream


### PR DESCRIPTION
It can be used to avoid the bug #1454 