### PR TITLE
Improve-moose-query

### DIFF
--- a/src/Moose-Query-Test/MooseQueryComparedToMooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryComparedToMooseQueryTest.class.st
@@ -32,7 +32,7 @@ MooseQueryComparedToMooseQueryTest >> testIncomingAccesses [
 					((method2 parameters flatCollect: #incomingAccesses) asOrderedCollection
 						addAll: (method2 localVariables flatCollect: #incomingAccesses);
 						yourself)) asSet.
-	self assert: (var3 queryIncoming: FAMIXAccess) asSet equals: var3 incomingAccesses asSet
+	self assert: (localVariable queryIncoming: FAMIXAccess) asSet equals: localVariable incomingAccesses asSet
 ]
 
 { #category : #tests }

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -155,6 +155,14 @@ MooseQueryTest >> testAllToScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllWithAnyScope [
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class2. package2}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FAMIXStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2 . localVariable}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAllWithScope [
 	| package3 class3 |
 	self assertCollection: (class1 allWithScope: FamixTMethod) hasSameElements: {method1}.
@@ -509,6 +517,14 @@ MooseQueryTest >> testWithAllParents [
 	self assert: class2 withAllParents size equals: 2.
 	self assert: method2 withAllParents size equals: 3.
 	self assert: var2 withAllParents size equals: 3
+]
+
+{ #category : #tests }
+MooseQueryTest >> testWithAnyScope [
+	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt}.
+	self assertCollection: (class2 withAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class2}.
+	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}.
+	self assertCollection: (class2 withAnyScope: {FamixTMethod . FAMIXStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}
 ]
 
 { #category : #tests }

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -19,12 +19,12 @@ Class {
 		'var1',
 		'acc1',
 		'namespace',
-		'var3',
 		'ref1',
 		'methodExt',
 		'isolatedPackage',
 		'isolatedClass',
-		'isolatedMethod'
+		'isolatedMethod',
+		'localVariable'
 	],
 	#category : #'Moose-Query-Test'
 }
@@ -53,7 +53,7 @@ MooseQueryTest >> setUp [
 	methodExt := FAMIXMethod new name: 'methodExt' ; parentType: class2 ; parentPackage: package1 ; mooseModel: model.
 	var1 := FAMIXAttribute new name: 'var1' ; parentType: class2 ; declaredType: class1 ; mooseModel: model.
 	var2 := FAMIXAttribute new name: 'var2' ; parentType: class2 ; mooseModel: model.
-	var3 := FAMIXLocalVariable new name: 'var3' ; parentBehaviouralEntity: method2 ; declaredType: class1 ; mooseModel: model.
+	localVariable := FAMIXLocalVariable new name: 'var3' ; parentBehaviouralEntity: method2 ; declaredType: class1 ; mooseModel: model.
 	access := FAMIXAccess new accessor: method1 ; variable: var2 ; mooseModel: model.
 	acc1 := FAMIXAccess new accessor: method2 ; variable: var1 ; mooseModel: model.
 	inv1 := FAMIXInvocation new sender: method1 ; addCandidate: method2 ; receiver: var2 ; mooseModel: model.
@@ -131,29 +131,27 @@ MooseQueryTest >> testAllParents [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllToAnyScope [
+	self assertCollection: (class2 allToAnyScope: {FAMIXMethod . FAMIXAttribute}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 allToAnyScope: {FAMIXMethod . FAMIXLocalVariable}) hasSameElements: {method2 . method3 . methodExt . localVariable}.
+	self assertCollection: (class2 allToAnyScope: {FAMIXMethod . FAMIXStructuralEntity}) hasSameElements: {method2 . method3 . methodExt . var1 . var2 . localVariable}.
+	self assertCollection: (class2 allToAnyScope: {FAMIXClass . FAMIXMethod}) hasSameElements: {class2 . method2 . method3 . methodExt}.
+	self assertCollection: (method1 allToAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAllToScope [
 	| class3 |
 	self assertCollection: (class1 allToScope: FamixTMethod) hasSameElements: {method1}.
-	self
-		assertCollection: (class2 allToScope: FamixTAttribute)
-		hasSameElements:
-			{var1.
-			var2}.
+	self assertCollection: (class2 allToScope: FamixTAttribute) hasSameElements: {var1 . var2}.
+	self assertCollection: (class2 allToScope: FAMIXStructuralEntity) hasSameElements: {var1 . var2 . localVariable}.
 	self assertCollection: (package1 allToScope: FamixTClass) hasSameElements: {class1}.
 	class3 := FAMIXClass new
 		name: 'class3';
 		container: class1;
 		mooseModel: model.
-	self
-		assertCollection: (class1 allToScope: FamixTClass)
-		hasSameElements:
-			{class1.
-			class3}.
-	self
-		assertCollection: (package1 allToScope: FamixTClass)
-		hasSameElements:
-			{class1.
-			class3}
+	self assertCollection: (class1 allToScope: FamixTClass) hasSameElements: {class1 . class3}.
+	self assertCollection: (package1 allToScope: FamixTClass) hasSameElements: {class1 . class3}
 ]
 
 { #category : #tests }
@@ -483,18 +481,19 @@ MooseQueryTest >> testQueryWith [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testToAnyScope [
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXAttribute}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXStructuralEntity}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXClass . FAMIXMethod}) hasSameElements: {class2}.
+	self assertCollection: (method1 toAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testToScope [
 	self assertCollection: (class1 toScope: FAMIXMethod) hasSameElements: {method1}.
-	self
-		assertCollection: (class2 toScope: FAMIXAttribute)
-		hasSameElements:
-			{var1.
-			var2}.
-	self
-		assertCollection: (package1 toScope: FAMIXMethod)
-		hasSameElements:
-			{method1.
-			methodExt}
+	self assertCollection: (class2 toScope: FAMIXAttribute) hasSameElements: {var1 . var2}.
+	self assertCollection: (class2 toScope: FAMIXStructuralEntity) hasSameElements: {var1 . var2. localVariable}.
+	self assertCollection: (package1 toScope: FAMIXMethod) hasSameElements: {method1 . methodExt}
 ]
 
 { #category : #tests }

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -63,6 +63,19 @@ MooseQueryTest >> setUp [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllAtAnyScope [
+	self assertCollection: (class1 allAtAnyScope: {FAMIXClass}) hasSameElements: {class1}.
+	self assertCollection: (class1 allAtAnyScope: {FAMIXPackage}) hasSameElements: {package1}.
+	self assertCollection: (class1 allAtAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {class1. package1}.
+	self assertCollection: (class1 allAtAnyScope: {FAMIXMethod}) hasSameElements: {}.
+	self assertCollection: (class1 allAtAnyScope: {FamixTClass}) hasSameElements: {class1}.
+	self assertCollection: (class1 allAtAnyScope: {FamixTPackage}) hasSameElements: {package1}.
+	self assertCollection: (class1 allAtAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class1. package1}.
+	self assertCollection: (class1 allAtAnyScope: {FamixTMethod}) hasSameElements: {}.
+	self assertCollection: (methodExt allAtAnyScope: {FAMIXPackage}) hasSameElements: {package1. package2}.
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAllAtScope [
 	| package3 |
 	self assertCollection: (class1 allAtScope: FamixTClass) hasSameElements: {class1}.
@@ -185,6 +198,19 @@ MooseQueryTest >> testAllWithScope [
 			{package1.
 			package3.
 			namespace}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testAtAnyScope [
+	self assertCollection: (class1 atAnyScope: {FAMIXClass}) hasSameElements: {class1}.
+	self assertCollection: (class1 atAnyScope: {FAMIXPackage}) hasSameElements: {package1}.
+	self assertCollection: (class1 atAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {class1}.
+	self assertCollection: (class1 atAnyScope: {FAMIXMethod}) hasSameElements: {}.
+	self assertCollection: (class1 atAnyScope: {FamixTClass}) hasSameElements: {class1}.
+	self assertCollection: (class1 atAnyScope: {FamixTPackage}) hasSameElements: {package1}.
+	self assertCollection: (class1 atAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class1}.
+	self assertCollection: (class1 atAnyScope: {FamixTMethod}) hasSameElements: {}.
+	self assertCollection: (methodExt atAnyScope: {FAMIXPackage}) hasSameElements: {package1. package2}.
 ]
 
 { #category : #tests }

--- a/src/Moose-Query/Collection.extension.st
+++ b/src/Moose-Query/Collection.extension.st
@@ -19,6 +19,12 @@ Collection >> allWithScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+Collection >> atAnyScope: aCollectionOfFamixScopes in: aCollection [
+	1 to: self size do: [ :ind | (self at: ind) atAnyScope: aCollectionOfFamixScopes in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> atScope: aFAMIXScope in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) atScope: aFAMIXScope in: aCollection ].
 	^ aCollection

--- a/src/Moose-Query/Collection.extension.st
+++ b/src/Moose-Query/Collection.extension.st
@@ -1,8 +1,20 @@
 Extension { #name : #Collection }
 
 { #category : #'*Moose-Query' }
+Collection >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection [
+	1 to: self size do: [ :ind | (self at: ind) allAtAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> allAtScope: aFAMIXScope in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) allAtScope: aFAMIXScope in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> allToAnyScope: aCollectionOfFamixClasses in: aCollection [
+	1 to: self size do: [ :ind | (self at: ind) allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
 	^ aCollection
 ]
 
@@ -27,6 +39,12 @@ Collection >> atAnyScope: aCollectionOfFamixScopes in: aCollection [
 { #category : #'*Moose-Query' }
 Collection >> atScope: aFAMIXScope in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) atScope: aFAMIXScope in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> toAnyScope: aCollectionOfFamixClasses in: aCollection [
+	1 to: self size do: [ :ind | (self at: ind) toAnyScope: aCollectionOfFamixClasses in: aCollection ].
 	^ aCollection
 ]
 

--- a/src/Moose-Query/MooseObjectQueryResult.class.st
+++ b/src/Moose-Query/MooseObjectQueryResult.class.st
@@ -8,8 +8,18 @@ Class {
 }
 
 { #category : #filtering }
+MooseObjectQueryResult >> allAtAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity allAtAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 MooseObjectQueryResult >> allAtScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity allAtScope: aClassFamix in: res ]) asSet
+]
+
+{ #category : #filtering }
+MooseObjectQueryResult >> allToAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity allToAnyScope: aCollectionOfFamixClasses in: res ]) asSet
 ]
 
 { #category : #filtering }
@@ -18,8 +28,18 @@ MooseObjectQueryResult >> allToScope: aClassFamix [
 ]
 
 { #category : #filtering }
+MooseObjectQueryResult >> allWithAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity allWithAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 MooseObjectQueryResult >> allWithScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity allWithScope: aClassFamix in: res ]) asSet
+]
+
+{ #category : #filtering }
+MooseObjectQueryResult >> atAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity atAnyScope: aCollectionOfFamixClasses in: res ]) asSet
 ]
 
 { #category : #filtering }
@@ -53,8 +73,18 @@ MooseObjectQueryResult >> primCollectAtScope: aScopeSymbol [
 ]
 
 { #category : #filtering }
+MooseObjectQueryResult >> toAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity toAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 MooseObjectQueryResult >> toScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity toScope: aClassFamix in: res ]) asSet
+]
+
+{ #category : #filtering }
+MooseObjectQueryResult >> withAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity withAnyScope: aCollectionOfFamixClasses in: res ]) asSet
 ]
 
 { #category : #filtering }

--- a/src/Moose-Query/MooseQueryResult.class.st
+++ b/src/Moose-Query/MooseQueryResult.class.st
@@ -43,7 +43,19 @@ MooseQueryResult >> add: newObject [
 ]
 
 { #category : #scoping }
+MooseQueryResult >> allAtAnyScope: aSymbol [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #scoping }
 MooseQueryResult >> allAtScope: aSymbol [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #scoping }
+MooseQueryResult >> allToAnyScope: aSymbol [
 
 	^ self subclassResponsibility
 ]
@@ -55,7 +67,18 @@ MooseQueryResult >> allToScope: aSymbol [
 ]
 
 { #category : #scoping }
+MooseQueryResult >> allWithAnyScope: aSymbol [
+	^ self subclassResponsibility
+]
+
+{ #category : #scoping }
 MooseQueryResult >> allWithScope: aSymbol [
+	^ self subclassResponsibility
+]
+
+{ #category : #scoping }
+MooseQueryResult >> atAnyScope: aSymbol [
+
 	^ self subclassResponsibility
 ]
 
@@ -209,6 +232,12 @@ MooseQueryResult >> storage: aCollection [
 ]
 
 { #category : #scoping }
+MooseQueryResult >> toAnyScope: aSymbol [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #scoping }
 MooseQueryResult >> toScope: aSymbol [
 
 	^ self subclassResponsibility
@@ -222,6 +251,11 @@ MooseQueryResult >> union: aCollection [
 	set := self asSet addAll: aCollection; yourself.
 	
 	 ^ self class on: (self receiver) withAll: set
+]
+
+{ #category : #scoping }
+MooseQueryResult >> withAnyScope: aSymbol [
+	^ self subclassResponsibility
 ]
 
 { #category : #scoping }

--- a/src/Moose-Query/TDependencyQueryResult.trait.st
+++ b/src/Moose-Query/TDependencyQueryResult.trait.st
@@ -36,6 +36,11 @@ TDependencyQueryResult >> allAtScope: aClassFamix [
 ]
 
 { #category : #filtering }
+TDependencyQueryResult >> allToAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allToAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 TDependencyQueryResult >> allToScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allToScope: aClassFamix in: res ]) asSet
 ]

--- a/src/Moose-Query/TDependencyQueryResult.trait.st
+++ b/src/Moose-Query/TDependencyQueryResult.trait.st
@@ -31,6 +31,11 @@ TDependencyQueryResult classSide >> generatedTraitNames [
 ]
 
 { #category : #filtering }
+TDependencyQueryResult >> allAtAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allAtAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 TDependencyQueryResult >> allAtScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allAtScope: aClassFamix in: res ]) asSet
 ]
@@ -46,8 +51,18 @@ TDependencyQueryResult >> allToScope: aClassFamix [
 ]
 
 { #category : #filtering }
+TDependencyQueryResult >> allWithAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allWithAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 TDependencyQueryResult >> allWithScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allWithScope: aClassFamix in: res ]) asSet
+]
+
+{ #category : #filtering }
+TDependencyQueryResult >> atAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) atAnyScope: aCollectionOfFamixClasses in: res ]) asSet
 ]
 
 { #category : #filtering }
@@ -144,8 +159,18 @@ TDependencyQueryResult >> sourceMethods [
 ]
 
 { #category : #filtering }
+TDependencyQueryResult >> toAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) toAnyScope: aCollectionOfFamixClasses in: res ]) asSet
+]
+
+{ #category : #filtering }
 TDependencyQueryResult >> toScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) toScope: aClassFamix in: res ]) asSet
+]
+
+{ #category : #filtering }
+TDependencyQueryResult >> withAnyScope: aCollectionOfFamixClasses [
+	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) withAnyScope: aCollectionOfFamixClasses in: res ]) asSet
 ]
 
 { #category : #filtering }

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -224,6 +224,24 @@ TEntityMetaLevelDependency >> addAllParentsIn: aCollection [
 ]
 
 { #category : #scoping }
+TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses [
+	"I am used to return all the encountered entities (recursively) at matching one of the class scope given as parameter that are up in the containment tree of the metamodel"
+
+	^ (self allAtAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet asArray
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClass in: aCollection [
+	| selectors |
+	(aCollectionOfFamixClass anySatisfy: [ :aClassFamix | (self isOfType: aClassFamix)]) ifTrue: [ aCollection add: self ].	
+	
+	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
+	1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtAnyScope: aCollectionOfFamixClass in: aCollection ].
+	
+	^ aCollection
+]
+
+{ #category : #scoping }
 TEntityMetaLevelDependency >> allAtScope: aClassFAMIX [
 	"I am used to return all the entities at a given famix class scope that are up in the containment tree of the metamodel on multiple levels."
 
@@ -330,6 +348,23 @@ TEntityMetaLevelDependency >> allWithScope: aClassFAMIX in: aCollection [
 
 	self allParentTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX inheritsFrom: class ] ] ifFound: [ self allAtScope: aClassFAMIX in: aCollection ].
 	self allChildrenTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX inheritsFrom: class ] ] ifFound: [ self allToScope: aClassFAMIX in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixClasses [
+	"I am used to return all the first encountered entities at matching one of the class scope given as parameter that are up in the containment tree of the metamodel"
+
+	^ (self atAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet asArray
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixScopes in: aCollection [
+	(aCollectionOfFamixScopes anySatisfy: [ :aClassFAMIX | self isOfType: aClassFAMIX ])
+		ifTrue: [ aCollection add: self ]
+		ifFalse: [ "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
+			| selectors |
+			1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) atAnyScope: aCollectionOfFamixScopes in: aCollection ] ].
 	^ aCollection
 ]
 

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -353,6 +353,26 @@ TEntityMetaLevelDependency >> allToScope: aClassFAMIX in: aCollection [
 ]
 
 { #category : #scoping }
+TEntityMetaLevelDependency >> allWithAnyScope: aCollectionOfFamixClasses [
+	"I am used to return all the entities (recursively) matching one of the class scope that are up or down in the containment tree of the metamodel"
+
+	^ (self allWithAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allWithAnyScope: aCollectionOfFamixClasses in: aCollection [
+	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self class traits includes: aFAMIXClass ]) ifTrue: [ self allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
+
+	self allParentTypes
+		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass inheritsFrom: class ] ] ]
+		ifFound: [ self allAtAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	self allChildrenTypes
+		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass inheritsFrom: class ] ] ]
+		ifFound: [ self allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #scoping }
 TEntityMetaLevelDependency >> allWithScope: aClassFAMIX [
 	"I am used to return all the entities at a given famix class scope that are up or down in the containment tree of the metamodel on multiple levels."
 
@@ -371,7 +391,7 @@ TEntityMetaLevelDependency >> allWithScope: aClassFAMIX in: aCollection [
 
 { #category : #scoping }
 TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixClasses [
-	"I am used to return all the first encountered entities at matching one of the class scope given as parameter that are up in the containment tree of the metamodel"
+	"I am used to return all the first encountered entities matching one of the class scope given as parameter that are up in the containment tree of the metamodel"
 
 	^ (self atAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet asArray
 ]
@@ -468,7 +488,7 @@ TEntityMetaLevelDependency >> parents [
 
 { #category : #scoping }
 TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses [
-	"I am used to return all the first encountered entities at matching one of the class scope given as parameter that are down in the containment tree of the metamodel"
+	"I am used to return all the first encountered entities matching one of the class scope given as parameter that are down in the containment tree of the metamodel"
 
 	^ (self toAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet asArray
 ]
@@ -513,6 +533,27 @@ TEntityMetaLevelDependency >> withAllParents [
 	"I return a collection including me and all my parents in the containement tree."
 
 	^ (self allParents , {self}) asArray
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> withAnyScope: aCollectionOfFamixClasses [
+	"I am used to return all the first encountered entities matching one of the class scope that are up or down in the containment tree of the metamodel"
+
+	^ (self withAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> withAnyScope: aCollectionOfFamixClasses in: aCollection [
+	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | (self class traits includes: aFAMIXClass) or: [ self class = aFAMIXClass ] ])
+		ifTrue: [ self atScope: aCollectionOfFamixClasses in: aCollection ].
+
+	self allParentTypes
+		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass mooseInheritsFrom: class ] ] ]
+		ifFound: [ self atAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	self allChildrenTypes
+		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass mooseInheritsFrom: class ] ] ]
+		ifFound: [ self toAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	^ aCollection
 ]
 
 { #category : #scoping }

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -231,13 +231,13 @@ TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses [
 ]
 
 { #category : #private }
-TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClass in: aCollection [
+TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection [
 	| selectors |
-	(aCollectionOfFamixClass anySatisfy: [ :aClassFamix | (self isOfType: aClassFamix)]) ifTrue: [ aCollection add: self ].	
-	
+	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self isOfType: aFAMIXClass ]) ifTrue: [ aCollection add: self ].
+
 	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
-	1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtAnyScope: aCollectionOfFamixClass in: aCollection ].
-	
+	1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtAnyScope: aCollectionOfFamixClasses in: aCollection ].
+
 	^ aCollection
 ]
 
@@ -313,6 +313,24 @@ TEntityMetaLevelDependency >> allProviders [
 { #category : #accessing }
 TEntityMetaLevelDependency >> allProvidersAtScope: aClass [
 	^ (self queryOutgoingDependencies atScope: aClass withNonMatchingEntitiesDo: [ :entities :res | entities ifNotNil: [ res addAll: entities asCollection ] ]) withoutSelfLoops
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allToAnyScope: aCollectionOfFamixClasses [
+	"I am used to return all the encountered entities (recursively) at matching one of the class scope given as parameter that are down in the containment tree of the metamodel"
+
+	^ (self allToAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet asArray
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allToAnyScope: aCollectionOfFamixClasses in: aCollection [
+	| selectors |
+	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self isOfType: aFAMIXClass ]) ifTrue: [ aCollection add: self ].
+
+	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
+	1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
+
+	^ aCollection
 ]
 
 { #category : #scoping }
@@ -446,6 +464,23 @@ TEntityMetaLevelDependency >> parents [
 	res := OrderedCollection new.
 	self parentSelectors do: [ :accessor | (self perform: accessor) ifNotNil: [ :r | res addAll: r asCollection ] ].
 	^ res asSet
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses [
+	"I am used to return all the first encountered entities at matching one of the class scope given as parameter that are down in the containment tree of the metamodel"
+
+	^ (self toAnyScope: aCollectionOfFamixClasses in: OrderedCollection new) asSet asArray
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses in: aCollection [
+	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self isOfType: aFAMIXClass ])
+		ifTrue: [ aCollection add: self ]
+		ifFalse: [ "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
+			| selectors |
+			1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) toAnyScope: aCollectionOfFamixClasses in: aCollection ] ].
+	^ aCollection
 ]
 
 { #category : #scoping }

--- a/src/Moose-Query/UndefinedObject.extension.st
+++ b/src/Moose-Query/UndefinedObject.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #UndefinedObject }
 
 { #category : #'*Moose-Query' }
+UndefinedObject >> allAtAnyScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 UndefinedObject >> allAtScope: aFAMIXScope in: aCollection [
 	^ aCollection
 ]
@@ -12,6 +17,11 @@ UndefinedObject >> allToScope: aFAMIXScope in: aCollection [
 
 { #category : #'*Moose-Query' }
 UndefinedObject >> allWithScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> atAnyScope: aCollectionOfFamixScope in: aCollection [
 	^ aCollection
 ]
 

--- a/src/Moose-Query/UndefinedObject.extension.st
+++ b/src/Moose-Query/UndefinedObject.extension.st
@@ -1,12 +1,17 @@
 Extension { #name : #UndefinedObject }
 
 { #category : #'*Moose-Query' }
-UndefinedObject >> allAtAnyScope: aFAMIXScope in: aCollection [
+UndefinedObject >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection [
 	^ aCollection
 ]
 
 { #category : #'*Moose-Query' }
 UndefinedObject >> allAtScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> allToAnyScope: aCollectionOfFamixClasses in: aCollection [
 	^ aCollection
 ]
 
@@ -27,6 +32,11 @@ UndefinedObject >> atAnyScope: aCollectionOfFamixScope in: aCollection [
 
 { #category : #'*Moose-Query' }
 UndefinedObject >> atScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> toAnyScope: aCollectionOfFamixClasses in: aCollection [
 	^ aCollection
 ]
 


### PR DESCRIPTION
Implement:- #toAnyScope:- #atAnyScope:- #withAnyScope:- #allToAnyScope:- #allAtAnyScope:- #allWithAnyScope:Those methods take as parameter a collection of famix scopes and will return the first (resp all) entities matching one of the scope.Pair programming with Benoît.