### PR TITLE
1235-allModelNamespaces-does-not-seems-right

### DIFF
--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -154,14 +154,10 @@ MooseAbstractGroup >> allModelMethods [
 { #category : #'*Famix-Traits' }
 MooseAbstractGroup >> allModelNamespaces [
 	<navigation: 'All model namespaces'>
-
-	^ self privateState cacheAt: 'All model namespaces'
-		ifAbsentPut: [
-			MooseGroup
-				withAll: (self allNamespaces select: [:each | 
-					each classes notEmpty and: [
-						each classes anySatisfy: [:class | class isStub not]]])
-				withDescription: 'All model namespaces' ]
+	^ self privateState
+		cacheAt: 'All model namespaces'
+		ifAbsentPut:
+			[ MooseGroup withAll: (self allNamespaces reject: [ :each | each isStub or: [ each types isEmpty or: [ each types allSatisfy: [ :type | type isStub ] ] ] ]) withDescription: 'All model namespaces' ]
 ]
 
 { #category : #'*Famix-Traits' }


### PR DESCRIPTION
fixes allModelNamespaces

It should look before if it is a stub, then if it has types and finally if at least one type is not a stubfixes #1235