### PR TITLE
1691-Smalltalk-importer-does-not-properly-set-abstractness-

### DIFF
--- a/src/Moose-SmalltalkImporter/SmalltalkImporter.class.st
+++ b/src/Moose-SmalltalkImporter/SmalltalkImporter.class.st
@@ -72,7 +72,7 @@ SmalltalkImporter >> basicClassCreation: aClass [
 
 { #category : #'private utils' }
 SmalltalkImporter >> checkAbstractClass: class [ 
-	(class methods contains: [ :each | each isAbstract ]) ifTrue: [ class isAbstract: true ]
+	class isAbstract:  (class methods contains: [ :each | each isAbstract ]) 
 ]
 
 { #category : #'private accessing' }


### PR DESCRIPTION
Modifying the importer to set the isAbstract attribute of classes.Fixes #1691