### PR TITLE
fix roassal playground formatted code

### DIFF
--- a/src/Roassal2GT/RTAbstractExample.extension.st
+++ b/src/Roassal2GT/RTAbstractExample.extension.st
@@ -8,13 +8,6 @@ RTAbstractExample >> gtDisplayExamplesIn: aComposite [
 ]
 
 { #category : #'*Roassal2GT-Inspector' }
-RTAbstractExample class >> gtInspectorPreviewIn: composite [
-	<gtInspectorPresentationOrder: 4>
-	<gtInspectorTag: #examples>
-	^ self new gtInspectorPreviewIn: composite
-]
-
-{ #category : #'*Roassal2GT-Inspector' }
 RTAbstractExample >> gtInspectorPreviewIn: composite [
 	<gtInspectorPresentationOrder: 4>
 	^ composite roassal2
@@ -24,6 +17,13 @@ RTAbstractExample >> gtInspectorPreviewIn: composite [
 		painting: [ :view | 
 			view @ RTDraggableView.
 			self gtOpenOn: view ]
+]
+
+{ #category : #'*Roassal2GT-Inspector' }
+RTAbstractExample class >> gtInspectorPreviewIn: composite [
+	<gtInspectorPresentationOrder: 4>
+	<gtInspectorTag: #examples>
+	^ self new gtInspectorPreviewIn: composite
 ]
 
 { #category : #'*Roassal2GT-Inspector' }

--- a/src/Roassal2GT/RTExampleSelection.class.st
+++ b/src/Roassal2GT/RTExampleSelection.class.st
@@ -132,7 +132,7 @@ RTExampleSelection >> matchesQuery: aSetOfNames [
 { #category : #public }
 RTExampleSelection >> playgroundSourceCode [ 
 	" this is really ugly - we would like to perfectly preserve the original format including comments BUT with pragmas stripped - is there a better way ? original code below "
-	^ self method parseTree body formattedCodeWithMaxLineLength: 999
+	^ self method parseTree body formattedCode
 	"
 	| sourceCode firstLine sourceCodeWithoutFirstLine |
 	sourceCode := self method sourceCode.


### PR DESCRIPTION
The first file should not have change... This is a bug with Iceberg

The second file change the selector #formattedCodeWithMaxLineLength: by #formattedCode (because the first not is no longer present in Pharo 70).

fix #1480 