### PR TITLE
1615-Remove-necessity-of-generating-generatedTraitNames

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
@@ -22,12 +22,6 @@ FAMIXAbstractFile class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAbstractFile class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileSystemEntity)
-]
-
 { #category : #meta }
 FAMIXAbstractFile class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFileAnchor.class.st
@@ -22,12 +22,6 @@ FAMIXAbstractFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAbstractFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileAnchor)
-]
-
 { #category : #meta }
 FAMIXAbstractFileAnchor class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -27,12 +27,6 @@ FAMIXAccess class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAccess class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAccess)
-]
-
 { #category : #meta }
 FAMIXAccess class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
@@ -22,12 +22,6 @@ FAMIXAnnotationInstance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAnnotationInstance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationInstance FamixTTypedAnnotationInstance FamixTWithAnnotationInstanceAttributes TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FAMIXAnnotationInstance class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
@@ -22,12 +22,6 @@ FAMIXAnnotationInstanceAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAnnotationInstanceAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationInstanceAttribute FamixTTypedAnnotationInstanceAttribute TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FAMIXAnnotationInstanceAttribute class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
@@ -22,12 +22,6 @@ FAMIXAnnotationType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAnnotationType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationType)
-]
-
 { #category : #meta }
 FAMIXAnnotationType class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationTypeAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationTypeAttribute.class.st
@@ -22,12 +22,6 @@ FAMIXAnnotationTypeAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAnnotationTypeAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationTypeAttribute FamixTTypedAnnotationInstanceAttribute)
-]
-
 { #category : #meta }
 FAMIXAnnotationTypeAttribute class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
@@ -22,12 +22,6 @@ FAMIXAssociation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAssociation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FAMIXAssociation class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -25,12 +25,6 @@ FAMIXAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAttribute FamixTWithClassScope)
-]
-
 { #category : #meta }
 FAMIXAttribute class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -22,12 +22,6 @@ FAMIXBehaviouralEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXBehaviouralEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocable FamixTTypedStructure FamixTWithAccesses FamixTWithDereferencedInvocations FamixTWithImplicitVariables FamixTWithInvocations FamixTWithLocalVariables FamixTWithParameters FamixTWithReferences FamixTWithSignature FamixTWithStatements)
-]
-
 { #category : #meta }
 FAMIXBehaviouralEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCFile.class.st
@@ -22,12 +22,6 @@ FAMIXCFile class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXCFile class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithFileInclude)
-]
-
 { #category : #meta }
 FAMIXCFile class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCSourceLanguage.class.st
@@ -20,12 +20,6 @@ FAMIXCSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXCSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXCSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCaughtException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCaughtException.class.st
@@ -22,12 +22,6 @@ FAMIXCaughtException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXCaughtException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTCaughtException)
-]
-
 { #category : #meta }
 FAMIXCaughtException class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXClass.class.st
@@ -25,12 +25,6 @@ FAMIXClass class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXClass class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTLCOMMetrics FamixTWithExceptions)
-]
-
 { #category : #meta }
 FAMIXClass class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXComment.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXComment.class.st
@@ -22,12 +22,6 @@ FAMIXComment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXComment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FAMIXComment class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCompilationUnit.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCompilationUnit.class.st
@@ -22,12 +22,6 @@ FAMIXCompilationUnit class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXCompilationUnit class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTCompilationUnit FamixTDefinedInModule)
-]
-
 { #category : #meta }
 FAMIXCompilationUnit class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
@@ -22,12 +22,6 @@ FAMIXContainerEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXContainerEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTContainingWithInvocationsGlue FamixTContainingWithStatementsGlue FamixTWithAnnotationTypes FamixTWithClasses FamixTWithFunctions FamixTWithTypes TOODependencyQueries)
-]
-
 { #category : #meta }
 FAMIXContainerEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCppSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCppSourceLanguage.class.st
@@ -20,12 +20,6 @@ FAMIXCppSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXCppSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXCppSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCustomSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCustomSourceLanguage.class.st
@@ -22,12 +22,6 @@ FAMIXCustomSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXCustomSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamed)
-]
-
 { #category : #meta }
 FAMIXCustomSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXDeclaredException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXDeclaredException.class.st
@@ -22,12 +22,6 @@ FAMIXDeclaredException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXDeclaredException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTDeclaredException)
-]
-
 { #category : #meta }
 FAMIXDeclaredException class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXDereferencedInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXDereferencedInvocation.class.st
@@ -22,12 +22,6 @@ FAMIXDereferencedInvocation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXDereferencedInvocation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTDereferencedInvocation)
-]
-
 { #category : #meta }
 FAMIXDereferencedInvocation class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -20,12 +20,6 @@ FAMIXEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXEntity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXEntity class >> metamodel [
 

--- a/src/Famix-Compatibility-Entities/FAMIXEnum.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnum.class.st
@@ -22,12 +22,6 @@ FAMIXEnum class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXEnum class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithEnumValues)
-]
-
 { #category : #meta }
 FAMIXEnum class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
@@ -22,12 +22,6 @@ FAMIXEnumValue class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXEnumValue class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTEnumValue)
-]
-
 { #category : #meta }
 FAMIXEnumValue class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXException.class.st
@@ -22,12 +22,6 @@ FAMIXException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTException)
-]
-
 { #category : #meta }
 FAMIXException class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFile.class.st
@@ -22,12 +22,6 @@ FAMIXFile class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXFile class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFile)
-]
-
 { #category : #meta }
 FAMIXFile class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFileAnchor.class.st
@@ -22,12 +22,6 @@ FAMIXFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileNavigation)
-]
-
 { #category : #meta }
 FAMIXFileAnchor class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXFolder.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFolder.class.st
@@ -22,12 +22,6 @@ FAMIXFolder class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXFolder class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFolder)
-]
-
 { #category : #meta }
 FAMIXFolder class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
@@ -22,12 +22,6 @@ FAMIXFunction class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXFunction class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTDefinedInModule FamixTFunction)
-]
-
 { #category : #meta }
 FAMIXFunction class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
@@ -22,12 +22,6 @@ FAMIXGlobalVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXGlobalVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTDefinedInModule FamixTGlobalVariable)
-]
-
 { #category : #meta }
 FAMIXGlobalVariable class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXHeader.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXHeader.class.st
@@ -22,12 +22,6 @@ FAMIXHeader class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXHeader class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTHeader)
-]
-
 { #category : #meta }
 FAMIXHeader class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
@@ -22,12 +22,6 @@ FAMIXImplicitVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXImplicitVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTImplicitVariable)
-]
-
 { #category : #meta }
 FAMIXImplicitVariable class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
@@ -22,12 +22,6 @@ FAMIXInclude class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXInclude class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileInclude)
-]
-
 { #category : #meta }
 FAMIXInclude class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXIndexedFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXIndexedFileAnchor.class.st
@@ -22,12 +22,6 @@ FAMIXIndexedFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXIndexedFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTIndexedFileNavigation)
-]
-
 { #category : #meta }
 FAMIXIndexedFileAnchor class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
@@ -22,12 +22,6 @@ FAMIXInheritance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXInheritance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInheritanceGlue FamixTSubInheritance FamixTSuperInheritance)
-]
-
 { #category : #meta }
 FAMIXInheritance class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -22,12 +22,6 @@ FAMIXInvocation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXInvocation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocation FamixTWithSignature)
-]
-
 { #category : #meta }
 FAMIXInvocation class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXJavaSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXJavaSourceLanguage.class.st
@@ -20,12 +20,6 @@ FAMIXJavaSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXJavaSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXJavaSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
@@ -20,12 +20,6 @@ FAMIXLeafEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXLeafEntity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXLeafEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
@@ -22,12 +22,6 @@ FAMIXLocalVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXLocalVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTLocalVariable)
-]
-
 { #category : #meta }
 FAMIXLocalVariable class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -25,12 +25,6 @@ FAMIXMethod class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXMethod class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMethod FamixTWithCaughtExceptions FamixTWithClassScope FamixTWithDeclaredExceptions FamixTWithThrownExceptions)
-]
-
 { #category : #meta }
 FAMIXMethod class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXModule.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXModule.class.st
@@ -22,12 +22,6 @@ FAMIXModule class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXModule class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTModule FamixTWithCompilationUnit FamixTWithHeader)
-]
-
 { #category : #meta }
 FAMIXModule class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXMultipleFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMultipleFileAnchor.class.st
@@ -22,12 +22,6 @@ FAMIXMultipleFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXMultipleFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMultipleFileAnchor)
-]
-
 { #category : #meta }
 FAMIXMultipleFileAnchor class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -27,12 +27,6 @@ FAMIXNamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXNamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocationsReceiver FamixTNamed FamixTPackageable FamixTPossibleStub FamixTWithAnnotationInstances FamixTWithModifiers TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FAMIXNamedEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
@@ -22,12 +22,6 @@ FAMIXNamespace class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXNamespace class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamespace)
-]
-
 { #category : #meta }
 FAMIXNamespace class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
@@ -22,12 +22,6 @@ FAMIXPackage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #'as yet unclassified' }
-FAMIXPackage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTCohesionCouplingMetrics FamixTPackage FamixTPackageWithClassesGlue)
-]
-
 { #category : #meta }
 FAMIXPackage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
@@ -22,12 +22,6 @@ FAMIXParameter class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXParameter class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTParameter)
-]
-
 { #category : #meta }
 FAMIXParameter class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXParameterType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterType.class.st
@@ -20,12 +20,6 @@ FAMIXParameterType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXParameterType class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXParameterType class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizableClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizableClass.class.st
@@ -22,12 +22,6 @@ FAMIXParameterizableClass class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXParameterizableClass class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithParameterizedTypes)
-]
-
 { #category : #meta }
 FAMIXParameterizableClass class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
@@ -22,12 +22,6 @@ FAMIXParameterizedType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXParameterizedType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTParameterizedType FamixTWithParameterizedTypeUsers)
-]
-
 { #category : #meta }
 FAMIXParameterizedType class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPharoAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPharoAnchor.class.st
@@ -23,12 +23,6 @@ FAMIXPharoAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXPharoAnchor class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXPharoAnchor class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorDefine.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorDefine.class.st
@@ -25,12 +25,6 @@ FAMIXPreprocessorDefine class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXPreprocessorDefine class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTPreprocessorIfdef)
-]
-
 { #category : #meta }
 FAMIXPreprocessorDefine class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorIfdef.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorIfdef.class.st
@@ -24,12 +24,6 @@ FAMIXPreprocessorIfdef class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXPreprocessorIfdef class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXPreprocessorIfdef class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorStatement.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorStatement.class.st
@@ -20,12 +20,6 @@ FAMIXPreprocessorStatement class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXPreprocessorStatement class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXPreprocessorStatement class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPrimitiveType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPrimitiveType.class.st
@@ -20,12 +20,6 @@ FAMIXPrimitiveType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXPrimitiveType class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXPrimitiveType class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -22,12 +22,6 @@ FAMIXReference class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXReference class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTReference)
-]
-
 { #category : #meta }
 FAMIXReference class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -22,12 +22,6 @@ FAMIXScopingEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXScopingEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTGlobalVariableScope FamixTScopingEntity)
