### PR TITLE
1616-Introduce-isMetamodelEntity-and-metamodelDefinitions

### DIFF
--- a/src/Fame-Rules/FameNameConventionBetweenFM3AndSmalltalkRule.class.st
+++ b/src/Fame-Rules/FameNameConventionBetweenFM3AndSmalltalkRule.class.st
@@ -67,7 +67,7 @@ FameNameConventionBetweenFM3AndSmalltalkRule >> checkClass: aContext [
 	| class pragmas pragma metaName |
 
 	class := aContext.
-	pragmas := Pragma allNamed: #MSEClass:super: in: class.
+	pragmas := class metamodelDefinitions.
 	pragmas ifEmpty: [ ^ self ].
 	pragmas size > 1 ifTrue: [ result addClass: class. ^ self ].
 	

--- a/src/Fame-Rules/FameNameConventionBetweenFM3AndSmalltalkRule.class.st
+++ b/src/Fame-Rules/FameNameConventionBetweenFM3AndSmalltalkRule.class.st
@@ -67,7 +67,7 @@ FameNameConventionBetweenFM3AndSmalltalkRule >> checkClass: aContext [
 	| class pragmas pragma metaName |
 
 	class := aContext.
-	pragmas := class metamodelDefinitions.
+	pragmas := class metamodelDefinitionPragmas.
 	pragmas ifEmpty: [ ^ self ].
 	pragmas size > 1 ifTrue: [ result addClass: class. ^ self ].
 	

--- a/src/Fame-Rules/FameSuperclassMetaDescribedExistRule.class.st
+++ b/src/Fame-Rules/FameSuperclassMetaDescribedExistRule.class.st
@@ -14,7 +14,7 @@ FameSuperclassMetaDescribedExistRule >> checkClass: aContext [
 | class pragmas pragma substrings metaSuperclassName |
 
 	class := aContext.
-	pragmas := class metamodelDefinitions.
+	pragmas := class metamodelDefinitionPragmas.
 	pragmas ifEmpty: [ ^ self ].
 	pragmas size > 1 ifTrue: [ result addClass: class. ^ self ].
 	

--- a/src/Fame-Rules/FameSuperclassMetaDescribedExistRule.class.st
+++ b/src/Fame-Rules/FameSuperclassMetaDescribedExistRule.class.st
@@ -14,7 +14,7 @@ FameSuperclassMetaDescribedExistRule >> checkClass: aContext [
 | class pragmas pragma substrings metaSuperclassName |
 
 	class := aContext.
-	pragmas := Pragma allNamed: #MSEClass:super: in: class.
+	pragmas := class metamodelDefinitions.
 	pragmas ifEmpty: [ ^ self ].
 	pragmas size > 1 ifTrue: [ result addClass: class. ^ self ].
 	

--- a/src/Fame-SmalltalkBinding/FMIncrementalMMBuilder.class.st
+++ b/src/Fame-SmalltalkBinding/FMIncrementalMMBuilder.class.st
@@ -285,12 +285,7 @@ FMIncrementalMMBuilder >> resolveSmalltalkBindingsIn: aFMMetaRepository [
 
 { #category : #'private-pragmas' }
 FMIncrementalMMBuilder >> retrieveClassPragma: aClass [
-	| pragma |
-	pragma := Pragma allNamed: #MSEClass:super: in: aClass class.
-	pragma isEmpty
-		ifTrue: [ self error: 'No Fame pragma ' , aClass name ].
-	pragma := pragma first.
-	^ pragma
+	^ aClass metamodelDefinitions ifEmpty: [ self error: 'No Fame pragma ' , aClass name ] ifNotEmpty: #first
 ]
 
 { #category : #'private-pragmas' }

--- a/src/Fame-SmalltalkBinding/FMIncrementalMMBuilder.class.st
+++ b/src/Fame-SmalltalkBinding/FMIncrementalMMBuilder.class.st
@@ -285,7 +285,7 @@ FMIncrementalMMBuilder >> resolveSmalltalkBindingsIn: aFMMetaRepository [
 
 { #category : #'private-pragmas' }
 FMIncrementalMMBuilder >> retrieveClassPragma: aClass [
-	^ aClass metamodelDefinitions ifEmpty: [ self error: 'No Fame pragma ' , aClass name ] ifNotEmpty: #first
+	^ aClass metamodelDefinitionPragmas ifEmpty: [ self error: 'No Fame pragma ' , aClass name ] ifNotEmpty: #first
 ]
 
 { #category : #'private-pragmas' }

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -191,7 +191,7 @@ FMPragmaProcessor >> processClass: aClass [
 { #category : #private }
 FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 	| pragma meta className superclassName |
-	pragma := aClass metamodelDefinitions.
+	pragma := aClass metamodelDefinitionPragmas.
 	pragma ifEmpty: anErrorBlock.
 	pragma
 		ifEmpty: [ className := aClass name.

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -191,7 +191,7 @@ FMPragmaProcessor >> processClass: aClass [
 { #category : #private }
 FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 	| pragma meta className superclassName |
-	pragma := Pragma allNamed: #MSEClass:super: in: aClass class.
+	pragma := aClass metamodelDefinitions.
 	pragma ifEmpty: anErrorBlock.
 	pragma
 		ifEmpty: [ className := aClass name.

--- a/src/Fame-SmalltalkBinding/Metaclass.extension.st
+++ b/src/Fame-SmalltalkBinding/Metaclass.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Metaclass }
+
+{ #category : #'*Fame-SmalltalkBinding' }
+Metaclass >> isMetamodelEntity [
+	^ self metamodelDefinitions isNotEmpty
+]
+
+{ #category : #'*Fame-SmalltalkBinding' }
+Metaclass >> metamodelDefinitions [
+	^ Pragma allNamed: #MSEClass:super: in: self
+]

--- a/src/Fame-SmalltalkBinding/Metaclass.extension.st
+++ b/src/Fame-SmalltalkBinding/Metaclass.extension.st
@@ -2,10 +2,10 @@ Extension { #name : #Metaclass }
 
 { #category : #'*Fame-SmalltalkBinding' }
 Metaclass >> isMetamodelEntity [
-	^ self metamodelDefinitions isNotEmpty
+	^ self metamodelDefinitionPragmas isNotEmpty
 ]
 
 { #category : #'*Fame-SmalltalkBinding' }
-Metaclass >> metamodelDefinitions [
+Metaclass >> metamodelDefinitionPragmas [
 	^ Pragma allNamed: #MSEClass:super: in: self
 ]

--- a/src/Fame-SmalltalkBinding/Object.extension.st
+++ b/src/Fame-SmalltalkBinding/Object.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Object }
+
+{ #category : #'*Fame-SmalltalkBinding' }
+Object >> isMetamodelEntity [
+	^ self class isMetamodelEntity
+]
+
+{ #category : #'*Fame-SmalltalkBinding' }
+Object >> metamodelDefinitions [
+	^ self class metamodelDefinitions
+]

--- a/src/Fame-SmalltalkBinding/Object.extension.st
+++ b/src/Fame-SmalltalkBinding/Object.extension.st
@@ -6,6 +6,6 @@ Object >> isMetamodelEntity [
 ]
 
 { #category : #'*Fame-SmalltalkBinding' }
-Object >> metamodelDefinitions [
-	^ self class metamodelDefinitions
+Object >> metamodelDefinitionPragmas [
+	^ self class metamodelDefinitionPragmas
 ]

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -129,7 +129,7 @@ FamixMetamodelGenerator class >> resetMetamodel [
 
 	classes := self packageName asPackage definedClasses select: [ :each | each inheritsFrom: MooseEntity ].
 	classes
-		addAll: (self packageName asPackage definedClasses select: [ :class | class isTrait and: [ "check that the trait is part of the metamodel" (Pragma allNamed: #MSEClass:super: in: class class) isNotEmpty ] ]).
+		addAll: (self packageName asPackage definedClasses select: [ :class | class isTrait and: [ class isMetamodelEntity ] ]).
 
 	classes addAll: self basicMetamodelClasses.
 

--- a/src/Moose-Core/FAMIXMetaModelClassesNotDeclaredInFameRule.class.st
+++ b/src/Moose-Core/FAMIXMetaModelClassesNotDeclaredInFameRule.class.st
@@ -19,7 +19,7 @@ FAMIXMetaModelClassesNotDeclaredInFameRule >> checkClass: aContext [
 
 	(self metaModelClasses includes: class instanceSide)
 		ifTrue: [
-			pragmas := Pragma allNamed: #MSEClass:super: in: class.
+			pragmas := class metamodelDefinitions.
 			pragmas ifEmpty: [
 				class isMeta ifTrue: [ result addClass: class ].
 			^ self ].

--- a/src/Moose-Core/FAMIXMetaModelClassesNotDeclaredInFameRule.class.st
+++ b/src/Moose-Core/FAMIXMetaModelClassesNotDeclaredInFameRule.class.st
@@ -19,7 +19,7 @@ FAMIXMetaModelClassesNotDeclaredInFameRule >> checkClass: aContext [
 
 	(self metaModelClasses includes: class instanceSide)
 		ifTrue: [
-			pragmas := class metamodelDefinitions.
+			pragmas := class metamodelDefinitionPragmas.
 			pragmas ifEmpty: [
 				class isMeta ifTrue: [ result addClass: class ].
 			^ self ].


### PR DESCRIPTION
Factorize some code by introducing #isMetamodelEntity and #metamodelDefinitions

This will be useful for futur features.

Fixes #1616