### PR TITLE
Menu bar install entry

### DIFF
--- a/src/Moose-MenuBar/MooseASTEntry.class.st
+++ b/src/Moose-MenuBar/MooseASTEntry.class.st
@@ -22,7 +22,7 @@ MooseASTEntry class >> menuCommandOn: aBuilder [
 		with: [ self allToolClasses
 						do: [ :cls | 
 							(aBuilder item: cls new label)
-								order: 15;
+								order: 20;
 								parent: self menuConfigurationSymbol;
 								label: 'Load ', cls new label;
 								help:'Load ', cls new label;

--- a/src/Moose-MenuBar/MooseASTEntry.class.st
+++ b/src/Moose-MenuBar/MooseASTEntry.class.st
@@ -1,28 +1,22 @@
 Class {
-	#name : #MooseAbstractInstallToolEntry,
-	#superclass : #MooseAbstractMenuEntry,
+	#name : #MooseASTEntry,
+	#superclass : #MooseAbstractInstallToolEntry,
 	#category : #'Moose-MenuBar'
 }
 
-{ #category : #'world menu' }
-MooseAbstractInstallToolEntry class >> allToolClasses [
-	^ self subclasses reject: #isCategory
-]
-
-{ #category : #testing }
-MooseAbstractInstallToolEntry class >> isCategory [
-	^ false
+{ #category : #execution }
+MooseASTEntry class >> isCategory [
+	^ self name = #MooseASTEntry
 ]
 
 { #category : #'world menu' }
-MooseAbstractInstallToolEntry class >> menuCommandOn: aBuilder [
+MooseASTEntry class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	| b |
 	b := ((aBuilder
 		item: self menuConfigurationSymbol;
 		order: 15;
-		parent: #Moose) icon: MooseIcons mooseIcon)
-		withSeparatorAfter;
+		parent: super menuConfigurationSymbol) icon: MooseIcons mooseIcon)
 		yourself.
 	b
 		with: [ self allToolClasses
@@ -37,6 +31,11 @@ MooseAbstractInstallToolEntry class >> menuCommandOn: aBuilder [
 ]
 
 { #category : #'world menu' }
-MooseAbstractInstallToolEntry class >> menuConfigurationSymbol [
-	^ #'Mosse Tools'
+MooseASTEntry class >> menuConfigurationSymbol [
+	^ #'AST Representation'
+]
+
+{ #category : #execution }
+MooseASTEntry >> label [
+	^ 'AST representation'
 ]

--- a/src/Moose-MenuBar/MooseAbstractInstallToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseAbstractInstallToolEntry.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #MooseAbstractInstallToolEntry,
+	#superclass : #MooseAbstractMenuEntry,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #'world menu' }
+MooseAbstractInstallToolEntry class >> allToolClasses [
+	^ self allSubclasses
+]
+
+{ #category : #'world menu' }
+MooseAbstractInstallToolEntry class >> menuCommandOn: aBuilder [
+	<worldMenu>
+	| b |
+	b := ((aBuilder
+		item: self menuConfigurationSymbol;
+		order: 15;
+		parent: #Moose) icon: MooseIcons mooseIcon)
+		withSeparatorAfter;
+		yourself.
+	b
+		with: [ self allToolClasses
+						do: [ :cls | 
+							(aBuilder item: cls new label)
+								order: 15;
+								parent: self menuConfigurationSymbol;
+								label: 'Load ', cls new label;
+								help:'Load ', cls new label;
+								icon: MooseIcons mooseIcon;
+								action: [ cls new run ] ] ].
+]
+
+{ #category : #'world menu' }
+MooseAbstractInstallToolEntry class >> menuConfigurationSymbol [
+	^ #'Mosse Tools'
+]

--- a/src/Moose-MenuBar/MooseAbstractInstallToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseAbstractInstallToolEntry.class.st
@@ -28,7 +28,7 @@ MooseAbstractInstallToolEntry class >> menuCommandOn: aBuilder [
 		with: [ self allToolClasses
 						do: [ :cls | 
 							(aBuilder item: cls new label)
-								order: 15;
+								order: 20;
 								parent: self menuConfigurationSymbol;
 								label: 'Load ', cls new label;
 								help:'Load ', cls new label;

--- a/src/Moose-MenuBar/MooseAbstractMenuEntry.class.st
+++ b/src/Moose-MenuBar/MooseAbstractMenuEntry.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #MooseAbstractMenuEntry,
+	#superclass : #Object,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #execution }
+MooseAbstractMenuEntry >> execute [
+	"Code to be executed"
+	self subclassResponsibility
+]
+
+{ #category : #execution }
+MooseAbstractMenuEntry >> label [
+	^ self subclassResponsibility 
+]
+
+{ #category : #execution }
+MooseAbstractMenuEntry >> run [
+	self execute
+]
+
+{ #category : #execution }
+MooseAbstractMenuEntry >> version [
+	^ self subclassResponsibility
+]

--- a/src/Moose-MenuBar/MooseAlgoToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseAlgoToolEntry.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #MooseAlgoToolEntry,
+	#superclass : #MooseAbstractInstallToolEntry,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #execution }
+MooseAlgoToolEntry >> execute [
+	Metacello new
+		baseline: 'SmaCC';
+		repository: 'github://jmoosetechnology/MooseAlgos:' , self version, '/src';
+		load
+]
+
+{ #category : #accessing }
+MooseAlgoToolEntry >> label [
+	^ 'Moose Algo'
+]
+
+{ #category : #accessing }
+MooseAlgoToolEntry >> version [
+	^ 'v1.1.3'
+]

--- a/src/Moose-MenuBar/MooseAlgoToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseAlgoToolEntry.class.st
@@ -8,7 +8,7 @@ Class {
 MooseAlgoToolEntry >> execute [
 	Metacello new
 		baseline: 'SmaCC';
-		repository: 'github://jmoosetechnology/MooseAlgos:' , self version, '/src';
+		repository: 'github://moosetechnology/MooseAlgos:' , self version, '/src';
 		load
 ]
 

--- a/src/Moose-MenuBar/MooseFASTJavaToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseFASTJavaToolEntry.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MooseFASTJavaToolEntry,
-	#superclass : #MooseAbstractInstallToolEntry,
+	#superclass : #MooseASTEntry,
 	#category : #'Moose-MenuBar'
 }
 

--- a/src/Moose-MenuBar/MooseFASTJavaToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseFASTJavaToolEntry.class.st
@@ -8,7 +8,7 @@ Class {
 MooseFASTJavaToolEntry >> execute [
 	Metacello new
 		baseline: 'FASTJava';
-		repository: 'github://moosetechnology/FAST-Java' , self version, '/src';
+		repository: 'github://moosetechnology/FAST-Java:' , self version, '/src';
 		load
 ]
 

--- a/src/Moose-MenuBar/MooseFASTJavaToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseFASTJavaToolEntry.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #MooseFASTJavaToolEntry,
+	#superclass : #MooseAbstractInstallToolEntry,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #execution }
+MooseFASTJavaToolEntry >> execute [
+	Metacello new
+		baseline: 'FASTJava';
+		repository: 'github://moosetechnology/FAST-Java' , self version, '/src';
+		load
+]
+
+{ #category : #accessing }
+MooseFASTJavaToolEntry >> label [
+	^ 'FAST Java'
+]
+
+{ #category : #accessing }
+MooseFASTJavaToolEntry >> version [
+	^ 'v0.0.1'
+]

--- a/src/Moose-MenuBar/MooseFASTToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseFASTToolEntry.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MooseFASTToolEntry,
-	#superclass : #MooseAbstractInstallToolEntry,
+	#superclass : #MooseASTEntry,
 	#category : #'Moose-MenuBar'
 }
 

--- a/src/Moose-MenuBar/MooseFASTToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseFASTToolEntry.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #MooseFASTToolEntry,
+	#superclass : #MooseAbstractInstallToolEntry,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #execution }
+MooseFASTToolEntry >> execute [
+	Metacello new
+		baseline: 'FAST';
+		repository: 'github://moosetechnology/FAST:' , self version, '/src';
+		load
+]
+
+{ #category : #accessing }
+MooseFASTToolEntry >> label [
+	^ 'FAST Core'
+]
+
+{ #category : #accessing }
+MooseFASTToolEntry >> version [
+	^ 'v0.0.1'
+]

--- a/src/Moose-MenuBar/MooseParserEntry.class.st
+++ b/src/Moose-MenuBar/MooseParserEntry.class.st
@@ -22,7 +22,7 @@ MooseParserEntry class >> menuCommandOn: aBuilder [
 		with: [ self allToolClasses
 						do: [ :cls | 
 							(aBuilder item: cls new label)
-								order: 15;
+								order: 20;
 								parent: self menuConfigurationSymbol;
 								label: 'Load ', cls new label;
 								help:'Load ', cls new label;

--- a/src/Moose-MenuBar/MooseParserEntry.class.st
+++ b/src/Moose-MenuBar/MooseParserEntry.class.st
@@ -1,28 +1,22 @@
 Class {
-	#name : #MooseAbstractInstallToolEntry,
-	#superclass : #MooseAbstractMenuEntry,
+	#name : #MooseParserEntry,
+	#superclass : #MooseAbstractInstallToolEntry,
 	#category : #'Moose-MenuBar'
 }
 
-{ #category : #'world menu' }
-MooseAbstractInstallToolEntry class >> allToolClasses [
-	^ self subclasses reject: #isCategory
-]
-
-{ #category : #testing }
-MooseAbstractInstallToolEntry class >> isCategory [
-	^ false
+{ #category : #execution }
+MooseParserEntry class >> isCategory [
+	^ self name = #MooseParserEntry
 ]
 
 { #category : #'world menu' }
-MooseAbstractInstallToolEntry class >> menuCommandOn: aBuilder [
+MooseParserEntry class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	| b |
 	b := ((aBuilder
 		item: self menuConfigurationSymbol;
 		order: 15;
-		parent: #Moose) icon: MooseIcons mooseIcon)
-		withSeparatorAfter;
+		parent: super menuConfigurationSymbol) icon: MooseIcons mooseIcon)
 		yourself.
 	b
 		with: [ self allToolClasses
@@ -37,6 +31,11 @@ MooseAbstractInstallToolEntry class >> menuCommandOn: aBuilder [
 ]
 
 { #category : #'world menu' }
-MooseAbstractInstallToolEntry class >> menuConfigurationSymbol [
-	^ #'Mosse Tools'
+MooseParserEntry class >> menuConfigurationSymbol [
+	^ #'Moose Parser'
+]
+
+{ #category : #execution }
+MooseParserEntry >> label [
+	^ 'Parser'
 ]

--- a/src/Moose-MenuBar/MoosePetitParserToolEntry.class.st
+++ b/src/Moose-MenuBar/MoosePetitParserToolEntry.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MoosePetitParserToolEntry,
-	#superclass : #MooseAbstractInstallToolEntry,
+	#superclass : #MooseParserEntry,
 	#category : #'Moose-MenuBar'
 }
 

--- a/src/Moose-MenuBar/MoosePetitParserToolEntry.class.st
+++ b/src/Moose-MenuBar/MoosePetitParserToolEntry.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #MoosePetitParserToolEntry,
+	#superclass : #MooseAbstractInstallToolEntry,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #execution }
+MoosePetitParserToolEntry >> execute [
+	Metacello new
+		baseline: 'PetitParser';
+		repository: 'github://moosetechnology/PetitParser:' , self version, '/src';
+		load
+]
+
+{ #category : #accessing }
+MoosePetitParserToolEntry >> label [
+	^ 'Petit Parser'
+]
+
+{ #category : #accessing }
+MoosePetitParserToolEntry >> version [
+	^ 'v2.1.x'
+]

--- a/src/Moose-MenuBar/MooseSmaCCToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseSmaCCToolEntry.class.st
@@ -8,7 +8,7 @@ Class {
 MooseSmaCCToolEntry >> execute [
 	Metacello new
 		baseline: 'SmaCC';
-		repository: 'github://j-brant/SmaCC' , self version, '/src';
+		repository: 'github://j-brant/SmaCC:' , self version, '/src';
 		load
 ]
 

--- a/src/Moose-MenuBar/MooseSmaCCToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseSmaCCToolEntry.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #MooseSmaCCToolEntry,
+	#superclass : #MooseParserEntry,
+	#category : #'Moose-MenuBar'
+}
+
+{ #category : #execution }
+MooseSmaCCToolEntry >> execute [
+	Metacello new
+		baseline: 'SmaCC';
+		repository: 'github://j-brant/SmaCC' , self version, '/src';
+		load
+]
+
+{ #category : #accessing }
+MooseSmaCCToolEntry >> label [
+	^ 'SmaCC'
+]
+
+{ #category : #accessing }
+MooseSmaCCToolEntry >> version [
+	^ 'master'
+]

--- a/src/Moose-MenuBar/package.st
+++ b/src/Moose-MenuBar/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Moose-MenuBar' }


### PR DESCRIPTION
This is a proposition

The idea is to add in the menu bar the possibility to install in the image the last supported version of a project supported by Moose (like PetitParser, MooseAlgo, SmaCC, ....)

Here, the code to install the remote project is hard coded in another method.
Maybe it should be a dependencies in the Moose baseline and we should call it