-]
-
 { #category : #meta }
 FAMIXScopingEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXSmalltalkSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSmalltalkSourceLanguage.class.st
@@ -20,12 +20,6 @@ FAMIXSmalltalkSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXSmalltalkSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXSmalltalkSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -28,12 +28,6 @@ FAMIXSourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXSourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #'Moose-Query-Extensions' }
 FAMIXSourceAnchor class >> parentTypes [
 	self flag: #todo. "Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."

--- a/src/Famix-Compatibility-Entities/FAMIXSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceLanguage.class.st
@@ -22,12 +22,6 @@ FAMIXSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FAMIXSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXSourceTextAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FAMIXSourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXSourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FAMIXSourceTextAnchor class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
@@ -22,12 +22,6 @@ FAMIXSourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXSourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithFiles FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FAMIXSourcedEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
@@ -22,12 +22,6 @@ FAMIXStructuralEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXStructuralEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAccessible FamixTTypedStructure FamixTWithDereferencedInvocations)
-]
-
 { #category : #meta }
 FAMIXStructuralEntity class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXThrownException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXThrownException.class.st
@@ -22,12 +22,6 @@ FAMIXThrownException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXThrownException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTThrownException)
-]
-
 { #category : #meta }
 FAMIXThrownException class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXTrait.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTrait.class.st
@@ -22,12 +22,6 @@ FAMIXTrait class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXTrait class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTTrait)
-]
-
 { #category : #meta }
 FAMIXTrait class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
@@ -22,12 +22,6 @@ FAMIXTraitUsage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXTraitUsage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTTraitUsage)
-]
-
 { #category : #meta }
 FAMIXTraitUsage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -22,12 +22,6 @@ FAMIXType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClassHierarchyNavigation FamixTContainingWithInvocationsGlue FamixTContainingWithStatementsGlue FamixTParameterizedTypeUser FamixTReferenceable FamixTTraitUser FamixTType FamixTWithAttributes FamixTWithMethods FamixTWithMethodsWithAccessesGlue FamixTWithMethodsWithModifiersGlue FamixTWithSubInheritances FamixTWithSuperInheritances FamixTWithTypeAliases FamixTWithTypedStructures)
-]
-
 { #category : #meta }
 FAMIXType class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXTypeAlias.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTypeAlias.class.st
@@ -22,12 +22,6 @@ FAMIXTypeAlias class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXTypeAlias class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTTypeAlias)
-]
-
 { #category : #meta }
 FAMIXTypeAlias class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownSourceLanguage.class.st
@@ -20,12 +20,6 @@ FAMIXUnknownSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXUnknownSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXUnknownSourceLanguage class >> requirements [
 

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
@@ -20,12 +20,6 @@ FAMIXUnknownVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FAMIXUnknownVariable class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FAMIXUnknownVariable class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
@@ -22,12 +22,6 @@ FamixJavaAbstractFile class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAbstractFile class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileSystemEntity)
-]
-
 { #category : #meta }
 FamixJavaAbstractFile class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAbstractFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixJavaAbstractFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAbstractFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileAnchor)
-]
-
 { #category : #meta }
 FamixJavaAbstractFileAnchor class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -22,12 +22,6 @@ FamixJavaAccess class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAccess class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAccess)
-]
-
 { #category : #meta }
 FamixJavaAccess class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -22,12 +22,6 @@ FamixJavaAnnotationInstance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAnnotationInstance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationInstance FamixTTypedAnnotationInstance FamixTWithAnnotationInstanceAttributes TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixJavaAnnotationInstance class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaAnnotationInstanceAttribute,
 	#superclass : #FamixJavaSourcedEntity,
-	#traits : 'FamixTAnnotationInstanceAttribute + FamixTTypedAnnotationInstanceAttribute + TDependencyQueries',
-	#classTraits : 'FamixTAnnotationInstanceAttribute classTrait + FamixTTypedAnnotationInstanceAttribute classTrait + TDependencyQueries classTrait',
+	#traits : 'FamixTAnnotationInstanceAttribute + FamixTTypedAnnotationInstanceAttribute + TDependencyQueries + TEntityMetaLevelDependency',
+	#classTraits : 'FamixTAnnotationInstanceAttribute classTrait + FamixTTypedAnnotationInstanceAttribute classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaAnnotationInstanceAttribute,
 	#superclass : #FamixJavaSourcedEntity,
-	#traits : 'FamixTAnnotationInstanceAttribute + FamixTTypedAnnotationInstanceAttribute + TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'FamixTAnnotationInstanceAttribute classTrait + FamixTTypedAnnotationInstanceAttribute classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
+	#traits : 'FamixTAnnotationInstanceAttribute + FamixTTypedAnnotationInstanceAttribute + TDependencyQueries',
+	#classTraits : 'FamixTAnnotationInstanceAttribute classTrait + FamixTTypedAnnotationInstanceAttribute classTrait + TDependencyQueries classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 
@@ -20,12 +20,6 @@ FamixJavaAnnotationInstanceAttribute class >> generatedSlotNames [
 	<generated>
 	'FamixJavaAnnotationInstanceAttribute class>>#generatedSlotNames'.
 	^ #()
-]
-
-{ #category : #generator }
-FamixJavaAnnotationInstanceAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationInstanceAttribute FamixTTypedAnnotationInstanceAttribute TDependencyQueries)
 ]
 
 { #category : #meta }

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaAnnotationType,
 	#superclass : #FamixJavaType,
-	#traits : 'FamixTAnnotationType + FamixTWithAttributes',
-	#classTraits : 'FamixTAnnotationType classTrait + FamixTWithAttributes classTrait',
+	#traits : 'FamixTAnnotationType',
+	#classTraits : 'FamixTAnnotationType classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 
@@ -20,12 +20,6 @@ FamixJavaAnnotationType class >> generatedSlotNames [
 	<generated>
 	'FamixJavaAnnotationType class>>#generatedSlotNames'.
 	^ #()
-]
-
-{ #category : #generator }
-FamixJavaAnnotationType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationType)
 ]
 
 { #category : #meta }

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -22,12 +22,6 @@ FamixJavaAnnotationTypeAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAnnotationTypeAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationTypeAttribute FamixTTypedAnnotationInstanceAttribute)
-]
-
 { #category : #meta }
 FamixJavaAnnotationTypeAttribute class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAssociation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAssociation.class.st
@@ -22,12 +22,6 @@ FamixJavaAssociation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAssociation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixJavaAssociation class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -25,12 +25,6 @@ FamixJavaAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAttribute FamixTWithClassScope)
-]
-
 { #category : #meta }
 FamixJavaAttribute class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaCaughtException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaCaughtException.class.st
@@ -22,12 +22,6 @@ FamixJavaCaughtException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaCaughtException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTCaughtException)
-]
-
 { #category : #meta }
 FamixJavaCaughtException class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -22,12 +22,6 @@ FamixJavaClass class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaClass class >> generatedTraitNames [
-	<generated>
-	^ #(FamixJavaTLCOMMetrics FamixTClass FamixTWithExceptions)
-]
-
 { #category : #meta }
 FamixJavaClass class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -22,12 +22,6 @@ FamixJavaComment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaComment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixJavaComment class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -22,12 +22,6 @@ FamixJavaContainerEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaContainerEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithAnnotationTypes FamixTWithClasses FamixTWithTypes TOODependencyQueries)
-]
-
 { #category : #meta }
 FamixJavaContainerEntity class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaDeclaredException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaDeclaredException.class.st
@@ -22,12 +22,6 @@ FamixJavaDeclaredException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaDeclaredException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTDeclaredException)
-]
-
 { #category : #meta }
 FamixJavaDeclaredException class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -37,12 +37,6 @@ FamixJavaEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaEntity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixJavaEntity class >> metamodel [
 

--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -22,12 +22,6 @@ FamixJavaEnum class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaEnum class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithEnumValues)
-]
-
 { #category : #meta }
 FamixJavaEnum class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -22,12 +22,6 @@ FamixJavaEnumValue class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaEnumValue class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTEnumValue)
-]
-
 { #category : #meta }
 FamixJavaEnumValue class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -22,12 +22,6 @@ FamixJavaException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTException)
-]
-
 { #category : #meta }
 FamixJavaException class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFile.class.st
@@ -22,12 +22,6 @@ FamixJavaFile class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaFile class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFile)
-]
-
 { #category : #meta }
 FamixJavaFile class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixJavaFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileNavigation)
-]
-
 { #category : #meta }
 FamixJavaFileAnchor class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaFolder.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFolder.class.st
@@ -22,12 +22,6 @@ FamixJavaFolder class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaFolder class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFolder)
-]
-
 { #category : #meta }
 FamixJavaFolder class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
@@ -22,12 +22,6 @@ FamixJavaGlobalVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaGlobalVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTGlobalVariable)
-]
-
 { #category : #meta }
 FamixJavaGlobalVariable class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -22,12 +22,6 @@ FamixJavaImplicitVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaImplicitVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTImplicitVariable)
-]
-
 { #category : #meta }
 FamixJavaImplicitVariable class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaImportingContext.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImportingContext.class.st
@@ -11,12 +11,6 @@ FamixJavaImportingContext class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaImportingContext class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixJavaImportingContext >> importAbstractFile [
 

--- a/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixJavaIndexedFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaIndexedFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTIndexedFileNavigation)
-]
-
 { #category : #meta }
 FamixJavaIndexedFileAnchor class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -22,12 +22,6 @@ FamixJavaInheritance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaInheritance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInheritanceGlue FamixTSubInheritance FamixTSuperInheritance)
-]
-
 { #category : #meta }
 FamixJavaInheritance class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -22,12 +22,6 @@ FamixJavaInvocation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaInvocation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocation FamixTWithSignature)
-]
-
 { #category : #meta }
 FamixJavaInvocation class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -22,12 +22,6 @@ FamixJavaLocalVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaLocalVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTLocalVariable)
-]
-
 { #category : #meta }
 FamixJavaLocalVariable class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -22,12 +22,6 @@ FamixJavaMethod class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaMethod class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocable FamixTMethod FamixTTypedStructure FamixTWithAccesses FamixTWithCaughtExceptions FamixTWithClassScope FamixTWithDeclaredExceptions FamixTWithImplicitVariables FamixTWithInvocations FamixTWithLocalVariables FamixTWithParameters FamixTWithReferences FamixTWithSignature FamixTWithStatements FamixTWithThrownExceptions)
-]
-
 { #category : #meta }
 FamixJavaMethod class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaMultipleFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMultipleFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixJavaMultipleFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaMultipleFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMultipleFileAnchor)
-]
-
 { #category : #meta }
 FamixJavaMultipleFileAnchor class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -22,12 +22,6 @@ FamixJavaNamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaNamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocationsReceiver FamixTNamed FamixTPackageable FamixTPossibleStub FamixTWithAnnotationInstances FamixTWithModifiers TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixJavaNamedEntity class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -22,12 +22,6 @@ FamixJavaNamespace class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaNamespace class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamespace)
-]
-
 { #category : #meta }
 FamixJavaNamespace class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -22,12 +22,6 @@ FamixJavaPackage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaPackage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTPackage FamixTPackageWithClassesGlue)
-]
-
 { #category : #meta }
 FamixJavaPackage class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -22,12 +22,6 @@ FamixJavaParameter class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaParameter class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTParameter)
