### PR TITLE
1696-Do-not-regenerate-requirements-in-case-its-empty

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
@@ -15,13 +15,6 @@ FAMIXAbstractFile class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAbstractFile class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXAbstractFile >> belongsTo [
 	<navigation: 'parent folder'>

--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFileAnchor.class.st
@@ -15,13 +15,6 @@ FAMIXAbstractFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAbstractFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-File' }
 FAMIXAbstractFileAnchor >> <= aFileAnchor [
 	^ self fileName <= aFileAnchor fileName

--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -20,13 +20,6 @@ FAMIXAccess class >> fromMethod [
 	^ self lookupSelector: #accessor
 ]
 
-{ #category : #meta }
-FAMIXAccess class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Moose-Query-Extensions' }
 FAMIXAccess class >> toMethod [
 	^ self lookupSelector: #variable

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationTypeAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationTypeAttribute.class.st
@@ -15,13 +15,6 @@ FAMIXAnnotationTypeAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAnnotationTypeAttribute class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXAnnotationTypeAttribute >> parentAnnotationType [
 	<MSEProperty: #parentAnnotationType type: #FAMIXAnnotationType> <derived> 

--- a/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
@@ -15,13 +15,6 @@ FAMIXAssociation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAssociation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXAssociation >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -15,13 +15,6 @@ FAMIXBehaviouralEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXBehaviouralEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCFile.class.st
@@ -15,13 +15,6 @@ FAMIXCFile class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXCFile class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXCFile >> allIncomingIncludeRelations [
 	| answer |

--- a/src/Famix-Compatibility-Entities/FAMIXCSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCSourceLanguage.class.st
@@ -13,13 +13,6 @@ FAMIXCSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXCSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXCSourceLanguage >> isC [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXCaughtException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCaughtException.class.st
@@ -14,10 +14,3 @@ FAMIXCaughtException class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXCaughtException class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXClass.class.st
@@ -18,13 +18,6 @@ FAMIXClass class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXClass class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions-visitor' }
 FAMIXClass >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXComment.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXComment.class.st
@@ -15,13 +15,6 @@ FAMIXComment class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXComment class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXComment >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCompilationUnit.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCompilationUnit.class.st
@@ -15,13 +15,6 @@ FAMIXCompilationUnit class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXCompilationUnit class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXCompilationUnit >> isCompilationUnit [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
@@ -15,13 +15,6 @@ FAMIXContainerEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXContainerEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXContainerEntity >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXCppSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCppSourceLanguage.class.st
@@ -12,10 +12,3 @@ FAMIXCppSourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXCppSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXCustomSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCustomSourceLanguage.class.st
@@ -14,10 +14,3 @@ FAMIXCustomSourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXCustomSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXDeclaredException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXDeclaredException.class.st
@@ -14,10 +14,3 @@ FAMIXDeclaredException class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXDeclaredException class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXDereferencedInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXDereferencedInvocation.class.st
@@ -14,10 +14,3 @@ FAMIXDereferencedInvocation class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXDereferencedInvocation class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -20,13 +20,6 @@ FAMIXEntity class >> metamodel [
 	^ (self class environment at: #FamixCompatibilityGenerator) metamodel
 ]
 
-{ #category : #meta }
-FAMIXEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Moose-Query-Extensions' }
 FAMIXEntity class >> resetMSEProperties [
 	"

--- a/src/Famix-Compatibility-Entities/FAMIXEnum.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnum.class.st
@@ -15,13 +15,6 @@ FAMIXEnum class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXEnum class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXEnum >> values [
 	^ self enumValues

--- a/src/Famix-Compatibility-Entities/FAMIXException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXException.class.st
@@ -15,13 +15,6 @@ FAMIXException class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXException class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #compatibility }
 FAMIXException >> definingEntity [
 	self subclassResponsibility

--- a/src/Famix-Compatibility-Entities/FAMIXFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFile.class.st
@@ -15,13 +15,6 @@ FAMIXFile class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXFile class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #properties }
 FAMIXFile >> averageNumberOfCharactersPerLine [
 	<MSEProperty: #averageNumberOfCharactersPerLine type: #Number>

--- a/src/Famix-Compatibility-Entities/FAMIXFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFileAnchor.class.st
@@ -15,13 +15,6 @@ FAMIXFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXFileAnchor >> mooseNameOn: aStream [
 	super mooseNameOn: aStream.

--- a/src/Famix-Compatibility-Entities/FAMIXFolder.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFolder.class.st
@@ -15,13 +15,6 @@ FAMIXFolder class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXFolder class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXFolder >> isFolder [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXHeader.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXHeader.class.st
@@ -15,13 +15,6 @@ FAMIXHeader class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXHeader class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXHeader >> isHeader [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
@@ -15,13 +15,6 @@ FAMIXInclude class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXInclude class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXInclude >> from [	
 	^ self source

--- a/src/Famix-Compatibility-Entities/FAMIXIndexedFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXIndexedFileAnchor.class.st
@@ -15,13 +15,6 @@ FAMIXIndexedFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXIndexedFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXIndexedFileAnchor >> lineCount [
 

--- a/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
@@ -15,13 +15,6 @@ FAMIXInheritance class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXInheritance class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXInheritance >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -15,13 +15,6 @@ FAMIXInvocation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXInvocation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXInvocation >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXJavaSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXJavaSourceLanguage.class.st
@@ -13,13 +13,6 @@ FAMIXJavaSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXJavaSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXJavaSourceLanguage >> isJava [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
@@ -13,13 +13,6 @@ FAMIXLeafEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXLeafEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #visiting }
 FAMIXLeafEntity >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXModule.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXModule.class.st
@@ -15,13 +15,6 @@ FAMIXModule class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXModule class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXModule >> classes [ 
 	^ #()

--- a/src/Famix-Compatibility-Entities/FAMIXMultipleFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMultipleFileAnchor.class.st
@@ -15,13 +15,6 @@ FAMIXMultipleFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXMultipleFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #public }
 FAMIXMultipleFileAnchor >> addFileAnchorWithPath: aPath [
 	self allFiles detect: [ :each | each fileName = aPath ] ifNone: [ self createAnchorWithPath: aPath ]

--- a/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
@@ -15,13 +15,6 @@ FAMIXNamespace class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXNamespace class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FAMIXNamespace >> abstractness: aNumber [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
@@ -15,13 +15,6 @@ FAMIXPackage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXPackage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXPackage >> abstractClasses [
 

--- a/src/Famix-Compatibility-Entities/FAMIXParameterType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterType.class.st
@@ -13,13 +13,6 @@ FAMIXParameterType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXParameterType class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXParameterType >> isParameterType [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizableClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizableClass.class.st
@@ -15,13 +15,6 @@ FAMIXParameterizableClass class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXParameterizableClass class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #generated }
 FAMIXParameterizableClass >> parameters [
 	<MSEProperty: #parameters type: #FAMIXParameterType> <multivalued> <derived>

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
@@ -15,13 +15,6 @@ FAMIXParameterizedType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXParameterizedType class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXParameterizedType >> allSubclassesDo: aBlock [
 	"we override this traversal because we want to

--- a/src/Famix-Compatibility-Entities/FAMIXPharoAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPharoAnchor.class.st
@@ -16,13 +16,6 @@ FAMIXPharoAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXPharoAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-File' }
 FAMIXPharoAnchor >> containerFiles [
 	^ {  }

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorDefine.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorDefine.class.st
@@ -18,13 +18,6 @@ FAMIXPreprocessorDefine class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXPreprocessorDefine class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXPreprocessorDefine >> macro [
 	<MSEProperty: #macro type: #String>

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorIfdef.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorIfdef.class.st
@@ -17,13 +17,6 @@ FAMIXPreprocessorIfdef class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXPreprocessorIfdef class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FAMIXPreprocessorIfdef >> isNegated [
 	<MSEProperty: #negated type: #Boolean>

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorStatement.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorStatement.class.st
@@ -12,10 +12,3 @@ FAMIXPreprocessorStatement class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXPreprocessorStatement class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXPrimitiveType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPrimitiveType.class.st
@@ -13,13 +13,6 @@ FAMIXPrimitiveType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXPrimitiveType class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXPrimitiveType >> isPrimitiveType [
 

--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -15,13 +15,6 @@ FAMIXReference class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXReference class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXReference >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXSmalltalkSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSmalltalkSourceLanguage.class.st
@@ -13,13 +13,6 @@ FAMIXSmalltalkSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXSmalltalkSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXSmalltalkSourceLanguage >> isSmalltalk [
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -27,13 +27,6 @@ FAMIXSourceAnchor class >> parentTypes [
 	^ {}
 ]
 
-{ #category : #meta }
-FAMIXSourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #generator }
 FAMIXSourceAnchor class >> resetMooseQueryCaches [
 	super resetMooseQueryCaches.

--- a/src/Famix-Compatibility-Entities/FAMIXSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceLanguage.class.st
@@ -15,13 +15,6 @@ FAMIXSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-C' }
 FAMIXSourceLanguage >> isC [ 
 	^ false

--- a/src/Famix-Compatibility-Entities/FAMIXSourceTextAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceTextAnchor.class.st
@@ -15,13 +15,6 @@ FAMIXSourceTextAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXSourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-File' }
 FAMIXSourceTextAnchor >> containerFiles [
 	^ {}

--- a/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
@@ -15,13 +15,6 @@ FAMIXSourcedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXSourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXSourcedEntity >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
@@ -15,13 +15,6 @@ FAMIXStructuralEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXStructuralEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXStructuralEntity >> accept: aVisitor [
 

--- a/src/Famix-Compatibility-Entities/FAMIXThrownException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXThrownException.class.st
@@ -14,10 +14,3 @@ FAMIXThrownException class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXThrownException class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXTrait.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTrait.class.st
@@ -14,10 +14,3 @@ FAMIXTrait class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXTrait class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
@@ -14,10 +14,3 @@ FAMIXTraitUsage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXTraitUsage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXTypeAlias.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTypeAlias.class.st
@@ -15,13 +15,6 @@ FAMIXTypeAlias class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXTypeAlias class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXTypeAlias >> allSubclassesDo: aBlock [
 	"we override this traversal because we want to

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownSourceLanguage.class.st
@@ -13,13 +13,6 @@ FAMIXUnknownSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXUnknownSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FAMIXUnknownSourceLanguage >> isUnknown [ 
 	^ true

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
@@ -13,13 +13,6 @@ FAMIXUnknownVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXUnknownVariable class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXUnknownVariable >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
@@ -15,13 +15,6 @@ FamixJavaAbstractFile class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAbstractFile class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAbstractFile >> belongsTo [
 	<navigation: 'parent folder'>

--- a/src/Famix-Java-Entities/FamixJavaAbstractFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFileAnchor.class.st
@@ -15,13 +15,6 @@ FamixJavaAbstractFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAbstractFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAbstractFileAnchor >> <= aFileAnchor [
 	^ self fileName <= aFileAnchor fileName

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -15,13 +15,6 @@ FamixJavaAccess class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAccess class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAccess >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -15,13 +15,6 @@ FamixJavaAnnotationTypeAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAnnotationTypeAttribute class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationTypeAttribute >> parentAnnotationType [
 	<MSEProperty: #parentAnnotationType type: #FamixJavaAnnotationType> 

--- a/src/Famix-Java-Entities/FamixJavaAssociation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAssociation.class.st
@@ -15,13 +15,6 @@ FamixJavaAssociation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAssociation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAssociation >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -18,13 +18,6 @@ FamixJavaAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAttribute class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAttribute >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaCaughtException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaCaughtException.class.st
@@ -14,10 +14,3 @@ FamixJavaCaughtException class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixJavaCaughtException class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -15,13 +15,6 @@ FamixJavaClass class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaClass class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaClass >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -15,13 +15,6 @@ FamixJavaComment class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaComment class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaComment >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -15,13 +15,6 @@ FamixJavaContainerEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaContainerEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaContainerEntity >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaDeclaredException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaDeclaredException.class.st
@@ -14,10 +14,3 @@ FamixJavaDeclaredException class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixJavaDeclaredException class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -37,13 +37,6 @@ FamixJavaEntity class >> metamodel [
 	^ (self class environment at: #FamixJavaGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixJavaEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Moose-Query' }
 FamixJavaEntity class >> resetMSEProperties [
 	"

--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -15,13 +15,6 @@ FamixJavaEnum class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaEnum class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaEnum >> values [
 	^ self enumValues

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -15,13 +15,6 @@ FamixJavaException class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaException class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #deprecated }
 FamixJavaException >> definingMethod [
 

--- a/src/Famix-Java-Entities/FamixJavaFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFile.class.st
@@ -15,13 +15,6 @@ FamixJavaFile class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaFile class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaFile >> averageNumberOfCharactersPerLine [
 	<MSEProperty: #averageNumberOfCharactersPerLine type: #Number>

--- a/src/Famix-Java-Entities/FamixJavaFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFileAnchor.class.st
@@ -15,13 +15,6 @@ FamixJavaFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixJavaFileAnchor >> mooseNameOn: aStream [
 	super mooseNameOn: aStream.

--- a/src/Famix-Java-Entities/FamixJavaFolder.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFolder.class.st
@@ -14,10 +14,3 @@ FamixJavaFolder class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixJavaFolder class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
@@ -15,13 +15,6 @@ FamixJavaIndexedFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaIndexedFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaIndexedFileAnchor >> lineCount [
 

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -15,13 +15,6 @@ FamixJavaInheritance class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaInheritance class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaInheritance >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -15,13 +15,6 @@ FamixJavaInvocation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaInvocation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaInvocation >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -15,13 +15,6 @@ FamixJavaMethod class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaMethod class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaMethod >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaMultipleFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMultipleFileAnchor.class.st
@@ -15,13 +15,6 @@ FamixJavaMultipleFileAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaMultipleFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaMultipleFileAnchor >> addFileAnchorWithPath: aPath [
 	self allFiles detect: [ :each | each fileName = aPath ] ifNone: [ self createAnchorWithPath: aPath ]

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -15,13 +15,6 @@ FamixJavaNamespace class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaNamespace class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaNamespace >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -15,13 +15,6 @@ FamixJavaPackage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaPackage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Implementation' }
 FamixJavaPackage >> abstractClasses [
 

--- a/src/Famix-Java-Entities/FamixJavaParameterType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterType.class.st
@@ -13,13 +13,6 @@ FamixJavaParameterType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaParameterType class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaParameterType >> isParameterType [
 	^ true

--- a/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
@@ -15,13 +15,6 @@ FamixJavaParameterizableClass class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaParameterizableClass class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaParameterizableClass >> parameters [
 	<MSEProperty: #parameters type: #FamixJavaParameterType> <multivalued> <derived>

--- a/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
@@ -15,13 +15,6 @@ FamixJavaParameterizedType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaParameterizedType class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaParameterizedType >> allSubclassesDo: aBlock [
 	"we override this traversal because we want to

--- a/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
@@ -13,13 +13,6 @@ FamixJavaPrimitiveType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaPrimitiveType class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixJavaPrimitiveType >> isPrimitiveType [
 

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -15,13 +15,6 @@ FamixJavaReference class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaReference class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaReference >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -28,13 +28,6 @@ FamixJavaSourceAnchor class >> parentTypes [
 ]
 
 { #category : #meta }
-FamixJavaSourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
-{ #category : #meta }
 FamixJavaSourceAnchor class >> resetMooseQueryCaches [
 	super resetMooseQueryCaches.
 	self resetTEntityMetaLevelDependencyCaches.

--- a/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
@@ -15,13 +15,6 @@ FamixJavaSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaSourceLanguage >> isC [ 
 	^ false

--- a/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
@@ -15,13 +15,6 @@ FamixJavaSourceTextAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaSourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaSourceTextAnchor >> containerFiles [
 	^ {}

--- a/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
@@ -15,13 +15,6 @@ FamixJavaSourcedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaSourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaSourcedEntity >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaStructuralEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaStructuralEntity.class.st
@@ -15,13 +15,6 @@ FamixJavaStructuralEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaStructuralEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaStructuralEntity >> accept: aVisitor [
 

--- a/src/Famix-Java-Entities/FamixJavaThrownException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaThrownException.class.st
@@ -14,10 +14,3 @@ FamixJavaThrownException class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixJavaThrownException class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
@@ -15,13 +15,6 @@ FamixJavaUnknownSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaUnknownSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaUnknownSourceLanguage >> isUnknown [ 
 	^ true

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -13,13 +13,6 @@ FamixJavaUnknownVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaUnknownVariable class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaUnknownVariable >> accept: aVisitor [
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -246,12 +246,15 @@ FmxMBClass >> generateRemotes [
 
 { #category : #generating }
 FmxMBClass >> generateRequirementsFor: aClass [
-
-	aClass classSide compile: ('requirements
+	self allRequirementNames
+		ifNotEmpty: [ :requirementNames | 
+			aClass classSide
+				compile:
+					('requirements
 
 	<generated>
-	^ \{ {1} \}' format: { self allRequirementNames joinUsing: '. ' }) 
-		classified: #meta
+	^ \{ {1} \}' format: {(requirementNames joinUsing: '. ')})
+				classified: #meta ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
@@ -416,20 +416,18 @@ FmxMBClassTest >> testRelatedTraitName [
 
 { #category : #tests }
 FmxMBClassTest >> testSimpleClass [
-
 	"check expected parameters of a newely generated class"
 
-	| simpleClass generated |
-	
-	simpleClass := builder newClassNamed: #Comment.	
+	| generated |
+	builder newClassNamed: #Comment.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
 	self assert: generated notNil.
 	self assert: generated isClass.
 	self assert: generated superclass name equals: 'MooseEntity'.
 	self assert: generated slots isEmpty.
-	self assert: generated instanceSide localSelectors isEmpty.	
-	self assertCollection: generated classSide localSelectors sorted equals: #(annotation #metamodel #requirements).
+	self assert: generated instanceSide localSelectors isEmpty.
+	self assertCollection: generated classSide localSelectors sorted equals: #(annotation #metamodel)
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
@@ -87,22 +87,13 @@ FmxMBImportingContextTest >> testNotGeneratedForEmptyBuilder [
 
 { #category : #initialization }
 FmxMBImportingContextTest >> testRequirements [
-
 	| localMethod |
-	
-	localMethod := generatedVariable classSide methodNamed: #requirements.
-	self assert: (localMethod sourceCode includesSubstring: '<generated>').
-	self assert: (localMethod sourceCode includesSubstring: '^ {  }').
-
-	localMethod := generatedMethod classSide methodNamed: #requirements.
-	self assert: (localMethod sourceCode includesSubstring: '<generated>').
-	self assert: (localMethod sourceCode includesSubstring: '^ {  }').
+	self assert: (generatedVariable classSide methodNamed: #requirements) isNil.
+	self assert: (generatedMethod classSide methodNamed: #requirements) isNil.
 
 	localMethod := generatedAccess classSide methodNamed: #requirements.
 	self assert: (localMethod sourceCode includesSubstring: '<generated>').
-	self assert: (localMethod sourceCode includesSubstring: '^ { TstMethod. TstVariable }').
-
-
+	self assert: (localMethod sourceCode includesSubstring: '^ { TstMethod. TstVariable }')
 ]
 
 { #category : #initialization }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -15,13 +15,6 @@ FamixStAccess class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAccess class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixStAccess >> mooseFinderSourceTextIn: composite [
 	<moosePresentationOrder: 20>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -15,13 +15,6 @@ FamixStAnnotationTypeAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAnnotationTypeAttribute class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixStAnnotationTypeAttribute >> parentAnnotationType [
 	<MSEProperty: #parentAnnotationType type: #FamixStAnnotationType> <derived> 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAssociation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAssociation.class.st
@@ -19,13 +19,6 @@ FamixStAssociation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAssociation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #printing }
 FamixStAssociation >> from [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -15,13 +15,6 @@ FamixStClass class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStClass class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStClass >> accessedAttributes [
 	

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -15,13 +15,6 @@ FamixStComment class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStComment class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixStComment >> belongsTo [
 	

--- a/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
@@ -15,13 +15,6 @@ FamixStContainerEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStContainerEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixStContainerEntity >> numberOfChildren [
 	<MSEProperty: #numberOfChildren type: #Number>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -20,13 +20,6 @@ FamixStEntity class >> metamodel [
 	^ (self class environment at: #FamixPharoSmalltalkGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixStEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixStEntity class >> resetMooseQueryCaches [
 	"Here do nothing. Customize in subclasses."

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
@@ -14,10 +14,3 @@ FamixStInheritance class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixStInheritance class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -15,13 +15,6 @@ FamixStInvocation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStInvocation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'instance creation' }
 FamixStInvocation >> getReceivingFAMIXClass [
 	|tmpReceiver|

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -19,13 +19,6 @@ FamixStMethod class >> annotation [
 ]
 
 { #category : #meta }
-FamixStMethod class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
-{ #category : #meta }
 FamixStMethod class >> shouldSearchForSmalltalkCodeInImage [
 	^ true
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -15,13 +15,6 @@ FamixStNamespace class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStNamespace class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixStNamespace >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
@@ -15,13 +15,6 @@ FamixStPackage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStPackage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixStPackage >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."

--- a/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
@@ -14,10 +14,3 @@ FamixStReference class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixStReference class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSmalltalkSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSmalltalkSourceLanguage.class.st
@@ -13,13 +13,6 @@ FamixStSmalltalkSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStSmalltalkSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixStSmalltalkSourceLanguage >> isSmalltalk [
 	^ true

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -24,13 +24,6 @@ FamixStSourceAnchor class >> parentTypes [
 	^ {}
 ]
 
-{ #category : #meta }
-FamixStSourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'as yet unclassified' }
 FamixStSourceAnchor class >> resetMooseQueryCaches [
 	super resetMooseQueryCaches.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
@@ -15,13 +15,6 @@ FamixStSourceLanguage class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixStSourceLanguage >> isSmalltalk [
 	^ false

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
@@ -14,10 +14,3 @@ FamixStSourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixStSourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
@@ -15,13 +15,6 @@ FamixStSourcedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStSourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixStSourcedEntity >> isImplicitVariable [
 	^false

--- a/src/Famix-PharoSmalltalk-Entities/FamixStStructuralEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStStructuralEntity.class.st
@@ -15,13 +15,6 @@ FamixStStructuralEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStStructuralEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'Famix-Implementation' }
 FamixStStructuralEntity >> entityHasOutgoingTypeDeclarations [
 	^ self declaredType isNotNil

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
@@ -12,10 +12,3 @@ FamixStUnknownSourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixStUnknownSourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
@@ -13,13 +13,6 @@ FamixStUnknownVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStUnknownVariable class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #'moosechef-scoping-filtering' }
 FamixStUnknownVariable >> typeScope [
 	"typeScope does not make sense for an unknown variable,

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
@@ -14,10 +14,3 @@ FamixTest1AbstractFile class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1AbstractFile class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFileAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest1AbstractFileAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1AbstractFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -14,10 +14,3 @@ FamixTest1Association class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1Association class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1Class.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Class.class.st
@@ -14,10 +14,3 @@ FamixTest1Class class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1Class class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1Comment.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Comment.class.st
@@ -14,10 +14,3 @@ FamixTest1Comment class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1Comment class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -20,13 +20,6 @@ FamixTest1Entity class >> metamodel [
 	^ (self class environment at: #FamixTest1Generator) metamodel
 ]
 
-{ #category : #meta }
-FamixTest1Entity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixTest1Entity >> isAccess [
 

--- a/src/Famix-Test1-Entities/FamixTest1File.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1File.class.st
@@ -14,10 +14,3 @@ FamixTest1File class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1File class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest1FileAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1FileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1Folder.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Folder.class.st
@@ -14,10 +14,3 @@ FamixTest1Folder class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1Folder class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest1IndexedFileAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1IndexedFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest1MultipleFileAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1MultipleFileAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
@@ -22,10 +22,3 @@ FamixTest1NamedEntity class >> dependencyFM3PropertyDescription [
 	^ self allDeclaredProperties
 		select: [ :e | e hasOpposite and: [ e opposite isSource or: [ e opposite isTarget ] ] ]
 ]
-
-{ #category : #meta }
-FamixTest1NamedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest1SourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1SourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
@@ -14,10 +14,3 @@ FamixTest1SourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1SourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest1SourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1SourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
@@ -14,10 +14,3 @@ FamixTest1SourcedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest1SourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2Association.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Association.class.st
@@ -14,10 +14,3 @@ FamixTest2Association class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2Association class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -14,10 +14,3 @@ FamixTest2Class class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2Class class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2Comment.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Comment.class.st
@@ -14,10 +14,3 @@ FamixTest2Comment class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2Comment class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -20,13 +20,6 @@ FamixTest2Entity class >> metamodel [
 	^ (self class environment at: #FamixTest2Generator) metamodel
 ]
 
-{ #category : #meta }
-FamixTest2Entity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixTest2Entity >> isAccess [
 

--- a/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
@@ -14,10 +14,3 @@ FamixTest2Inheritance class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2Inheritance class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
@@ -14,10 +14,3 @@ FamixTest2NamedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2NamedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest2SourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2SourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
@@ -14,10 +14,3 @@ FamixTest2SourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2SourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest2SourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2SourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
@@ -14,10 +14,3 @@ FamixTest2SourcedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest2SourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3Association.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Association.class.st
@@ -14,10 +14,3 @@ FamixTest3Association class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3Association class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3Class.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Class.class.st
@@ -14,10 +14,3 @@ FamixTest3Class class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3Class class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3Comment.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Comment.class.st
@@ -14,10 +14,3 @@ FamixTest3Comment class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3Comment class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -20,13 +20,6 @@ FamixTest3Entity class >> metamodel [
 	^ (self class environment at: #FamixTest3Generator) metamodel
 ]
 
-{ #category : #meta }
-FamixTest3Entity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixTest3Entity >> isAccess [
 

--- a/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
@@ -14,10 +14,3 @@ FamixTest3Invocation class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3Invocation class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
@@ -14,10 +14,3 @@ FamixTest3NamedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3NamedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
@@ -14,10 +14,3 @@ FamixTest3PrimitiveType class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3PrimitiveType class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3Reference.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Reference.class.st
@@ -14,10 +14,3 @@ FamixTest3Reference class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3Reference class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest3SourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3SourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
@@ -14,10 +14,3 @@ FamixTest3SourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3SourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
@@ -14,10 +14,3 @@ FamixTest3SourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3SourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
@@ -14,10 +14,3 @@ FamixTest3SourcedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3SourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
@@ -12,10 +12,3 @@ FamixTest4Cafeteria class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest4Cafeteria class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
@@ -12,10 +12,3 @@ FamixTest4Classroom class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest4Classroom class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -23,13 +23,6 @@ FamixTest4Entity class >> metamodel [
 	^ (self class environment at: #FamixTest4Generator) metamodel
 ]
 
-{ #category : #meta }
-FamixTest4Entity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTest4Entity >> name [
 

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -16,13 +16,6 @@ FamixTest4Person class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4Person class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #adding }
 FamixTest4Person >> addBooks: anObject [
 			

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -19,13 +19,6 @@ FamixTest4School class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4School class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #adding }
 FamixTest4School >> addRooms: anObject [
 			

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -15,13 +15,6 @@ FamixTestComposedAssociation class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTestComposedAssociation class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTestComposedAssociation >> c15 [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -20,13 +20,6 @@ FamixTestComposedCustomEntity1 class >> metamodel [
 	^ (self class environment at: #FamixTestComposedGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposedCustomEntity1 class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTestComposedCustomEntity1 >> c21 [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -20,13 +20,6 @@ FamixTestComposedCustomEntity2 class >> metamodel [
 	^ (self class environment at: #FamixTestComposedGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposedCustomEntity2 class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTestComposedCustomEntity2 >> c22s [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -20,13 +20,6 @@ FamixTestComposedCustomEntity3 class >> metamodel [
 	^ (self class environment at: #FamixTestComposedGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposedCustomEntity3 class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTestComposedCustomEntity3 >> c23 [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -20,13 +20,6 @@ FamixTestComposedCustomEntity4 class >> metamodel [
 	^ (self class environment at: #FamixTestComposedGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposedCustomEntity4 class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTestComposedCustomEntity4 >> c24s [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -20,13 +20,6 @@ FamixTestComposedEntity class >> metamodel [
 	^ (self class environment at: #FamixTestComposedGenerator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #accessing }
 FamixTestComposedEntity >> method [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Association.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Association.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1Association class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1Association class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1Class class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1Class class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1Comment class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1Comment class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
@@ -12,10 +12,3 @@ FamixTestComposed1CustomEntity1 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1CustomEntity1 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
@@ -12,10 +12,3 @@ FamixTestComposed1CustomEntity2 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1CustomEntity2 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
@@ -12,10 +12,3 @@ FamixTestComposed1CustomEntity3 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1CustomEntity3 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
@@ -12,10 +12,3 @@ FamixTestComposed1CustomEntity4 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1CustomEntity4 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1CustomEntity5 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1CustomEntity5 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -20,13 +20,6 @@ FamixTestComposed1Entity class >> metamodel [
 	^ (self class environment at: #FamixTestComposedSubmetamodel1Generator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposed1Entity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixTestComposed1Entity >> isAccess [
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1NamedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1NamedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1SourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1SourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1SourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1SourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1SourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1SourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
@@ -14,10 +14,3 @@ FamixTestComposed1SourcedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed1SourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Association.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Association.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2Association class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2Association class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2Class class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2Class class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2Comment class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2Comment class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
@@ -12,10 +12,3 @@ FamixTestComposed2CustomEntity1 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2CustomEntity1 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
@@ -12,10 +12,3 @@ FamixTestComposed2CustomEntity2 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2CustomEntity2 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
@@ -12,10 +12,3 @@ FamixTestComposed2CustomEntity3 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2CustomEntity3 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
@@ -12,10 +12,3 @@ FamixTestComposed2CustomEntity4 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2CustomEntity4 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2CustomEntity5 class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2CustomEntity5 class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -20,13 +20,6 @@ FamixTestComposed2Entity class >> metamodel [
 	^ (self class environment at: #FamixTestComposedSubmetamodel2Generator) metamodel
 ]
 
-{ #category : #meta }
-FamixTestComposed2Entity class >> requirements [
-
-	<generated>
-	^ {  }
-]
-
 { #category : #testing }
 FamixTestComposed2Entity >> isAccess [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2NamedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2NamedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2SourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2SourceAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2SourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2SourceLanguage class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2SourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2SourceTextAnchor class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
@@ -14,10 +14,3 @@ FamixTestComposed2SourcedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTestComposed2SourcedEntity class >> requirements [
-
-	<generated>
-	^ {  }
-]

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -186,6 +186,13 @@ MooseEntity class >> registerAsMooseSubclass: aClass [
 	self mooseSubClasses add: aClass
 ]
 
+{ #category : #accessing }
+MooseEntity class >> requirements [
+	"Used by Famix generator."
+
+	^ {}
+]
+
 { #category : #private }
 MooseEntity class >> resetIDGeneration [ 
 	"Resets the internal ID generation." 

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -370,15 +370,15 @@ MooseModel >> exportToMSEStream: aStream [
 ]
 
 { #category : #actions }
+MooseModel >> flushGroups [
+	self entities do: [ :entity | entity privateState flushGroups ] displayingProgress: [ :entity | 'Cleaning cache of ' , entity mooseName ]
+]
+
+{ #category : #actions }
 MooseModel >> flushPrivateState [
 	"Clean the private state caches of all the entities of the model. This will not impact attributes in the private state (informations you cannot derive)"
 	self flushProperties.
 	self flushGroups
-]
-
-{ #category : #actions }
-MooseModel >> flushGroups [
-	self entities do: [ :entity | entity privateState flushGroups ] displayingProgress: [ :entity | 'Cleaning cache of ' , entity mooseName ]
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Remove all empty requirement methods.Fixes #1696