### PR TITLE
1582-Famix-should-not-use-methods-of-Grease

### DIFF
--- a/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
+++ b/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
@@ -62,8 +62,9 @@ FamixTClassHierarchyNavigation >> allSuperclassesWithoutAliasesDo: aBlock [
 
 { #category : #enumerating }
 FamixTClassHierarchyNavigation >> anySuperclass [
-
-	self superInheritances ifEmpty: [ ^nil ] ifNotEmpty: [^ self superInheritances any superclass]. 
+	^ self superInheritances
+		ifEmpty: [ nil ]
+		ifNotEmpty: [ self superInheritances anyOne superclass ]
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
Remove dependency on Grease.

Fixes #1582