### PR TITLE
1137-allWithSubTypesOfofGroupClass-and-allWithTypeofGroupClass-use-the-same-cache-entry

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -67,7 +67,7 @@ MooseAbstractGroup >> allWithSubTypesOf: aSmalltalkClass [
 
 { #category : #groups }
 MooseAbstractGroup >> allWithSubTypesOf: aSmalltalkClass ofGroupClass:  aGroupSmalltalkClass [
-	^ self privateState cacheAt: aSmalltalkClass
+	^ self privateState cacheAt: 'sub', aSmalltalkClass className
 		ifAbsentPut: [
 			aGroupSmalltalkClass 
 				withAll: (aSmalltalkClass withMooseSubclasses flatCollect: [:each |


### PR DESCRIPTION
allWithSubTypesOf:ofGroupClass: and allWithType:ofGroupClass: use the same cache entryBut don't give the same results...A solution is to use another entry for subtypes, e.g. 'sub', <className>So I change the entry for the subTypes.fixes #1137