-]
-
 { #category : #meta }
 FamixJavaParameter class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaParameterType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterType.class.st
@@ -20,12 +20,6 @@ FamixJavaParameterType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaParameterType class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixJavaParameterType class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
@@ -22,12 +22,6 @@ FamixJavaParameterizableClass class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaParameterizableClass class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithParameterizedTypes)
-]
-
 { #category : #meta }
 FamixJavaParameterizableClass class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
@@ -22,12 +22,6 @@ FamixJavaParameterizedType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaParameterizedType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTParameterizedType FamixTWithParameterizedTypeUsers)
-]
-
 { #category : #meta }
 FamixJavaParameterizedType class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
@@ -20,12 +20,6 @@ FamixJavaPrimitiveType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaPrimitiveType class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixJavaPrimitiveType class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -22,12 +22,6 @@ FamixJavaReference class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaReference class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTReference)
-]
-
 { #category : #meta }
 FamixJavaReference class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
@@ -22,12 +22,6 @@ FamixJavaScopingEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaScopingEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTGlobalVariableScope FamixTScopingEntity)
-]
-
 { #category : #meta }
 FamixJavaScopingEntity class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -28,12 +28,6 @@ FamixJavaSourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaSourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #accessing }
 FamixJavaSourceAnchor class >> parentTypes [
 	self flag: #todo. "Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."

--- a/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixJavaSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixJavaSourceLanguage class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixJavaSourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaSourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixJavaSourceTextAnchor class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixJavaSourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaSourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithFiles FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixJavaSourcedEntity class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaStructuralEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaStructuralEntity.class.st
@@ -22,12 +22,6 @@ FamixJavaStructuralEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaStructuralEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAccessible FamixTTypedStructure FamixTWithDereferencedInvocations)
-]
-
 { #category : #meta }
 FamixJavaStructuralEntity class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaTLCOMMetrics.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTLCOMMetrics.trait.st
@@ -18,9 +18,3 @@ FamixJavaTLCOMMetrics classSide >> generatedSlotNames [
 	'FamixJavaTLCOMMetrics class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixJavaTLCOMMetrics classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Java-Entities/FamixJavaThrownException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaThrownException.class.st
@@ -22,12 +22,6 @@ FamixJavaThrownException class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaThrownException class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTThrownException)
-]
-
 { #category : #meta }
 FamixJavaThrownException class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -22,12 +22,6 @@ FamixJavaType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClassHierarchyNavigation FamixTParameterizedTypeUser FamixTReferenceable FamixTType FamixTWithTypeAliases FamixTWithTypedStructures)
-]
-
 { #category : #meta }
 FamixJavaType class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixJavaUnknownSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaUnknownSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixJavaUnknownSourceLanguage class >> requirements [
 

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -20,12 +20,6 @@ FamixJavaUnknownVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixJavaUnknownVariable class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixJavaUnknownVariable class >> requirements [
 

--- a/src/Famix-MetamodelBuilder-Core/Class.extension.st
+++ b/src/Famix-MetamodelBuilder-Core/Class.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Class }
+
+{ #category : #'*Famix-MetamodelBuilder-Core' }
+Class >> generatedTraitNames [
+	^ self traits select: #isMetamodelEntity thenCollect: #name
+]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -17,7 +17,7 @@ FmxMBRealRingEnvironment >> adoptClassDefinitionOf: realClass to: anRGClass [
 
 
 	generatedOldSlots := self generatedSlotsOf: realClass.
-	generatedOldTraits := self generatedTraitNamessOf: realClass.
+	generatedOldTraits := realClass generatedTraitNames.
 	customSlots := realClass localSlots copyWithoutAll: generatedOldSlots.
 	customTraits := realClass traitComposition members reject: [ :e | generatedOldTraits includes: e name].
 	customSlotNames := customSlots collect: #name.
@@ -155,20 +155,6 @@ FmxMBRealRingEnvironment >> ensurePackagesFrom: anRGEnvironment [
 ]
 
 { #category : #installing }
-FmxMBRealRingEnvironment >> generateTraitsDescriptionFrom: anRGClass [
-
-	| generatedTraits |
-	
-	generatedTraits := anRGClass traitComposition transformations.
-	
-	anRGClass classSide compile: ('generatedTraitNames
-	<generated>
-	^ {1}' format: { '#(', ((generatedTraits collect: #name) joinUsing: ' '), ')' }) classified: 'generator'
-		
-
-]
-
-{ #category : #installing }
 FmxMBRealRingEnvironment >> generatedSlotsOf: aRealClass [
 
 	| slotNames |
@@ -183,31 +169,10 @@ FmxMBRealRingEnvironment >> generatedSlotsOf: aRealClass [
 ]
 
 { #category : #installing }
-FmxMBRealRingEnvironment >> generatedTraitNamessOf: aRealClass [
-
-	| traitNames |
-	
-	^ traitNames := (aRealClass classSide canUnderstand: #generatedTraitNames)
-		ifTrue: [ aRealClass generatedTraitNames ]
-		ifFalse: [ Array new ].
-		
-
-	
-	
-]
-
-{ #category : #installing }
 FmxMBRealRingEnvironment >> generatedTraitsOf: aRealClass [
-
-	| traitNames |
-	
-	traitNames := (aRealClass classSide canUnderstand: #generatedTraitNames)
-		ifTrue: [ aRealClass generatedTraitNames ]
-		ifFalse: [ Array new ].
-		
-	^ (traitNames collect: [ :traitName | aRealClass traitComposition transformations detect: [ :each | each name = traitName ] ifNone: [nil] ]) select: #notNil.
-	
-	
+	^ aRealClass generatedTraitNames
+		collect: [ :traitName | aRealClass traitComposition transformations detect: [ :each | each name = traitName ] ifNone: [ nil ] ]
+		thenSelect: #isNotNil
 ]
 
 { #category : #installing }
@@ -224,7 +189,6 @@ FmxMBRealRingEnvironment >> installClassChangesFor: anRGClass [
 	self adoptClassCommentOf: realClass to: anRGClass.
 	self cleanClass: realClass.
 	self generateSlotsDescriptionFrom: anRGClass.
-	self generateTraitsDescriptionFrom: anRGClass.
 	self adoptMethodsOf: realClass to: anRGClass
 		
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -22,12 +22,6 @@ FamixStAccess class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAccess class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAccess)
-]
-
 { #category : #meta }
 FamixStAccess class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -22,12 +22,6 @@ FamixStAnnotationInstance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAnnotationInstance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationInstance FamixTTypedAnnotationInstance FamixTWithAnnotationInstanceAttributes TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixStAnnotationInstance class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -22,12 +22,6 @@ FamixStAnnotationInstanceAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAnnotationInstanceAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationInstanceAttribute FamixTTypedAnnotationInstanceAttribute TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixStAnnotationInstanceAttribute class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -22,12 +22,6 @@ FamixStAnnotationType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAnnotationType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationType)
-]
-
 { #category : #meta }
 FamixStAnnotationType class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -22,12 +22,6 @@ FamixStAnnotationTypeAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAnnotationTypeAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAnnotationTypeAttribute FamixTTypedAnnotationInstanceAttribute)
-]
-
 { #category : #meta }
 FamixStAnnotationTypeAttribute class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAssociation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAssociation.class.st
@@ -26,12 +26,6 @@ FamixStAssociation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAssociation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixStAssociation class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -25,12 +25,6 @@ FamixStAttribute class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStAttribute class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAttribute FamixTWithClassScope)
-]
-
 { #category : #meta }
 FamixStAttribute class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -22,12 +22,6 @@ FamixStClass class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStClass class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTClassHierarchyNavigation FamixTWithExceptions)
-]
-
 { #category : #meta }
 FamixStClass class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -22,12 +22,6 @@ FamixStComment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStComment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixStComment class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
@@ -22,12 +22,6 @@ FamixStContainerEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStContainerEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithAnnotationTypes FamixTWithClasses FamixTWithTypes TOODependencyQueries)
-]
-
 { #category : #meta }
 FamixStContainerEntity class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -20,12 +20,6 @@ FamixStEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStEntity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixStEntity class >> metamodel [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -22,12 +22,6 @@ FamixStGlobalVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStGlobalVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTGlobalVariable)
-]
-
 { #category : #meta }
 FamixStGlobalVariable class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -22,12 +22,6 @@ FamixStImplicitVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStImplicitVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTImplicitVariable)
-]
-
 { #category : #meta }
 FamixStImplicitVariable class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImportingContext.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImportingContext.class.st
@@ -11,12 +11,6 @@ FamixStImportingContext class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStImportingContext class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixStImportingContext >> importAccess [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
@@ -22,12 +22,6 @@ FamixStInheritance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStInheritance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInheritanceGlue FamixTSubInheritance FamixTSuperInheritance)
-]
-
 { #category : #meta }
 FamixStInheritance class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -22,12 +22,6 @@ FamixStInvocation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStInvocation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocation FamixTWithSignature)
-]
-
 { #category : #meta }
 FamixStInvocation class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
@@ -22,12 +22,6 @@ FamixStLocalVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStLocalVariable class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTLocalVariable)
-]
-
 { #category : #meta }
 FamixStLocalVariable class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -25,12 +25,6 @@ FamixStMethod class >> generatedSlotNames [
 	^ #(protocol)
 ]
 
-{ #category : #generator }
-FamixStMethod class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocable FamixTMethod FamixTTypedStructure FamixTWithAccesses FamixTWithClassScope FamixTWithImplicitVariables FamixTWithInvocations FamixTWithLocalVariables FamixTWithParameters FamixTWithReferences FamixTWithSignature)
-]
-
 { #category : #meta }
 FamixStMethod class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -22,12 +22,6 @@ FamixStNamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStNamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocationsReceiver FamixTNamed FamixTPackageable FamixTPossibleStub FamixTWithAnnotationInstances FamixTWithModifiers TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixStNamedEntity class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -22,12 +22,6 @@ FamixStNamespace class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStNamespace class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamespace)
-]
-
 { #category : #meta }
 FamixStNamespace class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
@@ -22,12 +22,6 @@ FamixStPackage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStPackage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTCohesionCouplingMetrics FamixTPackage FamixTPackageWithClassesGlue)
-]
-
 { #category : #meta }
 FamixStPackage class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
@@ -22,12 +22,6 @@ FamixStParameter class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStParameter class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTParameter)
-]
-
 { #category : #meta }
 FamixStParameter class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
@@ -22,12 +22,6 @@ FamixStReference class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStReference class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTReference)
-]
-
 { #category : #meta }
 FamixStReference class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
@@ -22,12 +22,6 @@ FamixStScopingEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStScopingEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTGlobalVariableScope FamixTScopingEntity)
-]
-
 { #category : #meta }
 FamixStScopingEntity class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSmalltalkSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSmalltalkSourceLanguage.class.st
@@ -20,12 +20,6 @@ FamixStSmalltalkSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStSmalltalkSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixStSmalltalkSourceLanguage class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -25,12 +25,6 @@ FamixStSourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStSourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor FamixTWithImmediateSource TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #accessing }
 FamixStSourceAnchor class >> parentTypes [
 	"Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixStSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixStSourceLanguage class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixStSourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStSourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixStSourceTextAnchor class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixStSourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStSourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixStSourcedEntity class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStStructuralEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStStructuralEntity.class.st
@@ -22,12 +22,6 @@ FamixStStructuralEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStStructuralEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAccessible FamixTTypedStructure)
-]
-
 { #category : #meta }
 FamixStStructuralEntity class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStTLCOMMetrics.trait.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStTLCOMMetrics.trait.st
@@ -18,9 +18,3 @@ FamixStTLCOMMetrics classSide >> generatedSlotNames [
 	'FamixStTLCOMMetrics class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixStTLCOMMetrics classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStType.class.st
@@ -22,12 +22,6 @@ FamixStType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTReferenceable FamixTType FamixTWithTypedStructures)
-]
-
 { #category : #meta }
 FamixStType class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
@@ -20,12 +20,6 @@ FamixStUnknownSourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStUnknownSourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixStUnknownSourceLanguage class >> requirements [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
@@ -20,12 +20,6 @@ FamixStUnknownVariable class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixStUnknownVariable class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixStUnknownVariable class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
@@ -22,12 +22,6 @@ FamixTest1AbstractFile class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1AbstractFile class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileSystemEntity)
-]
-
 { #category : #meta }
 FamixTest1AbstractFile class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest1AbstractFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1AbstractFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileAnchor)
