### PR TITLE
1570-generateWithCleaning-does-not-generate-entities-in-submetamodels

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -243,7 +243,8 @@ FamixMetamodelGenerator >> generateWithCleaning [
 	EpMonitor
 		disableDuring: [ self cleanPackage.
 			self define.
-			self builder generate ]
+			self builder generate.
+			subbuilders do: #generateRemotes ]
 ]
 
 { #category : #generation }


### PR DESCRIPTION
add subbuilders generateRemote when cleaningfixes #1570