### PR TITLE
1613-annotationInstanceAttribute-in-Java-miss-TEntityMetaLevelDependency

### DIFF
--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -142,6 +142,7 @@ FamixJavaGenerator >> defineHierarchy [
 	annotationInstanceAttribute --|> sourcedEntity.
 	annotationInstanceAttribute --|> #TAnnotationInstanceAttribute.
 	annotationInstanceAttribute --|> #TTypedAnnotationInstanceAttribute.
+	annotationInstanceAttribute --|> #TEntityMetaLevelDependency.
 	annotationInstanceAttribute --|> #TDependencyQueries.
 
 	annotationType --|> type.


### PR DESCRIPTION
annotationInstanceAttribute should use TEntityMetaLevelDependency.

Fixes #1613