-]
-
 { #category : #meta }
 FamixTest1AbstractFileAnchor class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -22,12 +22,6 @@ FamixTest1Association class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1Association class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest1Association class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1Class.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Class.class.st
@@ -22,12 +22,6 @@ FamixTest1Class class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1Class class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTLCOMMetrics FamixTWithMethods)
-]
-
 { #category : #meta }
 FamixTest1Class class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1Comment.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Comment.class.st
@@ -22,12 +22,6 @@ FamixTest1Comment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1Comment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixTest1Comment class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -20,12 +20,6 @@ FamixTest1Entity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1Entity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest1Entity class >> metamodel [
 

--- a/src/Famix-Test1-Entities/FamixTest1File.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1File.class.st
@@ -22,12 +22,6 @@ FamixTest1File class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1File class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFile)
-]
-
 { #category : #meta }
 FamixTest1File class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest1FileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1FileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFileNavigation)
-]
-
 { #category : #meta }
 FamixTest1FileAnchor class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1Folder.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Folder.class.st
@@ -22,12 +22,6 @@ FamixTest1Folder class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1Folder class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTFolder)
-]
-
 { #category : #meta }
 FamixTest1Folder class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
@@ -11,12 +11,6 @@ FamixTest1ImportingContext class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1ImportingContext class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTest1ImportingContext >> importAbstractFile [
 

--- a/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest1IndexedFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1IndexedFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTIndexedFileNavigation)
-]
-
 { #category : #meta }
 FamixTest1IndexedFileAnchor class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1Method.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Method.class.st
@@ -22,12 +22,6 @@ FamixTest1Method class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1Method class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMethod)
-]
-
 { #category : #meta }
 FamixTest1Method class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest1MultipleFileAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1MultipleFileAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMultipleFileAnchor)
