### PR TITLE
BugWithClassSideVariableForSmalltalkImporter

### DIFF
--- a/src/Moose-SmalltalkImporter/SmalltalkMethodVisitor.class.st
+++ b/src/Moose-SmalltalkImporter/SmalltalkMethodVisitor.class.st
@@ -15,7 +15,8 @@ SmalltalkMethodVisitor >> resolve: name [
 
 	| object klass pool |
 	(name = 'self' or: [ name = 'super' or: [ name = 'thisContext' ] ]) ifTrue: [ ^ importer ensureImplicitVariable: name asSymbol inFamixMethod: famixMethod ].
-	object := self methodEntity isClassSide ifFalse: [ methodScope resolve: name ifAbsent: [ nil ] ] ifTrue: [ methodScope resolve: self CIVString , name ifAbsent: [ nil ] ].
+	object := self methodEntity isClassSide ifTrue: [ methodScope resolve: self CIVString , name ifAbsent: [ nil ] ].
+	object ifNil: [ object := methodScope resolve: name ifAbsent: nil ].
 	object ~~ nil ifTrue: [ ^ object ].
 	name asString = 'Smalltalk' ifTrue: [ ^ importer ensureNamespace: Smalltalk ].
 	klass := self methodEntity smalltalkClass instanceSide.

--- a/src/Moose-SmalltalkImporter/SmalltalkMethodVisitor.class.st
+++ b/src/Moose-SmalltalkImporter/SmalltalkMethodVisitor.class.st
@@ -5,29 +5,27 @@ Class {
 }
 
 { #category : #private }
+SmalltalkMethodVisitor >> CIVString [
+	^ SmalltalkImporter CIVString
+]
+
+{ #category : #private }
 SmalltalkMethodVisitor >> resolve: name [
 	"Return a famix entity that correspond to the reference 'name' contained in a source code. It does the lookup according to the Smalltalk semantics"
 
 	| object klass pool |
-	(name = 'self' or: [ name = 'super' or: [ name = 'thisContext' ] ])
-		ifTrue: [ ^ importer
-				ensureImplicitVariable: name asSymbol
-				inFamixMethod: famixMethod ].
-	object := methodScope resolve: name ifAbsent: nil.
-	object ~~ nil
-		ifTrue: [ ^ object ].
-	name asString = 'Smalltalk'
-		ifTrue: [ ^ importer ensureNamespace: Smalltalk ].
+	(name = 'self' or: [ name = 'super' or: [ name = 'thisContext' ] ]) ifTrue: [ ^ importer ensureImplicitVariable: name asSymbol inFamixMethod: famixMethod ].
+	object := self methodEntity isClassSide ifFalse: [ methodScope resolve: name ifAbsent: [ nil ] ] ifTrue: [ methodScope resolve: self CIVString , name ifAbsent: [ nil ] ].
+	object ~~ nil ifTrue: [ ^ object ].
+	name asString = 'Smalltalk' ifTrue: [ ^ importer ensureNamespace: Smalltalk ].
 	klass := self methodEntity smalltalkClass instanceSide.
 	(klass usesLocalPoolVarNamed: name)
 		ifTrue: [ pool := klass sharedPoolOfVarNamed: name.
 			^ self importer ensureClassVarAttribute: name for: pool ].
-	(Smalltalk globals includesKey: name asSymbol)
-		ifFalse: [ ^ importer ensureUnknownVariable: name ].
+	(Smalltalk globals includesKey: name asSymbol) ifFalse: [ ^ importer ensureUnknownVariable: name ].
 
 	"The name must be a global accessible variable"
 	object := Smalltalk at: name asSymbol.
-	object isBehavior
-		ifTrue: [ ^ importer ensureClass: object class ].
+	object isBehavior ifTrue: [ ^ importer ensureClass: object class ].
 	^ importer ensureGlobalVariable: name asSymbol value: object
 ]

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
@@ -964,11 +964,7 @@ FamixReferenceModelImporterTest >> testUsedClassReifiedWithinReturn [
 FamixReferenceModelImporterTest >> testaccessSharedVariableFromTheClassSide [
 	"self debug: #testaccessSharedVariableFromTheClassSide"
 
-	| attributeName definingClassName classVarUniqueName accessDefinition methodUniqueName methodName methodClassName |
-	attributeName := #TheRootSharedVariable.
-	definingClassName := TheRoot mooseName.
-	methodClassName := TheRoot class mooseName.
-	methodName := #accessSharedVariableFromTheClassSide.
+	| classVarUniqueName accessDefinition methodUniqueName |
 	methodUniqueName := (TheRoot class >> #accessSharedVariableFromTheClassSide) mooseName.
 	classVarUniqueName := TheRoot @ #TheRootSharedVariable.
 	accessDefinition := self model allAccesses


### PR DESCRIPTION
We cannot import PetitParser2 with the current SmalltalkImporter because of an error when we try to find the inst variable of a classThis is the fix