### PR TITLE
1601-allModelNamespace

### DIFF
--- a/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
@@ -20,7 +20,7 @@ FAMIXModelQueriesTest >> setUp [
 	super setUp.
 	namespace1 := FAMIXNamespace new.
 	namespace2 := FAMIXNamespace new.
-	stubNamespace := FAMIXNamespace new.
+	stubNamespace := FAMIXNamespace new isStub: true.
 	class1 := FAMIXClass new.
 	stubClass1 := FAMIXClass new isStub: true.
 	interface1 := FAMIXClass new isInterface: true.

--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -157,7 +157,7 @@ MooseAbstractGroup >> allModelNamespaces [
 	^ self privateState
 		cacheAt: 'All model namespaces'
 		ifAbsentPut:
-			[ MooseGroup withAll: (self allNamespaces reject: [ :each | each isStub or: [ each types isEmpty or: [ each types allSatisfy: [ :type | type isStub ] ] ] ]) withDescription: 'All model namespaces' ]
+			[ MooseGroup withAll: (self allNamespaces reject: [ :each | each isStub ]) withDescription: 'All model namespaces' ]
 ]
 
 { #category : #'*Famix-Traits' }


### PR DESCRIPTION
fixes #1601a namespace is a stub only if isStub return true