### PR TITLE
isInterfaceFirstStep

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -48,15 +48,18 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-Smalltalk-Utils';
 				package: 'Famix-Compatibility-Generator' with: [ spec requires: #('Famix-BasicInfrastructure') ];
 				package: 'Famix-Compatibility-Entities' with: [ spec requires: #('Famix-Traits' 'Famix-Smalltalk-Utils') ];
+				package: 'Famix-Compatibility-Entities-Extensions' with: [ spec requires: #('Famix-Compatibility-Entities') ];
 				package: 'Moose-GenericImporter' with: [ spec requires: #('Famix-Compatibility-Entities') ];
 				package: 'Moose-SmalltalkImporter' with: [ spec requires: #('Moose-GenericImporter' 'RoelTyper' 'Famix-BasicInfrastructure') ];
 				package: 'Famix-PharoSmalltalk-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-PharoSmalltalk-Entities' with: [ spec requires: #('Famix-MetamodelBuilder-Core' 'Famix-Smalltalk-Utils' 'Famix-Traits') ];
+				package: 'Famix-PharoSmalltalk-Entities-Extensions' with: [ spec requires: #('Famix-PharoSmalltalk-Entities') ];
 				package: 'Famix-PharoSmalltalk-Importer' with: [ spec requires: #('Famix-PharoSmalltalk-Entities' 'Moose-SmalltalkImporter') ];
 				package: 'Famix-PharoSmalltalk-Tests' with: [ spec requires: #('Famix-PharoSmalltalk-Entities' 'Famix-Test1-Entities' 'Moose-Core') ];
 
 				package: 'Famix-Java-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-Java-Entities' with: [ spec requires: #('Famix-MetamodelBuilder-Core' 'Famix-Traits') ];
+				package: 'Famix-Java-Entities-Extensions' with: [ spec requires: #('Famix-Java-Entities') ];
 				package: 'Moose-TestResources-LAN';
 				package: 'Moose-TestResources-LCOM';
 				package: 'Moose-Query-Test' with: [ spec requires: #('Moose-Query' 'Famix-Compatibility-Entities') ];
@@ -90,9 +93,9 @@ BaselineOfFamix >> baseline: spec [
 				group: 'Core' with: #('Famix-Traits' 'Famix-Traits-Extensions' 'Moose-Query-Extensions');
 				group: 'Basic' with: #('Famix-BasicInfrastructure' 'Famix-MetamodelGeneration');
 				group: 'TestsResources' with: #('ReferenceTestResources' 'Moose-TestResources-LAN' 'Moose-TestResources-LCOM' 'KGBTestResources' 'PackageBlueprintTestResources');
-				group: 'ModelCompatibility' with: #('Famix-Compatibility-Generator' 'Famix-Compatibility-Entities');
-				group: 'ModelJava' with: #('Famix-Java-Generator' 'Famix-Java-Entities');
-				group: 'ModelSmalltalk' with: #('Famix-PharoSmalltalk-Generator' 'Famix-PharoSmalltalk-Entities' 'Famix-PharoSmalltalk-Importer');
+				group: 'ModelCompatibility' with: #('Famix-Compatibility-Generator' 'Famix-Compatibility-Entities' 'Famix-Compatibility-Entities-Extensions' );
+				group: 'ModelJava' with: #('Famix-Java-Generator' 'Famix-Java-Entities' 'Famix-Java-Entities-Extensions');
+				group: 'ModelSmalltalk' with: #('Famix-PharoSmalltalk-Generator' 'Famix-PharoSmalltalk-Entities' 'Famix-PharoSmalltalk-Importer' 'Famix-PharoSmalltalk-Entities-Extensions');
 				group: 'Importers' with: #('Moose-GenericImporter' 'Moose-SmalltalkImporter');
 				group: 'Tests'
 					with:

--- a/src/Famix-Compatibility-Entities-Extensions/FAMIXType.extension.st
+++ b/src/Famix-Compatibility-Entities-Extensions/FAMIXType.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #FAMIXType }
+
+{ #category : #'*Famix-Compatibility-Entities-Extensions' }
+FAMIXType >> anySuperclass [
+
+	"Mircea: this used to return interfaces too. fixed now. 
+	also added superclass that does the same thing"
+
+	self
+		allSuperclassesDo: [ :each | 
+			each isInterface
+				ifFalse: [ ^ each ] ].
+	^ nil
+]

--- a/src/Famix-Compatibility-Entities-Extensions/package.st
+++ b/src/Famix-Compatibility-Entities-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Compatibility-Entities-Extensions' }

--- a/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
@@ -48,7 +48,7 @@ FAMIXModelQueriesTest >> testAllClasses [
 
 { #category : #'as yet unclassified' }
 FAMIXModelQueriesTest >> testAllModelClasses [
-	self assert: model allModelClasses size equals: 1
+	self assert: model allModelPureClasses size equals: 1
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities-Extensions/FamixJavaClass.extension.st
+++ b/src/Famix-Java-Entities-Extensions/FamixJavaClass.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #FamixJavaClass }
+
+{ #category : #'*Famix-Java-Entities-Extensions' }
+FamixJavaClass >> isInterface [
+
+	<MSEProperty: #isInterface type: #Boolean>
+	<MSEComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces'>
+
+	^ self privateState attributeAt: #isInterface ifAbsent: [ false ]
+]
+
+{ #category : #'*Famix-Java-Entities-Extensions' }
+FamixJavaClass >> isInterface: aBoolean [
+
+	^ self privateState attributeAt: #isInterface put: true
+]

--- a/src/Famix-Java-Entities-Extensions/FamixJavaType.extension.st
+++ b/src/Famix-Java-Entities-Extensions/FamixJavaType.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #FamixJavaType }
+
+{ #category : #'*Famix-Java-Entities-Extensions' }
+FamixJavaType >> anySuperclass [
+"Mircea: this used to return interfaces too. fixed now. 
+	also added superclass that does the same thing"
+
+	self
+		allSuperclassesDo: [ :each | 
+			each isInterface
+				ifFalse: [ ^ each ] ].
+	^ nil
+]

--- a/src/Famix-Java-Entities-Extensions/package.st
+++ b/src/Famix-Java-Entities-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Java-Entities-Extensions' }

--- a/src/Famix-PharoSmalltalk-Entities-Extensions/FamixStMethod.extension.st
+++ b/src/Famix-PharoSmalltalk-Entities-Extensions/FamixStMethod.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #FamixStMethod }
+
+{ #category : #'*Famix-PharoSmalltalk-Entities-Extensions' }
+FamixStMethod >> isOverriding [
+	<MSEProperty: #isOverriding type: #Boolean>
+	<derived>
+	<MSEComment: 'The method is overrinding a method defined in a super class'>
+	
+	^self belongsTo directSuperclasses anySatisfy: [:each | 
+		each understands: self signature]
+]

--- a/src/Famix-PharoSmalltalk-Entities-Extensions/package.st
+++ b/src/Famix-PharoSmalltalk-Entities-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-PharoSmalltalk-Entities-Extensions' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -200,16 +200,6 @@ FamixStMethod >> isOverriden [
 ]
 
 { #category : #'Famix-Extensions-metrics-support' }
-FamixStMethod >> isOverriding [
-	<MSEProperty: #isOverriding type: #Boolean>
-	<derived>
-	<MSEComment: 'The method is overrinding a method defined in a super class'>
-	
-	^self belongsTo directSuperclasses anySatisfy: [:each | 
-		each isInterface not and: [each understands: self signature]]
-]
-
-{ #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> isSurelyInvokedBy: aFAMIXMethod [ 
 	 
 	| outgoingInvo |

--- a/src/Famix-Test1-Tests/FamixTClassTest.class.st
+++ b/src/Famix-Test1-Tests/FamixTClassTest.class.st
@@ -56,7 +56,8 @@ FamixTClassTest >> testIsClass [
 
 { #category : #tests }
 FamixTClassTest >> testIsInterface [
-
+	self skip.
+	"isInterface is no more in the TClass traits since in some languages as Smalltalk, there is no interface"
 	self deny: c1 isInterface.
 	c1 isInterface: true.
 	self assert: c1 isInterface.

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -48,21 +48,6 @@ FamixTClass >> isClass [
 ]
 
 { #category : #testing }
-FamixTClass >> isInterface [
-
-	<MSEProperty: #isInterface type: #Boolean>
-	<MSEComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces'>
-
-	^ self privateState attributeAt: #isInterface ifAbsent: [ false ]
-]
-
-{ #category : #testing }
-FamixTClass >> isInterface: aBoolean [
-
-	^ self privateState attributeAt: #isInterface put: true
-]
-
-{ #category : #testing }
 FamixTClass >> isTestCase [
 
 	<MSEProperty: #isTestCase type: #Boolean>

--- a/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
+++ b/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
@@ -49,7 +49,8 @@ FamixTClassHierarchyNavigation >> allSubclassesWithoutAliasesDo: aBlock [
 
 { #category : #enumerating }
 FamixTClassHierarchyNavigation >> allSuperclassesDo: aBlock [
-	self allSuperclassesWithoutAliasesDo: aBlock.
+	self superInheritances do: [:each | aBlock value: each superclass].
+	self superInheritances do: [:each | each superclass allSuperclassesDo: aBlock]
 
 ]
 
@@ -61,14 +62,8 @@ FamixTClassHierarchyNavigation >> allSuperclassesWithoutAliasesDo: aBlock [
 
 { #category : #enumerating }
 FamixTClassHierarchyNavigation >> anySuperclass [
-	"Mircea: this used to return interfaces too. fixed now. 
-	also added superclass that does the same thing"
 
-	self
-		allSuperclassesDo: [ :each | 
-			each isInterface
-				ifFalse: [ ^ each ] ].
-	^ nil
+	self superInheritances ifEmpty: [ ^nil ] ifNotEmpty: [^ self superInheritances any superclass]. 
 ]
 
 { #category : #enumerating }

--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -138,7 +138,7 @@ MooseAbstractGroup >> allModelClasses [
 	^ self privateState cacheAt: 'All model classes'
 		ifAbsentPut: [
 			MooseGroup
-				withAll: ((self allClasses reject: [:each | each isStub or: [each isInterface]]) )
+				withAll: ((self allClasses reject: [:each | each isStub ]) )
 				withDescription: 'All model classes' ]
 ]
 
@@ -174,6 +174,16 @@ MooseAbstractGroup >> allModelPackages [
 				withAll: ((self allPackages reject: [:each | each isStub]) sorted:
 																		[:p1 :p2 | p1 name < p2 name] )
 				withDescription: 'All model packages' ]
+]
+
+{ #category : #'*Famix-Traits' }
+MooseAbstractGroup >> allModelPureClasses [
+	self flag: 'this method exists only the time we manage correctly the interface'.
+	^ self privateState cacheAt: 'All model classes'
+		ifAbsentPut: [
+			MooseGroup
+				withAll: ((self allClasses reject: [:each | each isStub or: [each isInterface]]) )
+				withDescription: 'All model classes' ]
 ]
 
 { #category : #'*Famix-Traits' }


### PR DESCRIPTION
Removing isInterface from FamixTClass, putting it to JavaClass and  modifying consequently the tests and other methods.
Creating in MooseAbstractGroup allModelPureClasses that has the same behaviour than allModelClasses before. allModelClasses return class even if they are interface. This is a hack before creating Interface in Java.