-]
-
 { #category : #meta }
 FamixTest1MultipleFileAnchor class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
@@ -30,12 +30,6 @@ FamixTest1NamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1NamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamed TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest1NamedEntity class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest1SourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1SourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest1SourceAnchor class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixTest1SourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1SourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixTest1SourceLanguage class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest1SourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1SourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixTest1SourceTextAnchor class >> requirements [
 

--- a/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixTest1SourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest1SourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithFiles FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixTest1SourcedEntity class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2Association.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Association.class.st
@@ -22,12 +22,6 @@ FamixTest2Association class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2Association class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest2Association class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -22,12 +22,6 @@ FamixTest2Class class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2Class class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTWithSubInheritances FamixTWithSuperInheritances)
-]
-
 { #category : #meta }
 FamixTest2Class class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2Comment.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Comment.class.st
@@ -22,12 +22,6 @@ FamixTest2Comment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2Comment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixTest2Comment class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -20,12 +20,6 @@ FamixTest2Entity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2Entity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest2Entity class >> metamodel [
 

--- a/src/Famix-Test2-Entities/FamixTest2ImportingContext.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2ImportingContext.class.st
@@ -11,12 +11,6 @@ FamixTest2ImportingContext class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2ImportingContext class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTest2ImportingContext >> importAssociation [
 

--- a/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
@@ -22,12 +22,6 @@ FamixTest2Inheritance class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2Inheritance class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInheritanceGlue FamixTSubInheritance FamixTSuperInheritance)
-]
-
 { #category : #meta }
 FamixTest2Inheritance class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
@@ -22,12 +22,6 @@ FamixTest2NamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2NamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamed TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest2NamedEntity class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest2SourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2SourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest2SourceAnchor class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixTest2SourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2SourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixTest2SourceLanguage class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest2SourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2SourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixTest2SourceTextAnchor class >> requirements [
 

--- a/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixTest2SourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest2SourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixTest2SourcedEntity class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3Association.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Association.class.st
@@ -22,12 +22,6 @@ FamixTest3Association class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Association class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest3Association class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3Class.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Class.class.st
@@ -22,12 +22,6 @@ FamixTest3Class class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Class class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTContainingWithInvocationsGlue FamixTLCOMMetrics FamixTWithMethods)
-]
-
 { #category : #meta }
 FamixTest3Class class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3Comment.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Comment.class.st
@@ -22,12 +22,6 @@ FamixTest3Comment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Comment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixTest3Comment class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -20,12 +20,6 @@ FamixTest3Entity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Entity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest3Entity class >> metamodel [
 

--- a/src/Famix-Test3-Entities/FamixTest3ImportingContext.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3ImportingContext.class.st
@@ -11,12 +11,6 @@ FamixTest3ImportingContext class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3ImportingContext class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTest3ImportingContext >> importAssociation [
 

--- a/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
@@ -22,12 +22,6 @@ FamixTest3Invocation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Invocation class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocation)
-]
-
 { #category : #meta }
 FamixTest3Invocation class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3Method.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Method.class.st
@@ -22,12 +22,6 @@ FamixTest3Method class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Method class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTInvocable FamixTMethod FamixTWithInvocations FamixTWithReferences FamixTWithTypes)
-]
-
 { #category : #meta }
 FamixTest3Method class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
@@ -22,12 +22,6 @@ FamixTest3NamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3NamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamed TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest3NamedEntity class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
@@ -22,12 +22,6 @@ FamixTest3PrimitiveType class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3PrimitiveType class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTReferenceable FamixTWithTypes)
-]
-
 { #category : #meta }
 FamixTest3PrimitiveType class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3Reference.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Reference.class.st
@@ -22,12 +22,6 @@ FamixTest3Reference class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Reference class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTReference)
-]
-
 { #category : #meta }
 FamixTest3Reference class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest3SourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3SourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTest3SourceAnchor class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixTest3SourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3SourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixTest3SourceLanguage class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixTest3SourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3SourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixTest3SourceTextAnchor class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixTest3SourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3SourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixTest3SourcedEntity class >> requirements [
 

--- a/src/Famix-Test3-Entities/FamixTest3TWithMethod.trait.st
+++ b/src/Famix-Test3-Entities/FamixTest3TWithMethod.trait.st
@@ -18,9 +18,3 @@ FamixTest3TWithMethod classSide >> generatedSlotNames [
 	'FamixTest3TWithMethod class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTest3TWithMethod classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Test3-Entities/FamixTest3Types.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Types.class.st
@@ -22,12 +22,6 @@ FamixTest3Types class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest3Types class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTType)
-]
-
 { #category : #meta }
 FamixTest3Types class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -23,12 +23,6 @@ FamixTest4Book class >> generatedSlotNames [
 	^ #(person)
 ]
 
-{ #category : #generator }
-FamixTest4Book class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Book class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
@@ -20,12 +20,6 @@ FamixTest4Cafeteria class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest4Cafeteria class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Cafeteria class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
@@ -20,12 +20,6 @@ FamixTest4Classroom class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTest4Classroom class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Classroom class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -23,12 +23,6 @@ FamixTest4Entity class >> generatedSlotNames [
 	^ #(name)
 ]
 
-{ #category : #generator }
-FamixTest4Entity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Entity class >> metamodel [
 

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -23,12 +23,6 @@ FamixTest4Person class >> generatedSlotNames [
 	^ #(books)
 ]
 
-{ #category : #generator }
-FamixTest4Person class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Person class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -23,12 +23,6 @@ FamixTest4Principal class >> generatedSlotNames [
 	^ #(school)
 ]
 
-{ #category : #generator }
-FamixTest4Principal class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Principal class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -23,12 +23,6 @@ FamixTest4Room class >> generatedSlotNames [
 	^ #(school)
 ]
 
-{ #category : #generator }
-FamixTest4Room class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Room class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -26,12 +26,6 @@ FamixTest4School class >> generatedSlotNames [
 	^ #(principal rooms students teachers)
 ]
 
-{ #category : #generator }
-FamixTest4School class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4School class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -24,12 +24,6 @@ FamixTest4Student class >> generatedSlotNames [
 	^ #(school teachers)
 ]
 
-{ #category : #generator }
-FamixTest4Student class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Student class >> requirements [
 

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -24,12 +24,6 @@ FamixTest4Teacher class >> generatedSlotNames [
 	^ #(school students)
 ]
 
-{ #category : #generator }
-FamixTest4Teacher class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTest4Teacher class >> requirements [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -22,12 +22,6 @@ FamixTestComposedAssociation class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposedAssociation class >> generatedTraitNames [
-	<generated>
-	^ #(TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposedAssociation class >> requirements [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -20,12 +20,6 @@ FamixTestComposedCustomEntity1 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposedCustomEntity1 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposedCustomEntity1 class >> metamodel [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -20,12 +20,6 @@ FamixTestComposedCustomEntity2 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposedCustomEntity2 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposedCustomEntity2 class >> metamodel [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -20,12 +20,6 @@ FamixTestComposedCustomEntity3 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposedCustomEntity3 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposedCustomEntity3 class >> metamodel [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -20,12 +20,6 @@ FamixTestComposedCustomEntity4 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposedCustomEntity4 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposedCustomEntity4 class >> metamodel [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -20,12 +20,6 @@ FamixTestComposedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposedEntity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposedEntity class >> metamodel [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Association.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Association.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1Association class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1Association class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed1Association class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1Class class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1Class class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTLCOMMetrics FamixTWithMethods)
-]
-
 { #category : #meta }
 FamixTestComposed1Class class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1Comment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1Comment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixTestComposed1Comment class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
@@ -20,12 +20,6 @@ FamixTestComposed1CustomEntity1 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1CustomEntity1 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed1CustomEntity1 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
@@ -20,12 +20,6 @@ FamixTestComposed1CustomEntity2 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1CustomEntity2 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed1CustomEntity2 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
@@ -20,12 +20,6 @@ FamixTestComposed1CustomEntity3 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1CustomEntity3 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed1CustomEntity3 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
@@ -20,12 +20,6 @@ FamixTestComposed1CustomEntity4 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1CustomEntity4 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed1CustomEntity4 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1CustomEntity5 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1CustomEntity5 class >> generatedTraitNames [
-	<generated>
-	^ #(TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed1CustomEntity5 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -20,12 +20,6 @@ FamixTestComposed1Entity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1Entity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed1Entity class >> metamodel [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1Method class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1Method class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMethod)
-]
-
 { #category : #meta }
 FamixTestComposed1Method class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1NamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1NamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamed TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed1NamedEntity class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1SourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1SourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed1SourceAnchor class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1SourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1SourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixTestComposed1SourceLanguage class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1SourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1SourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixTestComposed1SourceTextAnchor class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixTestComposed1SourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed1SourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixTestComposed1SourcedEntity class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Association.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Association.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2Association class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2Association class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTAssociation TAssociationMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed2Association class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2Class class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2Class class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTClass FamixTLCOMMetrics FamixTWithMethods)
-]
-
 { #category : #meta }
 FamixTestComposed2Class class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2Comment class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2Comment class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTComment)
-]
-
 { #category : #meta }
 FamixTestComposed2Comment class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
@@ -20,12 +20,6 @@ FamixTestComposed2CustomEntity1 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2CustomEntity1 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed2CustomEntity1 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
@@ -20,12 +20,6 @@ FamixTestComposed2CustomEntity2 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2CustomEntity2 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed2CustomEntity2 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
@@ -20,12 +20,6 @@ FamixTestComposed2CustomEntity3 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2CustomEntity3 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed2CustomEntity3 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
@@ -20,12 +20,6 @@ FamixTestComposed2CustomEntity4 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2CustomEntity4 class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed2CustomEntity4 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2CustomEntity5 class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2CustomEntity5 class >> generatedTraitNames [
-	<generated>
-	^ #(TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed2CustomEntity5 class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -20,12 +20,6 @@ FamixTestComposed2Entity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2Entity class >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #meta }
 FamixTestComposed2Entity class >> metamodel [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2Method class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2Method class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTMethod)
-]
-
 { #category : #meta }
 FamixTestComposed2Method class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2NamedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2NamedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTNamed TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed2NamedEntity class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2SourceAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2SourceAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceAnchor TDependencyQueries TEntityMetaLevelDependency)
-]
-
 { #category : #meta }
 FamixTestComposed2SourceAnchor class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2SourceLanguage class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2SourceLanguage class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTSourceLanguage)
-]
-
 { #category : #meta }
 FamixTestComposed2SourceLanguage class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2SourceTextAnchor class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2SourceTextAnchor class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithImmediateSource)
-]
-
 { #category : #meta }
 FamixTestComposed2SourceTextAnchor class >> requirements [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
@@ -22,12 +22,6 @@ FamixTestComposed2SourcedEntity class >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTestComposed2SourcedEntity class >> generatedTraitNames [
-	<generated>
-	^ #(FamixTWithComments FamixTWithSourceAnchor FamixTWithSourceLanguage)
-]
-
 { #category : #meta }
 FamixTestComposed2SourcedEntity class >> requirements [
 

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -39,12 +39,6 @@ FamixTAccess classSide >> generatedSlotNames [
 	^ #(accessor isWrite variable)
 ]
 
-{ #category : #generator }
-FamixTAccess classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTAccess >> accessor [
 

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -22,12 +22,6 @@ FamixTAccessible classSide >> generatedSlotNames [
 	^ #(incomingAccesses)
 ]
 
-{ #category : #generator }
-FamixTAccessible classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTAccessible >> accessingClasses [
 

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -43,12 +43,6 @@ FamixTAnnotationInstance classSide >> generatedSlotNames [
 	^ #(annotatedEntity)
 ]
 
-{ #category : #generator }
-FamixTAnnotationInstance classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTAnnotationInstance >> annotatedEntity [
 

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -34,12 +34,6 @@ FamixTAnnotationInstanceAttribute classSide >> generatedSlotNames [
 	^ #(parentAnnotationInstance value)
 ]
 
-{ #category : #generator }
-FamixTAnnotationInstanceAttribute classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTAnnotationInstanceAttribute >> parentAnnotationInstance [
 

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -38,12 +38,6 @@ FamixTAnnotationType classSide >> generatedSlotNames [
 	^ #(annotationTypesContainer instances)
 ]
 
-{ #category : #generator }
-FamixTAnnotationType classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTAnnotationType >> annotationTypesContainer [
 

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -40,12 +40,6 @@ FamixTAnnotationTypeAttribute classSide >> generatedSlotNames [
 	^ #(annotationAttributeInstances)
 ]
 
-{ #category : #generator }
-FamixTAnnotationTypeAttribute classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTAnnotationTypeAttribute >> annotationAttributeInstances [
 

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -42,12 +42,6 @@ FamixTAssociation classSide >> generatedSlotNames [
 	^ #(next previous)
 ]
 
-{ #category : #generator }
-FamixTAssociation classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTAssociation >> isAssociation [
 

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -26,12 +26,6 @@ FamixTAttribute classSide >> generatedSlotNames [
 	^ #(parentType)
 ]
 
-{ #category : #generator }
-FamixTAttribute classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTAttribute >> isAttribute [
 

--- a/src/Famix-Traits/FamixTCaughtException.trait.st
+++ b/src/Famix-Traits/FamixTCaughtException.trait.st
@@ -25,12 +25,6 @@ FamixTCaughtException classSide >> generatedSlotNames [
 	^ #(definingEntity)
 ]
 
-{ #category : #generator }
-FamixTCaughtException classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTCaughtException >> definingEntity [
 

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -36,12 +36,6 @@ FamixTClass classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTClass classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTClass >> isClass [
 

--- a/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
+++ b/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
@@ -19,12 +19,6 @@ FamixTClassHierarchyNavigation classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTClassHierarchyNavigation classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> addedMethods [
 	| inheritedMethodNames |

--- a/src/Famix-Traits/FamixTClassMetrics.trait.st
+++ b/src/Famix-Traits/FamixTClassMetrics.trait.st
@@ -18,9 +18,3 @@ FamixTClassMetrics classSide >> generatedSlotNames [
 	'FamixTClassMetrics class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTClassMetrics classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Traits/FamixTClassWithInvocationsGlue.trait.st
+++ b/src/Famix-Traits/FamixTClassWithInvocationsGlue.trait.st
@@ -18,9 +18,3 @@ FamixTClassWithInvocationsGlue classSide >> generatedSlotNames [
 	'FamixTClassWithInvocationsGlue class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTClassWithInvocationsGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
+++ b/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
@@ -20,9 +20,3 @@ FamixTCohesionCouplingMetrics classSide >> generatedSlotNames [
 	'FamixTCohesionCouplingMetrics class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTCohesionCouplingMetrics classSide >> generatedTraitNames [
-	<generated>
-	^ #(FamixTPackage)
-]

--- a/src/Famix-Traits/FamixTComment.trait.st
+++ b/src/Famix-Traits/FamixTComment.trait.st
@@ -33,12 +33,6 @@ FamixTComment classSide >> generatedSlotNames [
 	^ #(container content)
 ]
 
-{ #category : #generator }
-FamixTComment classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTComment >> container [
 

--- a/src/Famix-Traits/FamixTCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTCompilationUnit.trait.st
@@ -25,12 +25,6 @@ FamixTCompilationUnit classSide >> generatedSlotNames [
 	^ #(compilationUnitOwner)
 ]
 
-{ #category : #generator }
-FamixTCompilationUnit classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTCompilationUnit >> compilationUnitOwner [
 

--- a/src/Famix-Traits/FamixTContainingWithInvocationsGlue.trait.st
+++ b/src/Famix-Traits/FamixTContainingWithInvocationsGlue.trait.st
@@ -19,12 +19,6 @@ FamixTContainingWithInvocationsGlue classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTContainingWithInvocationsGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTContainingWithInvocationsGlue >> incomingInvocations [
 

--- a/src/Famix-Traits/FamixTContainingWithStatementsGlue.trait.st
+++ b/src/Famix-Traits/FamixTContainingWithStatementsGlue.trait.st
@@ -36,12 +36,6 @@ FamixTContainingWithStatementsGlue classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTContainingWithStatementsGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTContainingWithStatementsGlue >> numberOfStatements [
 	<MSEProperty: #numberOfStatements type: #Number>

--- a/src/Famix-Traits/FamixTDeclaredException.trait.st
+++ b/src/Famix-Traits/FamixTDeclaredException.trait.st
@@ -25,12 +25,6 @@ FamixTDeclaredException classSide >> generatedSlotNames [
 	^ #(definingEntity)
 ]
 
-{ #category : #generator }
-FamixTDeclaredException classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTDeclaredException >> definingEntity [
 

--- a/src/Famix-Traits/FamixTDefinedInModule.trait.st
+++ b/src/Famix-Traits/FamixTDefinedInModule.trait.st
@@ -22,12 +22,6 @@ FamixTDefinedInModule classSide >> generatedSlotNames [
 	^ #(parentModule)
 ]
 
-{ #category : #generator }
-FamixTDefinedInModule classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTDefinedInModule >> parentModule [
 

--- a/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
+++ b/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
@@ -29,12 +29,6 @@ FamixTDereferencedInvocation classSide >> generatedSlotNames [
 	^ #(referencer)
 ]
 
-{ #category : #generator }
-FamixTDereferencedInvocation classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTDereferencedInvocation >> referencer [
 

--- a/src/Famix-Traits/FamixTDirectFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTDirectFileAnchor.trait.st
@@ -19,12 +19,6 @@ FamixTDirectFileAnchor classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTDirectFileAnchor classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTDirectFileAnchor >> sourceText [
 	(self startLine isNil and: [ self endLine isNil ]) ifTrue: [ ^ self completeText ].

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -35,12 +35,6 @@ FamixTEnumValue classSide >> generatedSlotNames [
 	^ #(parentEnum)
 ]
 
-{ #category : #generator }
-FamixTEnumValue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTEnumValue >> mooseNameOn: aStream [
 	(self belongsTo isNotNil and: [ self belongsTo name isNotNil ])

--- a/src/Famix-Traits/FamixTException.trait.st
+++ b/src/Famix-Traits/FamixTException.trait.st
@@ -25,12 +25,6 @@ FamixTException classSide >> generatedSlotNames [
 	^ #(exceptionClass)
 ]
 
-{ #category : #generator }
-FamixTException classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTException >> exceptionClass [
 

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -34,12 +34,6 @@ FamixTFile classSide >> generatedSlotNames [
 	^ #(entities)
 ]
 
-{ #category : #generator }
-FamixTFile classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTFile >> addEntity: famixEntity [
 	self entities add: famixEntity

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -27,12 +27,6 @@ FamixTFileAnchor classSide >> generatedSlotNames [
 	^ #(correspondingFile encoding fileName)
 ]
 
-{ #category : #generator }
-FamixTFileAnchor classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTFileAnchor >> addToFile: entity [
 	^ self correspondingFile addEntity: entity

--- a/src/Famix-Traits/FamixTFileInclude.trait.st
+++ b/src/Famix-Traits/FamixTFileInclude.trait.st
@@ -23,12 +23,6 @@ FamixTFileInclude classSide >> generatedSlotNames [
 	^ #(source target)
 ]
 
-{ #category : #generator }
-FamixTFileInclude classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTFileInclude >> source [
 

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -48,12 +48,6 @@ FamixTFileNavigation classSide >> generatedSlotNames [
 	^ #(endColumn endLine startColumn startLine)
 ]
 
-{ #category : #generator }
-FamixTFileNavigation classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTFileNavigation >> endColumn [
 

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -27,12 +27,6 @@ FamixTFileSystemEntity classSide >> generatedSlotNames [
 	^ #(parentFolder)
 ]
 
-{ #category : #generator }
-FamixTFileSystemEntity classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #constants }
 FamixTFileSystemEntity classSide >> named: aName filedIn: aFolder [
 

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -33,12 +33,6 @@ FamixTFolder classSide >> generatedSlotNames [
 	^ #(childrenFileSystemEntities)
 ]
 
-{ #category : #generator }
-FamixTFolder classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTFolder >> addChildFileSystemEntity: aFileOrFolder [
 	self childrenFileSystemEntities add: aFileOrFolder

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -25,12 +25,6 @@ FamixTFunction classSide >> generatedSlotNames [
 	^ #(functionOwner)
 ]
 
-{ #category : #generator }
-FamixTFunction classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTFunction >> functionOwner [
 

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -34,12 +34,6 @@ FamixTGlobalVariable classSide >> generatedSlotNames [
 	^ #(parentScope)
 ]
 
-{ #category : #generator }
-FamixTGlobalVariable classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTGlobalVariable >> parentScope [
 

--- a/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
@@ -22,12 +22,6 @@ FamixTGlobalVariableScope classSide >> generatedSlotNames [
 	^ #(globalVariables)
 ]
 
-{ #category : #generator }
-FamixTGlobalVariableScope classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTGlobalVariableScope >> addGlobalVariable: aGlobalVariable [ 
 	globalVariables add: aGlobalVariable

--- a/src/Famix-Traits/FamixTHeader.trait.st
+++ b/src/Famix-Traits/FamixTHeader.trait.st
@@ -25,12 +25,6 @@ FamixTHeader classSide >> generatedSlotNames [
 	^ #(headerOwner)
 ]
 
-{ #category : #generator }
-FamixTHeader classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTHeader >> headerOwner [
 

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -25,12 +25,6 @@ FamixTImplicitVariable classSide >> generatedSlotNames [
 	^ #(parentBehaviouralEntity)
 ]
 
-{ #category : #generator }
-FamixTImplicitVariable classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTImplicitVariable >> parentBehaviouralEntity [
 

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -42,12 +42,6 @@ FamixTIndexedFileNavigation classSide >> generatedSlotNames [
 	^ #(endPos startPos)
 ]
 
-{ #category : #generator }
-FamixTIndexedFileNavigation classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #private }
 FamixTIndexedFileNavigation >> countNumberOfLinesRuturnsFrom: aStream from: start to: end [
 	"Here is a speedup version of the #lineCount method for the IndexedFileAnchors.

--- a/src/Famix-Traits/FamixTInheritanceGlue.trait.st
+++ b/src/Famix-Traits/FamixTInheritanceGlue.trait.st
@@ -19,12 +19,6 @@ FamixTInheritanceGlue classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTInheritanceGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTInheritanceGlue >> isInheritance [ 
 	^true

--- a/src/Famix-Traits/FamixTInvocable.trait.st
+++ b/src/Famix-Traits/FamixTInvocable.trait.st
@@ -22,12 +22,6 @@ FamixTInvocable classSide >> generatedSlotNames [
 	^ #(incomingInvocations)
 ]
 
-{ #category : #generator }
-FamixTInvocable classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTInvocable >> addIncomingInvocation: anInvocation [
 	incomingInvocations add: anInvocation

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -44,12 +44,6 @@ FamixTInvocation classSide >> generatedSlotNames [
 	^ #(candidates receiver sender)
 ]
 
-{ #category : #generator }
-FamixTInvocation classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTInvocation >> addCandidate: aBehaviouralEntity [ 
 	candidates add: aBehaviouralEntity

--- a/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
+++ b/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
@@ -22,12 +22,6 @@ FamixTInvocationsReceiver classSide >> generatedSlotNames [
 	^ #(receivingInvocations)
 ]
 
-{ #category : #generator }
-FamixTInvocationsReceiver classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTInvocationsReceiver >> addReceivingInvocation: anInvocation [
 	receivingInvocations add: anInvocation

--- a/src/Famix-Traits/FamixTLCOMMetrics.trait.st
+++ b/src/Famix-Traits/FamixTLCOMMetrics.trait.st
@@ -19,12 +19,6 @@ FamixTLCOMMetrics classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTLCOMMetrics classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FamixTLCOMMetrics >> calculateLCOM2 [
 	

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -25,12 +25,6 @@ FamixTLocalVariable classSide >> generatedSlotNames [
 	^ #(parentBehaviouralEntity)
 ]
 
-{ #category : #generator }
-FamixTLocalVariable classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTLocalVariable >> parentBehaviouralEntity [
 

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -39,12 +39,6 @@ FamixTMethod classSide >> generatedSlotNames [
 	^ #(isAbstract isClassSide kind parentType)
 ]
 
-{ #category : #generator }
-FamixTMethod classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTMethod >> cyclomaticComplexity [
 	<MSEProperty: #cyclomaticComplexity type: #Number>

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -26,12 +26,6 @@ FamixTModule classSide >> generatedSlotNames [
 	^ #(moduleEntities)
 ]
 
-{ #category : #generator }
-FamixTModule classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTModule >> moduleEntities [
 

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -22,12 +22,6 @@ FamixTMultipleFileAnchor classSide >> generatedSlotNames [
 	^ #(allFiles)
 ]
 
-{ #category : #generator }
-FamixTMultipleFileAnchor classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTMultipleFileAnchor >> addSourceAnchor: aSourceAnchor [
 	self allFiles add: aSourceAnchor

--- a/src/Famix-Traits/FamixTNamed.trait.st
+++ b/src/Famix-Traits/FamixTNamed.trait.st
@@ -22,12 +22,6 @@ FamixTNamed classSide >> generatedSlotNames [
 	^ #(name)
 ]
 
-{ #category : #generator }
-FamixTNamed classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'instance creation' }
 FamixTNamed classSide >> named: aString [
 	^ self new

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -38,12 +38,6 @@ FamixTNamespace classSide >> generatedSlotNames [
 	^ #(namespaceEntities namespaceOwner)
 ]
 
-{ #category : #generator }
-FamixTNamespace classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTNamespace >> isNamespace [
 

--- a/src/Famix-Traits/FamixTNamespaceEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamespaceEntity.trait.st
@@ -22,12 +22,6 @@ FamixTNamespaceEntity classSide >> generatedSlotNames [
 	^ #(parentNamespace)
 ]
 
-{ #category : #generator }
-FamixTNamespaceEntity classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTNamespaceEntity >> parentNamespace [
 

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -36,12 +36,6 @@ FamixTPackage classSide >> generatedSlotNames [
 	^ #(childEntities packageOwner)
 ]
 
-{ #category : #generator }
-FamixTPackage classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTPackage >> childEntities [
 

--- a/src/Famix-Traits/FamixTPackageWithClassesGlue.trait.st
+++ b/src/Famix-Traits/FamixTPackageWithClassesGlue.trait.st
@@ -19,12 +19,6 @@ FamixTPackageWithClassesGlue classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTPackageWithClassesGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'Famix-Implementation' }
 FamixTPackageWithClassesGlue >> weightedMethodCount [
 	<MSEProperty: #weightedMethodCount type: #Number>

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -22,12 +22,6 @@ FamixTPackageable classSide >> generatedSlotNames [
 	^ #(parentPackage)
 ]
 
-{ #category : #generator }
-FamixTPackageable classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTPackageable >> isExtension [
 	^self belongsTo packageScope ~~ self packageScope.

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -25,12 +25,6 @@ FamixTParameter classSide >> generatedSlotNames [
 	^ #(parentBehaviouralEntity)
 ]
 
-{ #category : #generator }
-FamixTParameter classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTParameter >> parentBehaviouralEntity [
 

--- a/src/Famix-Traits/FamixTParameterizedType.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedType.trait.st
@@ -32,12 +32,6 @@ FamixTParameterizedType classSide >> generatedSlotNames [
 	^ #(parameterizableClass)
 ]
 
-{ #category : #generator }
-FamixTParameterizedType classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTParameterizedType >> parameterizableClass [
 

--- a/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
@@ -22,12 +22,6 @@ FamixTParameterizedTypeUser classSide >> generatedSlotNames [
 	^ #(argumentsInParameterizedTypes)
 ]
 
-{ #category : #generator }
-FamixTParameterizedTypeUser classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTParameterizedTypeUser >> argumentsInParameterizedTypes [
 

--- a/src/Famix-Traits/FamixTPossibleStub.trait.st
+++ b/src/Famix-Traits/FamixTPossibleStub.trait.st
@@ -22,12 +22,6 @@ FamixTPossibleStub classSide >> generatedSlotNames [
 	^ #(isStub)
 ]
 
-{ #category : #generator }
-FamixTPossibleStub classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTPossibleStub >> isStub [
 

--- a/src/Famix-Traits/FamixTPreprocessorDefine.trait.st
+++ b/src/Famix-Traits/FamixTPreprocessorDefine.trait.st
@@ -23,9 +23,3 @@ FamixTPreprocessorDefine classSide >> generatedSlotNames [
 	'FamixTPreprocessorDefine class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTPreprocessorDefine classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Traits/FamixTPreprocessorIfdef.trait.st
+++ b/src/Famix-Traits/FamixTPreprocessorIfdef.trait.st
@@ -23,9 +23,3 @@ FamixTPreprocessorIfdef classSide >> generatedSlotNames [
 	'FamixTPreprocessorIfdef class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTPreprocessorIfdef classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -36,12 +36,6 @@ FamixTReference classSide >> generatedSlotNames [
 	^ #(source target)
 ]
 
-{ #category : #generator }
-FamixTReference classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'instance creation' }
 FamixTReference classSide >> source: source target: target [
 	^ self new source: source; target: target

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -22,12 +22,6 @@ FamixTReferenceable classSide >> generatedSlotNames [
 	^ #(incomingReferences)
 ]
 
-{ #category : #generator }
-FamixTReferenceable classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTReferenceable >> addIncomingReference: aReference [ 
 	incomingReferences add: aReference

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -28,12 +28,6 @@ FamixTScopingEntity classSide >> generatedSlotNames [
 	^ #(childScopes parentScope)
 ]
 
-{ #category : #generator }
-FamixTScopingEntity classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTScopingEntity >> addChildScope: aScopingEntity [ 
 	childScopes add: aScopingEntity

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -25,12 +25,6 @@ FamixTSourceAnchor classSide >> generatedSlotNames [
 	^ #(element)
 ]
 
-{ #category : #generator }
-FamixTSourceAnchor classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTSourceAnchor >> element [
 

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -28,12 +28,6 @@ FamixTSourceLanguage classSide >> generatedSlotNames [
 	^ #(sourcedEntities)
 ]
 
-{ #category : #generator }
-FamixTSourceLanguage classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTSourceLanguage >> addSourcedEntity: aSourcedEntity [
 	^ self sourcedEntities add: aSourcedEntity

--- a/src/Famix-Traits/FamixTSub.trait.st
+++ b/src/Famix-Traits/FamixTSub.trait.st
@@ -22,12 +22,6 @@ FamixTSub classSide >> generatedSlotNames [
 	^ #(supers)
 ]
 
-{ #category : #generator }
-FamixTSub classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTSub >> supers [
 

--- a/src/Famix-Traits/FamixTSubInheritance.trait.st
+++ b/src/Famix-Traits/FamixTSubInheritance.trait.st
@@ -22,12 +22,6 @@ FamixTSubInheritance classSide >> generatedSlotNames [
 	^ #(subclass)
 ]
 
-{ #category : #generator }
-FamixTSubInheritance classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTSubInheritance >> from [
 	^ self subclass 

--- a/src/Famix-Traits/FamixTSuper.trait.st
+++ b/src/Famix-Traits/FamixTSuper.trait.st
@@ -22,12 +22,6 @@ FamixTSuper classSide >> generatedSlotNames [
 	^ #(subs)
 ]
 
-{ #category : #generator }
-FamixTSuper classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTSuper >> subs [
 

--- a/src/Famix-Traits/FamixTSuperInheritance.trait.st
+++ b/src/Famix-Traits/FamixTSuperInheritance.trait.st
@@ -22,12 +22,6 @@ FamixTSuperInheritance classSide >> generatedSlotNames [
 	^ #(superclass)
 ]
 
-{ #category : #generator }
-FamixTSuperInheritance classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #testing }
 FamixTSuperInheritance >> isInheritance [
 

--- a/src/Famix-Traits/FamixTTemplate.trait.st
+++ b/src/Famix-Traits/FamixTTemplate.trait.st
@@ -23,12 +23,6 @@ FamixTTemplate classSide >> generatedSlotNames [
 	^ #(templateOwner templateUsers)
 ]
 
-{ #category : #generator }
-FamixTTemplate classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTemplate >> templateOwner [
 

--- a/src/Famix-Traits/FamixTTemplateUser.trait.st
+++ b/src/Famix-Traits/FamixTTemplateUser.trait.st
@@ -22,12 +22,6 @@ FamixTTemplateUser classSide >> generatedSlotNames [
 	^ #(template)
 ]
 
-{ #category : #generator }
-FamixTTemplateUser classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTemplateUser >> template [
 

--- a/src/Famix-Traits/FamixTThrownException.trait.st
+++ b/src/Famix-Traits/FamixTThrownException.trait.st
@@ -25,12 +25,6 @@ FamixTThrownException classSide >> generatedSlotNames [
 	^ #(definingEntity)
 ]
 
-{ #category : #generator }
-FamixTThrownException classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTThrownException >> definingEntity [
 

--- a/src/Famix-Traits/FamixTTrait.trait.st
+++ b/src/Famix-Traits/FamixTTrait.trait.st
@@ -26,12 +26,6 @@ FamixTTrait classSide >> generatedSlotNames [
 	^ #(incomingTraitUsages traitOwner)
 ]
 
-{ #category : #generator }
-FamixTTrait classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTrait >> incomingTraitUsages [
 

--- a/src/Famix-Traits/FamixTTraitUsage.trait.st
+++ b/src/Famix-Traits/FamixTTraitUsage.trait.st
@@ -23,12 +23,6 @@ FamixTTraitUsage classSide >> generatedSlotNames [
 	^ #(trait user)
 ]
 
-{ #category : #generator }
-FamixTTraitUsage classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTraitUsage >> from [
 	^ self user

--- a/src/Famix-Traits/FamixTTraitUser.trait.st
+++ b/src/Famix-Traits/FamixTTraitUser.trait.st
@@ -22,12 +22,6 @@ FamixTTraitUser classSide >> generatedSlotNames [
 	^ #(outgoingTraitUsages)
 ]
 
-{ #category : #generator }
-FamixTTraitUser classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTraitUser >> outgoingTraitUsages [
 

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -37,12 +37,6 @@ FamixTType classSide >> generatedSlotNames [
 	^ #(typeContainer)
 ]
 
-{ #category : #generator }
-FamixTType classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'Famix-Extensions-nav All Dependencies' }
 FamixTType >> clientTypes [
 	<MSEProperty: #clientTypes type: #FamixTType>

--- a/src/Famix-Traits/FamixTTypeAlias.trait.st
+++ b/src/Famix-Traits/FamixTTypeAlias.trait.st
@@ -28,12 +28,6 @@ FamixTTypeAlias classSide >> generatedSlotNames [
 	^ #(aliasedType)
 ]
 
-{ #category : #generator }
-FamixTTypeAlias classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTypeAlias >> aliasedType [
 

--- a/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
@@ -22,12 +22,6 @@ FamixTTypedAnnotationInstance classSide >> generatedSlotNames [
 	^ #(annotationType)
 ]
 
-{ #category : #generator }
-FamixTTypedAnnotationInstance classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTypedAnnotationInstance >> annotationType [
 

--- a/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
@@ -22,12 +22,6 @@ FamixTTypedAnnotationInstanceAttribute classSide >> generatedSlotNames [
 	^ #(annotationTypeAttribute)
 ]
 
-{ #category : #generator }
-FamixTTypedAnnotationInstanceAttribute classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTypedAnnotationInstanceAttribute >> annotationTypeAttribute [
 

--- a/src/Famix-Traits/FamixTTypedStructure.trait.st
+++ b/src/Famix-Traits/FamixTTypedStructure.trait.st
@@ -22,12 +22,6 @@ FamixTTypedStructure classSide >> generatedSlotNames [
 	^ #(declaredType)
 ]
 
-{ #category : #generator }
-FamixTTypedStructure classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTTypedStructure >> declaredType [
 

--- a/src/Famix-Traits/FamixTWithAccesses.trait.st
+++ b/src/Famix-Traits/FamixTWithAccesses.trait.st
@@ -22,12 +22,6 @@ FamixTWithAccesses classSide >> generatedSlotNames [
 	^ #(accesses)
 ]
 
-{ #category : #generator }
-FamixTWithAccesses classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithAccesses >> accesses [
 

--- a/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
@@ -22,12 +22,6 @@ FamixTWithAnnotationInstanceAttributes classSide >> generatedSlotNames [
 	^ #(attributes)
 ]
 
-{ #category : #generator }
-FamixTWithAnnotationInstanceAttributes classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithAnnotationInstanceAttributes >> attributes [
 

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -22,12 +22,6 @@ FamixTWithAnnotationInstances classSide >> generatedSlotNames [
 	^ #(annotationInstances)
 ]
 
-{ #category : #generator }
-FamixTWithAnnotationInstances classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'Famix-Java' }
 FamixTWithAnnotationInstances >> allAnnotationInstances [
 	| result |

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -22,12 +22,6 @@ FamixTWithAnnotationTypes classSide >> generatedSlotNames [
 	^ #(definedAnnotationTypes)
 ]
 
-{ #category : #generator }
-FamixTWithAnnotationTypes classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithAnnotationTypes >> definedAnnotationTypes [
 

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -22,12 +22,6 @@ FamixTWithAttributes classSide >> generatedSlotNames [
 	^ #(attributes)
 ]
 
-{ #category : #generator }
-FamixTWithAttributes classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTWithAttributes >> addAttribute: anAttribute [
 	attributes add: anAttribute

--- a/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
@@ -22,12 +22,6 @@ FamixTWithCaughtExceptions classSide >> generatedSlotNames [
 	^ #(caughtExceptions)
 ]
 
-{ #category : #generator }
-FamixTWithCaughtExceptions classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithCaughtExceptions >> caughtExceptions [
 

--- a/src/Famix-Traits/FamixTWithClassScope.trait.st
+++ b/src/Famix-Traits/FamixTWithClassScope.trait.st
@@ -18,9 +18,3 @@ FamixTWithClassScope classSide >> generatedSlotNames [
 	'FamixTWithClassScope class>>#generatedSlotNames'.
 	^ #()
 ]
-
-{ #category : #generator }
-FamixTWithClassScope classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]

--- a/src/Famix-Traits/FamixTWithClasses.trait.st
+++ b/src/Famix-Traits/FamixTWithClasses.trait.st
@@ -19,12 +19,6 @@ FamixTWithClasses classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTWithClasses classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithClasses >> classes [
 	"Classes are usually seen as types from the point of view of a Container. However, there may other types (e.g. aspects) which we dont want to see as classes and are rejected by this method."

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -22,12 +22,6 @@ FamixTWithComments classSide >> generatedSlotNames [
 	^ #(comments)
 ]
 
-{ #category : #generator }
-FamixTWithComments classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithComments >> comments [
 

--- a/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
@@ -22,12 +22,6 @@ FamixTWithCompilationUnit classSide >> generatedSlotNames [
 	^ #(compilationUnit)
 ]
 
-{ #category : #generator }
-FamixTWithCompilationUnit classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithCompilationUnit >> compilationUnit [
 

--- a/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
@@ -22,12 +22,6 @@ FamixTWithDeclaredExceptions classSide >> generatedSlotNames [
 	^ #(declaredExceptions)
 ]
 
-{ #category : #generator }
-FamixTWithDeclaredExceptions classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithDeclaredExceptions >> declaredExceptions [
 

--- a/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
@@ -22,12 +22,6 @@ FamixTWithDereferencedInvocations classSide >> generatedSlotNames [
 	^ #(dereferencedInvocations)
 ]
 
-{ #category : #generator }
-FamixTWithDereferencedInvocations classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithDereferencedInvocations >> dereferencedInvocations [
 

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -22,12 +22,6 @@ FamixTWithEnumValues classSide >> generatedSlotNames [
 	^ #(enumValues)
 ]
 
-{ #category : #generator }
-FamixTWithEnumValues classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithEnumValues >> enumValues [
 

--- a/src/Famix-Traits/FamixTWithExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithExceptions.trait.st
@@ -22,12 +22,6 @@ FamixTWithExceptions classSide >> generatedSlotNames [
 	^ #(exceptions)
 ]
 
-{ #category : #generator }
-FamixTWithExceptions classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithExceptions >> exceptions [
 

--- a/src/Famix-Traits/FamixTWithFileInclude.trait.st
+++ b/src/Famix-Traits/FamixTWithFileInclude.trait.st
@@ -23,12 +23,6 @@ FamixTWithFileInclude classSide >> generatedSlotNames [
 	^ #(incomingIncludeRelations outgoingIncludeRelations)
 ]
 
-{ #category : #generator }
-FamixTWithFileInclude classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithFileInclude >> incomingIncludeRelations [
 

--- a/src/Famix-Traits/FamixTWithFiles.trait.st
+++ b/src/Famix-Traits/FamixTWithFiles.trait.st
@@ -22,12 +22,6 @@ FamixTWithFiles classSide >> generatedSlotNames [
 	^ #(containerFiles)
 ]
 
-{ #category : #generator }
-FamixTWithFiles classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithFiles >> containerFiles [
 

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -22,12 +22,6 @@ FamixTWithFunctions classSide >> generatedSlotNames [
 	^ #(functions)
 ]
 
-{ #category : #generator }
-FamixTWithFunctions classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithFunctions >> functions [
 

--- a/src/Famix-Traits/FamixTWithHeader.trait.st
+++ b/src/Famix-Traits/FamixTWithHeader.trait.st
@@ -22,12 +22,6 @@ FamixTWithHeader classSide >> generatedSlotNames [
 	^ #(header)
 ]
 
-{ #category : #generator }
-FamixTWithHeader classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithHeader >> header [
 

--- a/src/Famix-Traits/FamixTWithImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTWithImmediateSource.trait.st
@@ -22,12 +22,6 @@ FamixTWithImmediateSource classSide >> generatedSlotNames [
 	^ #(source)
 ]
 
-{ #category : #generator }
-FamixTWithImmediateSource classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithImmediateSource >> isFile [
 

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -22,12 +22,6 @@ FamixTWithImplicitVariables classSide >> generatedSlotNames [
 	^ #(implicitVariables)
 ]
 
-{ #category : #generator }
-FamixTWithImplicitVariables classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTWithImplicitVariables >> addImplicitVariable: anImplicitVariable [
 	implicitVariables add: anImplicitVariable

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -22,12 +22,6 @@ FamixTWithInvocations classSide >> generatedSlotNames [
 	^ #(outgoingInvocations)
 ]
 
-{ #category : #generator }
-FamixTWithInvocations classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTWithInvocations >> addOutgoingInvocation: anInvocation [
 	outgoingInvocations add: anInvocation

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -22,12 +22,6 @@ FamixTWithLocalVariables classSide >> generatedSlotNames [
 	^ #(localVariables)
 ]
 
-{ #category : #generator }
-FamixTWithLocalVariables classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithLocalVariables >> addLocalVariable: aLocalVariable [
 	localVariables add: aLocalVariable

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -22,12 +22,6 @@ FamixTWithMethods classSide >> generatedSlotNames [
 	^ #(methods)
 ]
 
-{ #category : #generator }
-FamixTWithMethods classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithMethods >> addMethod: aMethod [
 	methods add: aMethod

--- a/src/Famix-Traits/FamixTWithMethodsWithAccessesGlue.trait.st
+++ b/src/Famix-Traits/FamixTWithMethodsWithAccessesGlue.trait.st
@@ -19,12 +19,6 @@ FamixTWithMethodsWithAccessesGlue classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTWithMethodsWithAccessesGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTWithMethodsWithAccessesGlue >> tightClassCohesion [
 	<MSEProperty: #tightClassCohesion type: #Number>

--- a/src/Famix-Traits/FamixTWithMethodsWithModifiersGlue.trait.st
+++ b/src/Famix-Traits/FamixTWithMethodsWithModifiersGlue.trait.st
@@ -19,12 +19,6 @@ FamixTWithMethodsWithModifiersGlue classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTWithMethodsWithModifiersGlue classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTWithMethodsWithModifiersGlue >> numberOfAbstractMethods [
 	<MSEProperty: #numberOfAbstractMethods type: #Number>

--- a/src/Famix-Traits/FamixTWithModifiers.trait.st
+++ b/src/Famix-Traits/FamixTWithModifiers.trait.st
@@ -22,12 +22,6 @@ FamixTWithModifiers classSide >> generatedSlotNames [
 	^ #(modifiers)
 ]
 
-{ #category : #generator }
-FamixTWithModifiers classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'Famix-Implementation' }
 FamixTWithModifiers >> addModifier: aString [
 	self modifiers add: aString

--- a/src/Famix-Traits/FamixTWithNamespaces.trait.st
+++ b/src/Famix-Traits/FamixTWithNamespaces.trait.st
@@ -22,12 +22,6 @@ FamixTWithNamespaces classSide >> generatedSlotNames [
 	^ #(namespaces)
 ]
 
-{ #category : #generator }
-FamixTWithNamespaces classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithNamespaces >> namespaces [
 

--- a/src/Famix-Traits/FamixTWithPackages.trait.st
+++ b/src/Famix-Traits/FamixTWithPackages.trait.st
@@ -22,12 +22,6 @@ FamixTWithPackages classSide >> generatedSlotNames [
 	^ #(packages)
 ]
 
-{ #category : #generator }
-FamixTWithPackages classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithPackages >> packages [
 

--- a/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
@@ -22,12 +22,6 @@ FamixTWithParameterizedTypeUsers classSide >> generatedSlotNames [
 	^ #(arguments)
 ]
 
-{ #category : #generator }
-FamixTWithParameterizedTypeUsers classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithParameterizedTypeUsers >> arguments [
 

--- a/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
@@ -22,12 +22,6 @@ FamixTWithParameterizedTypes classSide >> generatedSlotNames [
 	^ #(parameterizedTypes)
 ]
 
-{ #category : #generator }
-FamixTWithParameterizedTypes classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithParameterizedTypes >> parameterizedTypes [
 

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -22,12 +22,6 @@ FamixTWithParameters classSide >> generatedSlotNames [
 	^ #(parameters)
 ]
 
-{ #category : #generator }
-FamixTWithParameters classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTWithParameters >> addParameter: aParameter [ 
 	parameters add: aParameter

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -22,12 +22,6 @@ FamixTWithReferences classSide >> generatedSlotNames [
 	^ #(outgoingReferences)
 ]
 
-{ #category : #generator }
-FamixTWithReferences classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithReferences >> addOutgoingReference: aReference [ 
 	outgoingReferences add: aReference

--- a/src/Famix-Traits/FamixTWithSignature.trait.st
+++ b/src/Famix-Traits/FamixTWithSignature.trait.st
@@ -22,12 +22,6 @@ FamixTWithSignature classSide >> generatedSlotNames [
 	^ #(signature)
 ]
 
-{ #category : #generator }
-FamixTWithSignature classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithSignature >> signature [
 

--- a/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
@@ -22,12 +22,6 @@ FamixTWithSourceAnchor classSide >> generatedSlotNames [
 	^ #(sourceAnchor)
 ]
 
-{ #category : #generator }
-FamixTWithSourceAnchor classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'Famix-Implementation' }
 FamixTWithSourceAnchor >> computeNumberOfLinesOfCode [
 	self hasSourceAnchor 

--- a/src/Famix-Traits/FamixTWithSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceLanguage.trait.st
@@ -22,12 +22,6 @@ FamixTWithSourceLanguage classSide >> generatedSlotNames [
 	^ #(declaredSourceLanguage)
 ]
 
-{ #category : #generator }
-FamixTWithSourceLanguage classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithSourceLanguage >> declaredSourceLanguage [
 

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -19,12 +19,6 @@ FamixTWithStatements classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-FamixTWithStatements classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #metrics }
 FamixTWithStatements >> numberOfStatements [
 	<MSEProperty: #numberOfStatements type: #Number>

--- a/src/Famix-Traits/FamixTWithSubInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithSubInheritances.trait.st
@@ -22,12 +22,6 @@ FamixTWithSubInheritances classSide >> generatedSlotNames [
 	^ #(superInheritances)
 ]
 
-{ #category : #generator }
-FamixTWithSubInheritances classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithSubInheritances >> addSuperInheritance: anInheritance [ 
 	superInheritances add: anInheritance

--- a/src/Famix-Traits/FamixTWithSuperInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithSuperInheritances.trait.st
@@ -22,12 +22,6 @@ FamixTWithSuperInheritances classSide >> generatedSlotNames [
 	^ #(subInheritances)
 ]
 
-{ #category : #generator }
-FamixTWithSuperInheritances classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithSuperInheritances >> addSubInheritance: anInheritance [ 
 	subInheritances add: anInheritance

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -22,12 +22,6 @@ FamixTWithTemplates classSide >> generatedSlotNames [
 	^ #(templates)
 ]
 
-{ #category : #generator }
-FamixTWithTemplates classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithTemplates >> templates [
 

--- a/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
@@ -22,12 +22,6 @@ FamixTWithThrownExceptions classSide >> generatedSlotNames [
 	^ #(thrownExceptions)
 ]
 
-{ #category : #generator }
-FamixTWithThrownExceptions classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithThrownExceptions >> thrownExceptions [
 

--- a/src/Famix-Traits/FamixTWithTrait.trait.st
+++ b/src/Famix-Traits/FamixTWithTrait.trait.st
@@ -22,12 +22,6 @@ FamixTWithTrait classSide >> generatedSlotNames [
 	^ #(traits)
 ]
 
-{ #category : #generator }
-FamixTWithTrait classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithTrait >> traits [
 

--- a/src/Famix-Traits/FamixTWithTypeAliases.trait.st
+++ b/src/Famix-Traits/FamixTWithTypeAliases.trait.st
@@ -22,12 +22,6 @@ FamixTWithTypeAliases classSide >> generatedSlotNames [
 	^ #(typeAliases)
 ]
 
-{ #category : #generator }
-FamixTWithTypeAliases classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 FamixTWithTypeAliases >> allTypeAliases [
 	| all |

--- a/src/Famix-Traits/FamixTWithTypedStructures.trait.st
+++ b/src/Famix-Traits/FamixTWithTypedStructures.trait.st
@@ -22,12 +22,6 @@ FamixTWithTypedStructures classSide >> generatedSlotNames [
 	^ #(structuresWithDeclaredType)
 ]
 
-{ #category : #generator }
-FamixTWithTypedStructures classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #deprecated }
 FamixTWithTypedStructures >> addBehaviourWithDeclaredType: aBehaviour [
 	self structuresWithDeclaredType add: aBehaviour

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -22,12 +22,6 @@ FamixTWithTypes classSide >> generatedSlotNames [
 	^ #(types)
 ]
 
-{ #category : #generator }
-FamixTWithTypes classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #adding }
 FamixTWithTypes >> addType: aType [ 
 	types add: aType

--- a/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
@@ -32,12 +32,6 @@ TAssociationMetaLevelDependency classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-TAssociationMetaLevelDependency classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #private }
 TAssociationMetaLevelDependency classSide >> privateSourceTypesIn: aMetamodel [
 	"I return the classes that could be my source"

--- a/src/Moose-Query/TDependencyQueries.trait.st
+++ b/src/Moose-Query/TDependencyQueries.trait.st
@@ -77,12 +77,6 @@ TDependencyQueries classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-TDependencyQueries classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #'moosequery-queries-generic' }
 TDependencyQueries >> createIncomingQueryResultWith: aCollection [
 	^ MooseIncomingQueryResult on: self withAll: aCollection

--- a/src/Moose-Query/TDependencyQueryResult.trait.st
+++ b/src/Moose-Query/TDependencyQueryResult.trait.st
@@ -24,12 +24,6 @@ TDependencyQueryResult classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-TDependencyQueryResult classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #filtering }
 TDependencyQueryResult >> allAtAnyScope: aCollectionOfFamixClasses [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :dep | (self opposite: dep) allAtAnyScope: aCollectionOfFamixClasses in: res ]) asSet

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -74,12 +74,6 @@ TEntityMetaLevelDependency classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-TEntityMetaLevelDependency classSide >> generatedTraitNames [
-	<generated>
-	^ #()
-]
-
 { #category : #accessing }
 TEntityMetaLevelDependency classSide >> incomingAssociationTypesIn: aMetamodel [
 

--- a/src/Moose-Query/TOODependencyQueries.trait.st
+++ b/src/Moose-Query/TOODependencyQueries.trait.st
@@ -26,12 +26,6 @@ TOODependencyQueries classSide >> generatedSlotNames [
 	^ #()
 ]
 
-{ #category : #generator }
-TOODependencyQueries classSide >> generatedTraitNames [
-	<generated>
-	^ #(TDependencyQueries)
-]
-
 { #category : #testing }
 TOODependencyQueries >> hasIncomingTypeDeclaration [
 	"This method could be more readable but it needs to be really performant"


### PR DESCRIPTION
Do not generate a method with the generated traits for every class/trait.

Instead we check the traits of the class and if they have a famix annotation. 

This commit also remove all the now useless methods.

Fixes #1615