### PR TITLE
1603-We-cant-inspect-a-group-with-only-integers

### DIFF
--- a/src/Fame-Core/FM3NullDescription.class.st
+++ b/src/Fame-Core/FM3NullDescription.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #FM3NullDescription,
+	#superclass : #FM3MetaDescription,
+	#category : #'Fame-Core'
+}

--- a/src/Fame-Core/Object.extension.st
+++ b/src/Fame-Core/Object.extension.st
@@ -16,14 +16,14 @@ Object >> isFM3Property [
 ]
 
 { #category : #'*Fame-Core' }
-Object >> metamodel [
-
-	^ self class metamodel
+Object class >> metamodel [ 
+	^ nil
 ]
 
 { #category : #'*Fame-Core' }
-Object class >> metamodel [ 
-	^ nil
+Object >> metamodel [
+
+	^ self class metamodel
 ]
 
 { #category : #'*Fame-Core' }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -203,7 +203,7 @@ MooseGroup >> min: aSymbolOrBlock [
 { #category : #accessing }
 MooseGroup >> mooseDescription [
 
-	^ self mooseModel metamodel descriptionOf: self class instanceSide  
+	^ self mooseModel ifNil: [ FM3NullDescription new ] ifNotNil: [ :mooseModel | mooseModel metamodel descriptionOf: self class instanceSide]  
 ]
 
 { #category : #accessing }

--- a/src/Moose-Core/Object.extension.st
+++ b/src/Moose-Core/Object.extension.st
@@ -115,6 +115,11 @@ Object >> mooseMenuMorph [
 	^ menu
 ]
 
+{ #category : #'*Moose-Core' }
+Object >> mooseModel [
+	^ nil
+]
+
 { #category : #'*moose-core' }
 Object >> mooseName [
 	^ self printString


### PR DESCRIPTION
We can inspect a group of element

I propose to introduce a NullPatern (that should be improve latter probably, but it fixes this very important problem)
So we can inspect from Moose collection of elements that are not part of the Models

fixes #1603 