### PR TITLE
make the MooseFinder using the same panels than the Moose Inspector (…

### DIFF
--- a/src/Moose-Finder/MooseFinder.class.st
+++ b/src/Moose-Finder/MooseFinder.class.st
@@ -14,30 +14,33 @@ MooseFinder class >> announcerFor: anObject [
 		ifFalse: [Announcer new]
 ]
 
+{ #category : #accessing }
+MooseFinder class >> extensionsPragma [
+	^ #gtInspectorPresentationOrder:
+]
+
 { #category : #building }
 MooseFinder >> compose [
-	self pager 
-"		act: [:b | b update] icon: GLMUIThemeExtraIcons glamorousRefresh entitled: 'Update';
-"		title: [:each | 'Moose Finder on ', each mooseInterestingEntity gtDisplayString];
-		show: [ :a :each |
-			a 	
-				title: ((each mooseInterestingEntity gtDisplayString), ' (', 
-							each mooseInterestingEntity class name, ')');
-				dynamicActions: [ :list | list entity mooseInterestingEntity mooseFinderActions ].
-			each mooseInterestingEntity mooseFinderPresentationsIn: a inContext: self.
-			a 
-				updateOn: MooseEntityAdded 
-				from: [ each isNil ifFalse: [each announcer] ifTrue: [nil] ].
-			a 
-				updateOn: MooseEntityRemoved 
-				from: [ each isNil ifFalse: [each announcer] ifTrue: [nil] ].
-			a	
-				updateOn: MooseEntityRenamed 
-				from: [ each isNil ifFalse: [each announcer] ifTrue: [nil] ]].
-
+	super compose.
+	self pager
+		title: [ :each | 'Moose Finder on ' , each mooseInterestingEntity gtDisplayString ];
+		show: [ :a :each | 
+			a
+				title: each mooseInterestingEntity gtDisplayString , ' (' , each mooseInterestingEntity class name , ')';
+				dynamicActions: [ :list | list entity mooseInterestingEntity mooseFinderActions asOrderedCollection , each gtInspectorActions asOrderedCollection ].
+			each mooseInterestingEntity gtInspectorPresentationsIn: a inContext: self.
+			a updateOn: MooseEntityAdded from: [ each isNil ifFalse: [ each announcer ] ifTrue: [ nil ] ].
+			a updateOn: MooseEntityRemoved from: [ each isNil ifFalse: [ each announcer ] ifTrue: [ nil ] ].
+			a updateOn: MooseEntityRenamed from: [ each isNil ifFalse: [ each announcer ] ifTrue: [ nil ] ] ]
 ]
 
 { #category : #accessing }
 MooseFinder >> panes [
 	^ self first panes
+]
+
+{ #category : #asserting }
+MooseFinder >> shouldDisplayPresentationCreatedBy: aMethod [
+
+	^ self pager shouldDisplayPresentationCreatedBy: aMethod
 ]


### PR DESCRIPTION
…and add to it the previous behaviors)

So, if an entity is present in the metamodel, nothing change
If the entity is absent, we still can browser it in the same way as the inspector

fixes #1594 