### PR TITLE
MovingTraits

### DIFF
--- a/src/Fame-Core/FMRepository.class.st
+++ b/src/Fame-Core/FMRepository.class.st
@@ -72,7 +72,6 @@ FMRepository >> additionalProperties [
 
 { #category : #accessing }
 FMRepository >> additionalPropertiesFor: entityClass [
-
 	^ self additionalProperties at: entityClass ifAbsentPut: [ IdentityDictionary new ]
 ]
 

--- a/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
@@ -6,7 +6,7 @@ Class {
 	#category : #'Famix-Compatibility-Entities-Entities'
 }
 
-{ #category : #meta }
+{ #category : #'as yet unclassified' }
 FAMIXPackage class >> annotation [
 
 	<MSEClass: #Package super: #FAMIXScopingEntity>
@@ -15,14 +15,14 @@ FAMIXPackage class >> annotation [
 	^self
 ]
 
-{ #category : #generator }
+{ #category : #'as yet unclassified' }
 FAMIXPackage class >> generatedSlotNames [
 	<generated>
 	'FAMIXPackage class>>#generatedSlotNames'.
 	^ #()
 ]
 
-{ #category : #generator }
+{ #category : #'as yet unclassified' }
 FAMIXPackage class >> generatedTraitNames [
 	<generated>
 	^ #(FamixTCohesionCouplingMetrics FamixTPackage FamixTPackageWithClassesGlue)

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaAnnotationType,
 	#superclass : #FamixJavaType,
-	#traits : 'FamixTAnnotationType',
-	#classTraits : 'FamixTAnnotationType classTrait',
+	#traits : 'FamixTAnnotationType + FamixTWithAttributes',
+	#classTraits : 'FamixTAnnotationType classTrait + FamixTWithAttributes classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -35,7 +35,7 @@ FamixJavaAttribute class >> generatedTraitNames [
 FamixJavaAttribute class >> requirements [
 
 	<generated>
-	^ { FamixJavaType }
+	^ {  }
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaClass,
 	#superclass : #FamixJavaType,
-	#traits : 'FamixTClass + FamixTLCOMMetrics + FamixTWithExceptions',
-	#classTraits : 'FamixTClass classTrait + FamixTLCOMMetrics classTrait + FamixTWithExceptions classTrait',
+	#traits : 'FamixJavaTLCOMMetrics + FamixTClass + FamixTWithExceptions',
+	#classTraits : 'FamixJavaTLCOMMetrics classTrait + FamixTClass classTrait + FamixTWithExceptions classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 
@@ -25,7 +25,7 @@ FamixJavaClass class >> generatedSlotNames [
 { #category : #generator }
 FamixJavaClass class >> generatedTraitNames [
 	<generated>
-	^ #(FamixTClass FamixTLCOMMetrics FamixTWithExceptions)
+	^ #(FamixJavaTLCOMMetrics FamixTClass FamixTWithExceptions)
 ]
 
 { #category : #meta }

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -32,7 +32,7 @@ FamixJavaMethod class >> generatedTraitNames [
 FamixJavaMethod class >> requirements [
 
 	<generated>
-	^ { FamixJavaType }
+	^ {  }
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaTLCOMMetrics.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTLCOMMetrics.trait.st
@@ -1,0 +1,26 @@
+Trait {
+	#name : #FamixJavaTLCOMMetrics,
+	#category : #'Famix-Java-Entities-Traits'
+}
+
+{ #category : #meta }
+FamixJavaTLCOMMetrics classSide >> annotation [
+
+	<MSEClass: #TLCOMMetrics super: #Trait>
+	<generated>
+	<package: #'Famix-Java-Entities'>
+	^self
+]
+
+{ #category : #generator }
+FamixJavaTLCOMMetrics classSide >> generatedSlotNames [
+	<generated>
+	'FamixJavaTLCOMMetrics class>>#generatedSlotNames'.
+	^ #()
+]
+
+{ #category : #generator }
+FamixJavaTLCOMMetrics classSide >> generatedTraitNames [
+	<generated>
+	^ #()
+]

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaType,
 	#superclass : #FamixJavaContainerEntity,
-	#traits : 'FamixTClassHierarchyNavigation + FamixTContainingWithInvocationsGlue + FamixTContainingWithStatementsGlue + FamixTParameterizedTypeUser + FamixTReferenceable + FamixTType + FamixTWithAttributes + FamixTWithMethods + FamixTWithMethodsWithAccessesGlue + FamixTWithMethodsWithModifiersGlue + FamixTWithSubInheritances + FamixTWithSuperInheritances + FamixTWithTypeAliases + FamixTWithTypedStructures',
-	#classTraits : 'FamixTClassHierarchyNavigation classTrait + FamixTContainingWithInvocationsGlue classTrait + FamixTContainingWithStatementsGlue classTrait + FamixTParameterizedTypeUser classTrait + FamixTReferenceable classTrait + FamixTType classTrait + FamixTWithAttributes classTrait + FamixTWithMethods classTrait + FamixTWithMethodsWithAccessesGlue classTrait + FamixTWithMethodsWithModifiersGlue classTrait + FamixTWithSubInheritances classTrait + FamixTWithSuperInheritances classTrait + FamixTWithTypeAliases classTrait + FamixTWithTypedStructures classTrait',
+	#traits : 'FamixTClassHierarchyNavigation + FamixTParameterizedTypeUser + FamixTReferenceable + FamixTType + FamixTWithTypeAliases + FamixTWithTypedStructures',
+	#classTraits : 'FamixTClassHierarchyNavigation classTrait + FamixTParameterizedTypeUser classTrait + FamixTReferenceable classTrait + FamixTType classTrait + FamixTWithTypeAliases classTrait + FamixTWithTypedStructures classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 
@@ -25,7 +25,7 @@ FamixJavaType class >> generatedSlotNames [
 { #category : #generator }
 FamixJavaType class >> generatedTraitNames [
 	<generated>
-	^ #(FamixTClassHierarchyNavigation FamixTContainingWithInvocationsGlue FamixTContainingWithStatementsGlue FamixTParameterizedTypeUser FamixTReferenceable FamixTType FamixTWithAttributes FamixTWithMethods FamixTWithMethodsWithAccessesGlue FamixTWithMethodsWithModifiersGlue FamixTWithSubInheritances FamixTWithSuperInheritances FamixTWithTypeAliases FamixTWithTypedStructures)
+	^ #(FamixTClassHierarchyNavigation FamixTParameterizedTypeUser FamixTReferenceable FamixTType FamixTWithTypeAliases FamixTWithTypedStructures)
 ]
 
 { #category : #meta }

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -159,6 +159,7 @@ FamixJavaGenerator >> defineHierarchy [
 	class --|> type.
 	class --|> #TWithExceptions.
 	class --|> #TClass.
+	class --|> #TLCOMMetrics.
 
 	containerEntity --|> namedEntity.
 	containerEntity --|> #TWithTypes.
@@ -240,10 +241,6 @@ FamixJavaGenerator >> defineHierarchy [
 	type --|> #TReferenceable.
 	type --|> #TWithTypedStructures.
 	type --|> #TWithTypeAliases.
-	type --|> #TWithMethods.
-	type --|> #TWithSuperInheritances.
-	type --|> #TWithSubInheritances.
-	type --|> #TWithAttributes.
 	type --|> #TParameterizedTypeUser.
 	type --|> #TClassHierarchyNavigation. 
 

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -896,9 +896,6 @@ FamixGenerator >> defineGlueingTraits [
 	tPackageWithClassesGlue := builder newTraitNamed: #TPackageWithClassesGlue.
 	tPackageWithClassesGlue glues: tPackage with: tWithClasses.
 
-	tLCOMMetrics := builder newTraitNamed: #TLCOMMetrics.
-	tLCOMMetrics glues: tClass with: tWithMethods.
-
 	tClassWithInvocationsGlue := builder newTraitNamed: #TClassWithInvocationsGlue.
 	tClassWithInvocationsGlue glues: tClass with: tWithInvocations.
 	

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStAnnotationType,
 	#superclass : #FamixStType,
-	#traits : 'FamixTAnnotationType',
-	#classTraits : 'FamixTAnnotationType classTrait',
+	#traits : 'FamixTAnnotationType + FamixTWithAttributes',
+	#classTraits : 'FamixTAnnotationType classTrait + FamixTWithAttributes classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -35,7 +35,7 @@ FamixStAttribute class >> generatedTraitNames [
 FamixStAttribute class >> requirements [
 
 	<generated>
-	^ { FamixStType }
+	^ {  }
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStClass,
 	#superclass : #FamixStType,
-	#traits : 'FamixTClass + FamixTClassHierarchyNavigation + FamixTContainingWithInvocationsGlue + FamixTLCOMMetrics + FamixTWithExceptions + FamixTWithMethods + FamixTWithMethodsWithAccessesGlue + FamixTWithMethodsWithModifiersGlue + FamixTWithSubInheritances + FamixTWithSuperInheritances',
-	#classTraits : 'FamixTClass classTrait + FamixTClassHierarchyNavigation classTrait + FamixTContainingWithInvocationsGlue classTrait + FamixTLCOMMetrics classTrait + FamixTWithExceptions classTrait + FamixTWithMethods classTrait + FamixTWithMethodsWithAccessesGlue classTrait + FamixTWithMethodsWithModifiersGlue classTrait + FamixTWithSubInheritances classTrait + FamixTWithSuperInheritances classTrait',
+	#traits : 'FamixTClass + FamixTClassHierarchyNavigation + FamixTWithExceptions',
+	#classTraits : 'FamixTClass classTrait + FamixTClassHierarchyNavigation classTrait + FamixTWithExceptions classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 
@@ -25,7 +25,7 @@ FamixStClass class >> generatedSlotNames [
 { #category : #generator }
 FamixStClass class >> generatedTraitNames [
 	<generated>
-	^ #(FamixTClass FamixTClassHierarchyNavigation FamixTContainingWithInvocationsGlue FamixTLCOMMetrics FamixTWithExceptions FamixTWithMethods FamixTWithMethodsWithAccessesGlue FamixTWithMethodsWithModifiersGlue FamixTWithSubInheritances FamixTWithSuperInheritances)
+	^ #(FamixTClass FamixTClassHierarchyNavigation FamixTWithExceptions)
 ]
 
 { #category : #meta }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -35,7 +35,7 @@ FamixStMethod class >> generatedTraitNames [
 FamixStMethod class >> requirements [
 
 	<generated>
-	^ { FamixStClass }
+	^ {  }
 ]
 
 { #category : #meta }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStTLCOMMetrics.trait.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStTLCOMMetrics.trait.st
@@ -1,0 +1,26 @@
+Trait {
+	#name : #FamixStTLCOMMetrics,
+	#category : #'Famix-PharoSmalltalk-Entities-Traits'
+}
+
+{ #category : #meta }
+FamixStTLCOMMetrics classSide >> annotation [
+
+	<MSEClass: #TLCOMMetrics super: #Trait>
+	<generated>
+	<package: #'Famix-PharoSmalltalk-Entities'>
+	^self
+]
+
+{ #category : #generator }
+FamixStTLCOMMetrics classSide >> generatedSlotNames [
+	<generated>
+	'FamixStTLCOMMetrics class>>#generatedSlotNames'.
+	^ #()
+]
+
+{ #category : #generator }
+FamixStTLCOMMetrics classSide >> generatedTraitNames [
+	<generated>
+	^ #()
+]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStType,
 	#superclass : #FamixStContainerEntity,
-	#traits : 'FamixTReferenceable + FamixTType + FamixTWithAttributes + FamixTWithTypedStructures',
-	#classTraits : 'FamixTReferenceable classTrait + FamixTType classTrait + FamixTWithAttributes classTrait + FamixTWithTypedStructures classTrait',
+	#traits : 'FamixTReferenceable + FamixTType + FamixTWithTypedStructures',
+	#classTraits : 'FamixTReferenceable classTrait + FamixTType classTrait + FamixTWithTypedStructures classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 
@@ -25,7 +25,7 @@ FamixStType class >> generatedSlotNames [
 { #category : #generator }
 FamixStType class >> generatedTraitNames [
 	<generated>
-	^ #(FamixTReferenceable FamixTType FamixTWithAttributes FamixTWithTypedStructures)
+	^ #(FamixTReferenceable FamixTType FamixTWithTypedStructures)
 ]
 
 { #category : #meta }

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -120,10 +120,8 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	class --|> type.
 	class --|> #TWithExceptions.
 	class --|> #TClass.
-	class --|> #TWithMethods.
-	class --|> #TWithSuperInheritances.
-	class --|> #TWithSubInheritances.
 	class --|> #TClassHierarchyNavigation.
+
 	
 	containerEntity --|> namedEntity.
 	containerEntity --|> #TWithTypes.
@@ -193,7 +191,6 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	type --|> containerEntity.
 	type --|> #TType.
 	type --|> #TReferenceable.
-	type --|> #TWithAttributes.
 	type --|> #TWithTypedStructures.
 
 	unknownSourceLanguage --|> sourceLanguage.

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -98,8 +98,8 @@ TEntityMetaLevelDependencyTest >> testAllChildren [
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllChildrenTypes [
 
-	self assertCollection: c1 allChildrenTypes hasSameElements: { FamixTMethod }.
-	self assertCollection: c2 allChildrenTypes hasSameElements: { FamixTMethod }.
+	self assertCollection: c1 allChildrenTypes hasSameElements: { FamixTMethod. FamixTAttribute  }.
+	self assertCollection: c2 allChildrenTypes hasSameElements: { FamixTMethod. FamixTAttribute }.
 	self assertCollection: m1 allChildrenTypes hasSameElements: { }.
 	self assert: anchor1 allChildrenTypes isEmpty.
 ]
@@ -107,15 +107,15 @@ TEntityMetaLevelDependencyTest >> testAllChildrenTypes [
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllIncomingAssociationTypes [
 
-	"just smoke test, we have no associations in this testing meta-model"
-	self assert: c1 allIncomingAssociationTypes isEmpty
+	
+	self assertCollection: c1 allIncomingAssociationTypes  hasSameElements:  { FamixTSuperInheritance }
 ]
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllOutgoingAssociationTypes [
 
-	"just smoke test, we have no associations in this testing meta-model"
-	self assert: c1 allOutgoingAssociationTypes isEmpty
+	
+	self assertCollection: c1 allOutgoingAssociationTypes hasSameElements: { FamixTSubInheritance }
 ]
 
 { #category : #tests }
@@ -205,8 +205,8 @@ TEntityMetaLevelDependencyTest >> testChildren [
 TEntityMetaLevelDependencyTest >> testChildrenSelectors [
 
 	self assertCollection: m1 childrenSelectors hasSameElements: { }.
-	self assertCollection: c1 childrenSelectors hasSameElements: { #methods }.
-	self assertCollection: c2 childrenSelectors hasSameElements: { #methods}.
+	self assertCollection: c1 childrenSelectors hasSameElements: { #methods . #attributes}.
+	self assertCollection: c2 childrenSelectors hasSameElements: { #methods . #attributes}.
 	self assertCollection: anchor1 childrenSelectors hasSameElements: { }.
 	
 
@@ -215,29 +215,25 @@ TEntityMetaLevelDependencyTest >> testChildrenSelectors [
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testIncomingAssociationTypes [
 
-	"just smoke test, we have no associations in this testing meta-model"
-	self assert: c1 incomingAssociationTypes isEmpty
+	self assertCollection: c1 allIncomingAssociationTypes  hasSameElements:  { FamixTSuperInheritance }
 ]
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testIncomingMSEProperties [
 
-	"just smoke test, we have no associations in this testing meta-model"
-	self assert: c1 incomingMSEProperties isEmpty
+	self assertCollection: c1 allIncomingAssociationTypes  hasSameElements:  { FamixTSuperInheritance }
 ]
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testOutgoingAssociationTypes [
 
-	"just smoke test, we have no associations in this testing meta-model"
-	self assert: c1 outgoingAssociationTypes isEmpty
+	self assertCollection: c1 allOutgoingAssociationTypes hasSameElements: { FamixTSubInheritance }
 ]
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testOutgoingMSEProperties [
 
-	"just smoke test, we have no associations in this testing meta-model"
-	self assert: c1 outgoingMSEProperties isEmpty
+	self assertCollection: c1 allOutgoingAssociationTypes hasSameElements: { FamixTSubInheritance }
 ]
 
 { #category : #tests }

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixTest2Class,
 	#superclass : #FamixTest2NamedEntity,
-	#traits : 'FamixTClass + FamixTWithSubInheritances + FamixTWithSuperInheritances',
-	#classTraits : 'FamixTClass classTrait + FamixTWithSubInheritances classTrait + FamixTWithSuperInheritances classTrait',
+	#traits : 'FamixTClass',
+	#classTraits : 'FamixTClass classTrait',
 	#category : #'Famix-Test2-Entities-Entities'
 }
 

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -7,6 +7,8 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 "
 Trait {
 	#name : #FamixTClass,
+	#traits : 'FamixTWithMethods + FamixTWithSubInheritances + FamixTWithSuperInheritances + FamixTWithAttributes + FamixTLCOMMetrics',
+	#classTraits : 'FamixTWithMethods classTrait + FamixTWithSubInheritances classTrait + FamixTWithSuperInheritances classTrait + FamixTWithAttributes classTrait + FamixTLCOMMetrics classTrait',
 	#category : #'Famix-Traits-Class'
 }
 

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -124,7 +124,6 @@ TEntityMetaLevelDependency classSide >> parentTypesIn: aMetamodel [
 
 { #category : #new }
 TEntityMetaLevelDependency classSide >> privateAllChildrenTypesIn: aMetamodel [
-
 	^ ((self childrenTypesIn: aMetamodel) withDeepCollect: [ :each | each childrenTypesInMetamodel: aMetamodel] as: Set) asOrderedCollection
 ]
 

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixPropertiesTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixPropertiesTest.class.st
@@ -116,11 +116,6 @@ FamixPropertiesTest >> testClassMethods [
 		assert: (self nodeClass propertyNamed: #numberOfMethodsAdded)
 		equals: (self nodeClass propertyNamed: #numberOfMethods).
 	self assert: (self nodeClass propertyNamed: #numberOfConstructorMethods) equals: 0.
-	self assert: (self nodeClass propertyNamed: #numberOfPrivateMethods) equals: 0.
-	self assert: (self nodeClass propertyNamed: #numberOfProtectedMethods) equals: 0.
-	self
-		assert: (self nodeClass propertyNamed: #numberOfPublicMethods)
-		equals: (self nodeClass propertyNamed: #numberOfMethods).
 	self
 		assert: (self workstationClass propertyNamed: #numberOfMethodsInherited)
 		equals: (self nodeClass propertyNamed: #numberOfMethods) + (self nodeClass propertyNamed: #numberOfMethodsInherited).


### PR DESCRIPTION
Moving used Traits from the specific generator to the generic traits.
Modifying Tests because only directed selectors are taken into account in MooseQuery with FamixNG.
Modifying St and Java generator