### PR TITLE
1668-Generation-does-not-update-changes-in-superclass

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/Class.extension.st
+++ b/src/Famix-MetamodelBuilder-Core/Class.extension.st
@@ -29,6 +29,9 @@ Class >> generatedTraits [
 
 { #category : #'*Famix-MetamodelBuilder-Core' }
 Class >> needToAdaptTo: aRGClass [
-	^ ((self generatedTraits collect: #name) asSet = (aRGClass traitComposition transformations collect: #name) asSet
-		and: [ (self generatedSlots collect: #name) asSet = (aRGClass slots collect: #name) asSet ]) not
+	((self generatedTraits collect: #name) equalsTo: (aRGClass traitComposition transformations collect: #name)) ifFalse: [ ^ true ].
+
+	((self generatedSlots collect: #name) equalsTo: (aRGClass slots collect: #name)) ifFalse: [ ^ true ].
+
+	^ (self superclass ifNil: [ Trait ]) name ~= aRGClass superclass name
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelCleaningStrategiesTestGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelCleaningStrategiesTestGenerator.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #FamixMetamodelGenerator,
 	#instVars : [
 		'fmx',
-		'tOneTrait'
+		'tOneTrait',
+		'fmx2'
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-Helpers'
 }
@@ -25,13 +26,15 @@ FamixMetamodelCleaningStrategiesTestGenerator class >> prefix [
 { #category : #definition }
 FamixMetamodelCleaningStrategiesTestGenerator >> defineClasses [
 	super defineClasses.
-	fmx := builder newClassNamed: #FmxTestEntity
+	fmx := builder newClassNamed: #FmxTestEntity.
+	fmx2 := builder newClassNamed: #FmxTestEntityWithDifferentSuperclass
 ]
 
 { #category : #definition }
 FamixMetamodelCleaningStrategiesTestGenerator >> defineHierarchy [
 	super defineHierarchy.
-	fmx --|> tOneTrait
+	fmx --|> tOneTrait.
+	fmx2 --|> fmx
 ]
 
 { #category : #definition }
@@ -49,5 +52,5 @@ FamixMetamodelCleaningStrategiesTestGenerator >> defineRelations [
 { #category : #definition }
 FamixMetamodelCleaningStrategiesTestGenerator >> defineTraits [
 	super defineTraits.
-	tOneTrait := builder newTraitNamed: #TATrait.
+	tOneTrait := builder newTraitNamed: #TATrait
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -48,6 +48,16 @@ FmxMBGeneratorCleaningStrategyTest >> generateClasses [
 		classVariables: {}
 		package: self packageName.
 	Trait named: #TFmxCleanerTestAddedTrait uses: {} package: self packageName.
+	"We change the superclass of this class to ensure regeneration will update it. Check non regression for: https://github.com/moosetechnology/Moose/issues/1668"
+	self class environment
+		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
+		ifPresent: [ :class | 
+			MooseEntity
+				subclass: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
+				slots: {}
+				classVariables: {}
+				package: 'Famix-MetamodelBuilder-TestsResources-Entities' ]
+		ifAbsent: [ self fail ].
 	self class compile: 'extensionsMethodForTest' classified: '*' , generator packageName
 ]
 
@@ -87,6 +97,12 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningCleaning [
 			self assert: (class class hasInstVarNamed: #grandFrais) ]
 		ifAbsent: [ self fail ].
 
+	"Before the generation, the superclass should not be updated."
+	self class environment
+		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
+		ifPresent: [ :class | self assert: class superclass name equals: #MooseEntity ]
+		ifAbsent: [ self fail ].
+
 	self assert: (self class methodDict at: #extensionsMethodForTest ifPresent: [ true ] ifAbsent: [ false ]).
 
 	self class environment at: #FmxCleanerTestAddedClass ifPresent: [ :class | self assert: class package name equals: self packageName ] ifAbsent: [ self fail ].
@@ -113,6 +129,12 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningGeneration [
 			self assert: (class hasClassVarNamed: #Fuhrmanator).
 			self assert: (class class hasInstVarNamed: #grandFrais) ]
 		ifAbsent: [ self fail ].
+		
+	"After the generation, the superclass should be updated to be the one described in the generator."
+	self class environment
+		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
+		ifPresent: [ :class | self assert: class superclass name equals: #FmxTestCleaningStrategyFmxTestEntity ]
+		ifAbsent: [ self fail ].
 
 	self assert: (self class methodDict at: #extensionsMethodForTest ifPresent: [ true ] ifAbsent: [ false ]).
 
@@ -125,6 +147,7 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningCleaning [
 	generator define.
 	generator withCleaning cleaningStrategy cleanBeforeGeneration: generator.
 	self should: [ self class environment at: #FmxTestCleaningStrategyFmxTestEntity ] raise: KeyNotFound.
+	self should: [ self class environment at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass ] raise: KeyNotFound.
 	self should: [ self class environment at: #FmxCleanerTestAddedClass ] raise: KeyNotFound.
 	self should: [ self class environment at: #TFmxCleanerTestAddedTrait ] raise: KeyNotFound.
 	self assert: (self class methodDict at: #extensionsMethodForTest ifPresent: [ false ] ifAbsent: [ true ])
@@ -144,6 +167,12 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningGeneration [
 			self deny: (class hasInstVarNamed: #bananaTree).
 			self deny: (class hasClassVarNamed: #Fuhrmanator).
 			self deny: (class class hasInstVarNamed: #grandFrais) ]
+		ifAbsent: [ self fail ].
+	
+	"After the generation, the superclass should be updated."
+	self class environment
+		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
+		ifPresent: [ :class | self assert: class superclass name equals: #FmxTestCleaningStrategyFmxTestEntity ]
 		ifAbsent: [ self fail ].
 	
 	self assert: (self class methodDict at: #extensionsMethodForTest ifPresent: [ false ] ifAbsent: [ true ]).

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -81,7 +81,6 @@ FmxMBGeneratorCleaningStrategyTest >> tearDown [
 
 { #category : #running }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningCleaning [
-	generator define.
 	generator withoutCleaning cleaningStrategy cleanBeforeGeneration: generator.
 	self class environment
 		at: #FmxTestCleaningStrategyFmxTestEntity
@@ -129,7 +128,7 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningGeneration [
 			self assert: (class hasClassVarNamed: #Fuhrmanator).
 			self assert: (class class hasInstVarNamed: #grandFrais) ]
 		ifAbsent: [ self fail ].
-		
+
 	"After the generation, the superclass should be updated to be the one described in the generator."
 	self class environment
 		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
@@ -144,7 +143,6 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningGeneration [
 
 { #category : #running }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningCleaning [
-	generator define.
 	generator withCleaning cleaningStrategy cleanBeforeGeneration: generator.
 	self should: [ self class environment at: #FmxTestCleaningStrategyFmxTestEntity ] raise: KeyNotFound.
 	self should: [ self class environment at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass ] raise: KeyNotFound.
@@ -156,6 +154,7 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningCleaning [
 { #category : #running }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningGeneration [
 	generator generateWithCleaning.
+
 	self class environment
 		at: #FmxTestCleaningStrategyFmxTestEntity
 		ifPresent: [ :class | 
@@ -168,13 +167,13 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningGeneration [
 			self deny: (class hasClassVarNamed: #Fuhrmanator).
 			self deny: (class class hasInstVarNamed: #grandFrais) ]
 		ifAbsent: [ self fail ].
-	
+
 	"After the generation, the superclass should be updated."
 	self class environment
 		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
 		ifPresent: [ :class | self assert: class superclass name equals: #FmxTestCleaningStrategyFmxTestEntity ]
 		ifAbsent: [ self fail ].
-	
+
 	self assert: (self class methodDict at: #extensionsMethodForTest ifPresent: [ false ] ifAbsent: [ true ]).
 
 	self should: [ self class environment at: #FmxCleanerTestAddedClass ] raise: KeyNotFound.


### PR DESCRIPTION
When a generator change the superclass of a class it should recompile it.

Fix + test.

Fixes #1668