### PR TITLE
1705-Pharo-Namespaces-can-receive-invocations

### DIFF
--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStNamespace,
 	#superclass : #FamixStScopingEntity,
-	#traits : 'FamixTNamespace',
-	#classTraits : 'FamixTNamespace classTrait',
+	#traits : 'FamixTInvocationsReceiver + FamixTNamespace',
+	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamespace classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -163,6 +163,7 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 
 	namespace --|> scopingEntity.
 	namespace --|> #TNamespace.
+	namespace --|> #TInvocationsReceiver.
 
 	package --|> scopingEntity.
 	package --|> #TPackage.


### PR DESCRIPTION
Modifying Pharo MM to enable Smalltalk (a StNamespace) to be receiver of Invocations.Fixes #1705