### PR TITLE
Remove-method-related-to-obsolete-visitor

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -25,21 +25,6 @@ FAMIXAccess class >> toMethod [
 	^ self lookupSelector: #variable
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXAccess >> accept: aVisitor [
-
-	aVisitor visitAccess: self
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXAccess >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self isWrite: anEntity isWrite.
-	self accessor: (aVisitor visit: anEntity accessor).
-	self variable: (aVisitor visit: anEntity variable).
-]
-
 { #category : #testing }
 FAMIXAccess >> isAccess [
 	^true

--- a/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
@@ -15,24 +15,11 @@ FAMIXAssociation class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXAssociation >> accept: aVisitor [
-
-	aVisitor visitAssociation: self
-]
-
 { #category : #accessing }
 FAMIXAssociation >> anyTo [
 	"This is a utility method that could be used polymorphically to obtain exactly one
 	target entity even when the internal implementation stores these as a collection"
 	^ self to asOrderedCollection anyOne
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXAssociation >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	"self previous: (aVisitor visit: anEntity previous)."
 ]
 
 { #category : #accessing }

--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -25,12 +25,6 @@ FAMIXAttribute class >> requirements [
 	^ { FAMIXType }
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXAttribute >> accept: aVisitor [
-
-	aVisitor visitAttribute: self
-]
-
 { #category : #'Famix-Smalltalk' }
 FAMIXAttribute >> beInstanceVariable [
 
@@ -57,13 +51,6 @@ FAMIXAttribute >> belongsTo: anObject [
 	<generated>
 	self parentType: anObject
 
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXAttribute >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self hasClassScope: anEntity hasClassScope
 ]
 
 { #category : #accessing }

--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -16,12 +16,6 @@ FAMIXBehaviouralEntity class >> annotation [
 ]
 
 { #category : #'Famix-Extensions' }
-FAMIXBehaviouralEntity >> accept: aVisitor [
-
-	aVisitor visitBehaviouralEntity: self
-]
-
-{ #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> clientBehaviours [
 	<MSEProperty: #clientBehaviours type: #FAMIXBehaviouralEntity> <multivalued> <derived>
 	<MSEComment: 'All behaviours that depend on the receiver'>
@@ -44,25 +38,6 @@ FAMIXBehaviouralEntity >> computeNumberOfLinesOfCodeIfSmalltalk [
 	parser := RBVisitorForFAMIXMetrics new.
 	parser processMethod: self usingImporter: nil inModel: nil.
 	^ parser numberOfLinesOfCode
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXBehaviouralEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self signature: anEntity signature copy.
-	self declaredType: (aVisitor visit: anEntity declaredType).
-	
-	anEntity localVariables do: [ :var | 
-		self addLocalVariable: (aVisitor visit: var) ].
-	anEntity parameters do: [ :par | 
-		self addParameter: (aVisitor visit: par) ].
-	anEntity outgoingInvocations do: [ :inv | 
-		aVisitor visit: inv ].
-	anEntity accesses do: [ :acc | 
-		aVisitor visit: acc ].
-	anEntity outgoingReferences do: [:r|
-		aVisitor visit: r ]
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Entities/FAMIXClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXClass.class.st
@@ -18,12 +18,6 @@ FAMIXClass class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions-visitor' }
-FAMIXClass >> accept: aVisitor [
-
-	aVisitor visitClass: self
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FAMIXClass >> accessedAttributes [
 	

--- a/src/Famix-Compatibility-Entities/FAMIXComment.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXComment.class.st
@@ -15,12 +15,6 @@ FAMIXComment class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXComment >> accept: aVisitor [
-
-	aVisitor visitComment: self
-]
-
 { #category : #converting }
 FAMIXComment >> asFAMIXComment [
 	^ self
@@ -30,13 +24,6 @@ FAMIXComment >> asFAMIXComment [
 FAMIXComment >> belongsTo [
 	
 	^ self container
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXComment >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self content: anEntity content copy
 ]
 
 { #category : #printing }

--- a/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
@@ -15,12 +15,6 @@ FAMIXContainerEntity class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXContainerEntity >> accept: aVisitor [
-
-	aVisitor visitContainerEntity: self
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXContainerEntity >> addClass: aClass [
 	
@@ -30,16 +24,6 @@ FAMIXContainerEntity >> addClass: aClass [
 { #category : #accessing }
 FAMIXContainerEntity >> addFunction: aFunction [ 
 	functions add: aFunction
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXContainerEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	anEntity types do: [:t|
-		self addType: (aVisitor visit: t) ].
-
-	
 ]
 
 { #category : #testing }

--- a/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
@@ -22,12 +22,6 @@ FAMIXGlobalVariable class >> requirements [
 	^ { FAMIXScopingEntity }
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXGlobalVariable >> accept: aVisitor [
-
-	aVisitor visitGlobalVariable: self
-]
-
 { #category : #accessing }
 FAMIXGlobalVariable >> belongsTo [
 

--- a/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
@@ -22,11 +22,6 @@ FAMIXImplicitVariable class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXImplicitVariable >> accept: aVisitor [
-	aVisitor visitImplicitVariable: self
-]
-
 { #category : #accessing }
 FAMIXImplicitVariable >> belongsTo [
 
@@ -53,14 +48,6 @@ FAMIXImplicitVariable >> container [
 FAMIXImplicitVariable >> container: aBehaviouralEntity [
 	self deprecated: 'Please use #parentBehaviouralEntity: instead'.
 	^ self parentBehaviouralEntity: aBehaviouralEntity
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXImplicitVariable >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self container: (aVisitor visit: anEntity container).
-
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
@@ -15,20 +15,6 @@ FAMIXInheritance class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXInheritance >> accept: aVisitor [
-
-	aVisitor visitInheritance: self
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXInheritance >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self superclass: (aVisitor visit: anEntity superclass).
-	self subclass: (aVisitor visit: anEntity subclass).
-]
-
 { #category : #'Moose-Hismo' }
 FAMIXInheritance >> historicalUniqueName [
 	

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -16,21 +16,6 @@ FAMIXInvocation class >> annotation [
 ]
 
 { #category : #'Famix-Extensions' }
-FAMIXInvocation >> accept: aVisitor [
-
-	aVisitor visitInvocation: self
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXInvocation >> copyFrom: anEntity within: aVisitor [
-	super copyFrom: anEntity within: aVisitor.
-	self sender: (aVisitor visit: anEntity sender).
-	self receiver: (aVisitor visit: anEntity receiver).
-	self signature: anEntity signature copy.
-	anEntity candidates do: [ :c | self addCandidate: (aVisitor visit: c) ]
-]
-
-{ #category : #'Famix-Extensions' }
 FAMIXInvocation >> getReceivingFAMIXClass [
 	|tmpReceiver|
 	"return the FAMIXClass of the receiver. If the receiver is a FAMIXClass, this one is returned. If it is self or super, the corresponding FAMIXClass is returned. The receiver may not be nil"

--- a/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
@@ -12,9 +12,3 @@ FAMIXLeafEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #visiting }
-FAMIXLeafEntity >> accept: aVisitor [
-
-	aVisitor visitLeafEntity: self
-]

--- a/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
@@ -22,12 +22,6 @@ FAMIXLocalVariable class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXLocalVariable >> accept: aVisitor [
-
-	aVisitor visitLocalVariable: self
-]
-
 { #category : #accessing }
 FAMIXLocalVariable >> belongsTo [
 

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -35,12 +35,6 @@ FAMIXMethod class >> shouldSearchForSmalltalkCodeInImage: anObject [
 	ShouldSearchForSmalltalkCodeInImage := anObject
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXMethod >> accept: aVisitor [
-
-	aVisitor visitMethod: self
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FAMIXMethod >> accessedAttributes [
 	
@@ -115,16 +109,6 @@ FAMIXMethod >> compiledMethod [
 	^ self smalltalkClass  compiledMethodAt: self name asSymbol
 	
 	
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXMethod >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self kind: anEntity kind copy.
-	self protocol: anEntity protocol copy.
-
-
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -33,12 +33,6 @@ FAMIXNamedEntity class >> resetMooseQueryCaches [
 	self resetTEntityMetaLevelDependencyCaches.
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXNamedEntity >> accept: aVisitor [
-
-	aVisitor visitNamedEntity: self
-]
-
 { #category : #accessing }
 FAMIXNamedEntity >> belongsTo [
 	
@@ -49,16 +43,6 @@ FAMIXNamedEntity >> belongsTo [
 FAMIXNamedEntity >> belongsTo: anObject [
 
 	^self subclassResponsibility
-
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXNamedEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self name: anEntity name copy.
-	self isStub: anEntity isStub.
-	self modifiers: (anEntity modifiers collect: #copy)
 
 ]
 

--- a/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
@@ -21,12 +21,6 @@ FAMIXNamespace >> abstractness: aNumber [
 	self privateState propertyAt: #abstractness put: aNumber
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXNamespace >> accept: aVisitor [
-
-	aVisitor visitNamespace: self
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FAMIXNamespace >> afferentCoupling: aNumber [
 

--- a/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
@@ -35,12 +35,6 @@ FAMIXPackage >> abstractness [
 	^ (nsClasses select: [:c | c isAbstract]) size / (nsClasses size)
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXPackage >> accept: aVisitor [
-
-	aVisitor visitPackage: self
-]
-
 { #category : #accessing }
 FAMIXPackage >> addChildNamedEntity: aNamedEntity [
 	childEntities add: aNamedEntity
@@ -183,16 +177,6 @@ FAMIXPackage >> containedEntities [
 { #category : #'Famix-Extensions-accessing' }
 FAMIXPackage >> containedEntities: collection [
 	self definedClasses: collection.
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXPackage >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	
-	anEntity childNamedEntities do: [:c|
-		self addChildNamedEntity: (aVisitor visit: c ) ].
-
 ]
 
 { #category : #'Famix-Smalltalk' }

--- a/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
@@ -22,12 +22,6 @@ FAMIXParameter class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXParameter >> accept: aVisitor [
-
-	aVisitor visitParameter: self
-]
-
 { #category : #accessing }
 FAMIXParameter >> belongsTo [
 

--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -15,20 +15,6 @@ FAMIXReference class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXReference >> accept: aVisitor [
-
-	aVisitor visitReference: self
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXReference >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self source: (aVisitor visit: anEntity source).
-	self target: (aVisitor visit: anEntity target).
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXReference >> mooseNameOn: aStream [
 	"aStream nextPutAll: 'Reference'."

--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -29,12 +29,6 @@ FAMIXScopingEntity >> abstractness [
 	self subclassResponsibility
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXScopingEntity >> accept: aVisitor [
-
-	aVisitor visitScopingEntity: self
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FAMIXScopingEntity >> afferentCoupling [
 	"Afferent coupling for a module is the number of modules that depend upon this module"
@@ -95,18 +89,6 @@ FAMIXScopingEntity >> childrenOfMyKind [
 	"Polymorphic accessor to children of this scope in a hierarchical structure (package->subpackages, scope->subscopes)"
 
 	^ self children allWithSubTypesOf: self class
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXScopingEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	anEntity globalVariables do: [ :glv | 
-		self addGlobalVariable: (aVisitor visit: glv) ].
-	anEntity childScopes do: [ :cs | 
-		self addChildScope: (aVisitor visit: cs) ].
-	anEntity functions do: [ :f | "empty loop in smalltalk models"
-		self addFunction: (aVisitor visit: f) ].
 ]
 
 { #category : #'Famix-Extensions-metrics' }

--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -34,12 +34,6 @@ FAMIXSourceAnchor class >> resetMooseQueryCaches [
 
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXSourceAnchor >> accept: aVisitor [
-
-	aVisitor visitSourceAnchor: self
-]
-
 { #category : #accessing }
 FAMIXSourceAnchor >> belongsTo [ 
 		
@@ -61,13 +55,6 @@ FAMIXSourceAnchor >> containerFiles [
 	"I should return a collection of files corresponding to the source anchor. If there is no file just return an empty collection."
 
 	^ self subclassResponsibility
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXSourceAnchor >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self element: (aVisitor visit: anEntity)
 ]
 
 { #category : #accessing }

--- a/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
@@ -15,12 +15,6 @@ FAMIXSourcedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXSourcedEntity >> accept: aVisitor [
-
-	aVisitor visitEntity: self
-]
-
 { #category : #accessing }
 FAMIXSourcedEntity >> addComment: aComment [
 		comments add: aComment asFAMIXComment
@@ -43,15 +37,6 @@ FAMIXSourcedEntity >> containerFiles: aColl [
 	"This method is a hack for now because we need an opposite to the files."
 
 	
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXSourcedEntity >> copyFrom: anEntity within: aVisitor [
-
-	sourceAnchor := aVisitor visit: anEntity sourceAnchor.
-	anEntity comments do: [:com | 
-		self comments add: (aVisitor visit: com) ].
-
 ]
 
 { #category : #'Famix-SourceAnchor' }

--- a/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
@@ -15,20 +15,6 @@ FAMIXStructuralEntity class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXStructuralEntity >> accept: aVisitor [
-
-	aVisitor visitStructuralEntity: self
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXStructuralEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self declaredType: (aVisitor visit: anEntity declaredType).
-
-]
-
 { #category : #'as yet unclassified' }
 FAMIXStructuralEntity >> entityHasOutgoingTypeDeclarations [
 	^ self declaredType isNotNil

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -22,12 +22,6 @@ FAMIXType class >> requirements [
 	^ { FAMIXContainerEntity }
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXType >> accept: aVisitor [
-
-	aVisitor visitType: self
-]
-
 { #category : #'Famix-Extensions-navigation' }
 FAMIXType >> accessTo: aFAMIXPackageOrFAMIXClass [ 
 
@@ -125,20 +119,6 @@ FAMIXType >> container [
 FAMIXType >> container: aContainer [
 
 	self typeContainer: aContainer
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXType >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-
-	anEntity superInheritances do: [:inh|
-		aVisitor visit: inh ].
-	anEntity attributes do: [:a |
-		self addAttribute: (aVisitor visit: a) ].
-	anEntity methods do: [:m|
-		self addMethod: (aVisitor visit: m) ].
-
 ]
 
 { #category : #'moosequery-queries-incoming' }

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
@@ -13,23 +13,9 @@ FAMIXUnknownVariable class >> annotation [
 	^self
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXUnknownVariable >> accept: aVisitor [
-
-	aVisitor visitUnknownVariable: self
-]
-
 { #category : #accessing }
 FAMIXUnknownVariable >> belongsTo [
 	^ nil
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXUnknownVariable >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self container: (aVisitor visit: anEntity container).
-
 ]
 
 { #category : #'moosechef-scoping-filtering' }

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -16,21 +16,6 @@ FamixJavaAccess class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaAccess >> accept: aVisitor [
-
-	aVisitor visitAccess: self
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaAccess >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self isWrite: anEntity isWrite.
-	self accessor: (aVisitor visit: anEntity accessor).
-	self variable: (aVisitor visit: anEntity variable).
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaAccess >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPutAll: ' (Access)'

--- a/src/Famix-Java-Entities/FamixJavaAssociation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAssociation.class.st
@@ -16,23 +16,10 @@ FamixJavaAssociation class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaAssociation >> accept: aVisitor [
-
-	aVisitor visitAssociation: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaAssociation >> anyTo [
 	"This is a utility method that could be used polymorphically to obtain exactly one
 	target entity even when the internal implementation stores these as a collection"
 	^ self to asOrderedCollection anyOne
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaAssociation >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	"self previous: (aVisitor visit: anEntity previous)."
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -18,12 +18,6 @@ FamixJavaAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaAttribute >> accept: aVisitor [
-
-	aVisitor visitAttribute: self
-]
-
 { #category : #accessing }
 FamixJavaAttribute >> belongsTo [
 
@@ -38,13 +32,6 @@ FamixJavaAttribute >> belongsTo: anObject [
 	<generated>
 	self parentType: anObject
 
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaAttribute >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self hasClassScope: anEntity hasClassScope
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -15,12 +15,6 @@ FamixJavaClass class >> annotation [
 	^self
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaClass >> accept: aVisitor [
-
-	aVisitor visitClass: self
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FamixJavaClass >> accessedAttributes [
 	

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -16,12 +16,6 @@ FamixJavaComment class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaComment >> accept: aVisitor [
-
-	aVisitor visitComment: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaComment >> asFamixJavaComment [
 	^ self
 ]
@@ -30,13 +24,6 @@ FamixJavaComment >> asFamixJavaComment [
 FamixJavaComment >> belongsTo [
 	
 	^ self container
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaComment >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self content: anEntity content copy
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -16,25 +16,9 @@ FamixJavaContainerEntity class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaContainerEntity >> accept: aVisitor [
-
-	aVisitor visitContainerEntity: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaContainerEntity >> addClass: aClass [
 	
 	types add: aClass
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaContainerEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	anEntity types do: [:t|
-		self addType: (aVisitor visit: t) ].
-
-	
 ]
 
 { #category : #testing }

--- a/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
@@ -22,12 +22,6 @@ FamixJavaGlobalVariable class >> requirements [
 	^ { FamixJavaScopingEntity }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaGlobalVariable >> accept: aVisitor [
-
-	aVisitor visitGlobalVariable: self
-]
-
 { #category : #accessing }
 FamixJavaGlobalVariable >> belongsTo [
 

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -22,11 +22,6 @@ FamixJavaImplicitVariable class >> requirements [
 	^ { FamixJavaMethod }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaImplicitVariable >> accept: aVisitor [
-	aVisitor visitImplicitVariable: self
-]
-
 { #category : #accessing }
 FamixJavaImplicitVariable >> belongsTo [
 
@@ -53,14 +48,6 @@ FamixJavaImplicitVariable >> container [
 FamixJavaImplicitVariable >> container: aBehaviouralEntity [
 	self deprecated: 'Please use #parentBehaviouralEntity: instead'.
 	^ self parentBehaviouralEntity: aBehaviouralEntity
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaImplicitVariable >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self container: (aVisitor visit: anEntity container).
-
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -16,20 +16,6 @@ FamixJavaInheritance class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaInheritance >> accept: aVisitor [
-
-	aVisitor visitInheritance: self
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaInheritance >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self superclass: (aVisitor visit: anEntity superclass).
-	self subclass: (aVisitor visit: anEntity subclass).
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaInheritance >> historicalUniqueName [
 	
 	^(self subclass mooseName , '->' , self superclass mooseName) asSymbol

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -16,21 +16,6 @@ FamixJavaInvocation class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaInvocation >> accept: aVisitor [
-
-	aVisitor visitInvocation: self
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaInvocation >> copyFrom: anEntity within: aVisitor [
-	super copyFrom: anEntity within: aVisitor.
-	self sender: (aVisitor visit: anEntity sender).
-	self receiver: (aVisitor visit: anEntity receiver).
-	self signature: anEntity signature copy.
-	anEntity candidates do: [ :c | self addCandidate: (aVisitor visit: c) ]
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaInvocation >> getReceivingFAMIXClass [
 	|tmpReceiver|
 	"return the FAMIXClass of the receiver. If the receiver is a FAMIXClass, this one is returned. If it is self or super, the corresponding FAMIXClass is returned. The receiver may not be nil"

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -22,12 +22,6 @@ FamixJavaLocalVariable class >> requirements [
 	^ { FamixJavaMethod }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaLocalVariable >> accept: aVisitor [
-
-	aVisitor visitLocalVariable: self
-]
-
 { #category : #accessing }
 FamixJavaLocalVariable >> belongsTo [
 

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -15,12 +15,6 @@ FamixJavaMethod class >> annotation [
 	^self
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaMethod >> accept: aVisitor [
-
-	aVisitor visitMethod: self
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FamixJavaMethod >> accessedAttributes [
 	
@@ -79,16 +73,6 @@ FamixJavaMethod >> clientPackages [
 	"returns a set of all the packages that depend on the receiver"
 
 	^ (self queryAllIncoming atScope: FamixTPackage) withoutSelfLoops
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaMethod >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self kind: anEntity kind copy.
-	"self category: anEntity category copy."
-
-
 ]
 
 { #category : #'moosequery-queries-generic' }

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -30,12 +30,6 @@ FamixJavaNamedEntity class >> resetMooseQueryCaches [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaNamedEntity >> accept: aVisitor [
-
-	aVisitor visitNamedEntity: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaNamedEntity >> belongsTo [
 	
 	^self subclassResponsibility
@@ -45,16 +39,6 @@ FamixJavaNamedEntity >> belongsTo [
 FamixJavaNamedEntity >> belongsTo: anObject [
 
 	^self subclassResponsibility
-
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaNamedEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self name: anEntity name copy.
-	self isStub: anEntity isStub.
-	self modifiers: (anEntity modifiers collect: #copy)
 
 ]
 

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -36,12 +36,6 @@ FamixJavaNamespace >> abstractness: aNumber [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaNamespace >> accept: aVisitor [
-
-	aVisitor visitNamespace: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaNamespace >> afferentCoupling [
 	<MSEProperty: #afferentCoupling type: #Number>
 	<derived>

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -35,12 +35,6 @@ FamixJavaPackage >> abstractness [
 	^ (nsClasses select: [ :c | c isAbstract ]) size / nsClasses size
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaPackage >> accept: aVisitor [
-
-	aVisitor visitPackage: self
-]
-
 { #category : #adding }
 FamixJavaPackage >> addChildNamedEntity: aNamedEntity [
 	childEntities add: aNamedEntity
@@ -153,16 +147,6 @@ FamixJavaPackage >> containedEntities [
 { #category : #'Famix-Extensions-accessing' }
 FamixJavaPackage >> containedEntities: collection [
 	self definedClasses: collection.
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaPackage >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	
-	anEntity childEntities do: [:c|
-		self addChildNamedEntity: (aVisitor visit: c ) ].
-
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -22,12 +22,6 @@ FamixJavaParameter class >> requirements [
 	^ { FamixJavaMethod }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaParameter >> accept: aVisitor [
-
-	aVisitor visitParameter: self
-]
-
 { #category : #accessing }
 FamixJavaParameter >> belongsTo [
 

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -16,20 +16,6 @@ FamixJavaReference class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaReference >> accept: aVisitor [
-
-	aVisitor visitReference: self
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaReference >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self source: (aVisitor visit: anEntity source).
-	self target: (aVisitor visit: anEntity target).
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaReference >> mooseNameOn: aStream [
 	"aStream nextPutAll: 'Reference'."
 

--- a/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
@@ -29,12 +29,6 @@ FamixJavaScopingEntity >> abstractness [
 	self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaScopingEntity >> accept: aVisitor [
-
-	aVisitor visitScopingEntity: self
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixJavaScopingEntity >> afferentCoupling [
 	"Afferent coupling for a module is the number of modules that depend upon this module"
@@ -89,18 +83,6 @@ FamixJavaScopingEntity >> childrenOfMyKind [
 	"Polymorphic accessor to children of this scope in a hierarchical structure (package->subpackages, scope->subscopes)"
 
 	^ self children allWithSubTypesOf: self class
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaScopingEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	anEntity globalVariables do: [ :glv | 
-		self addGlobalVariable: (aVisitor visit: glv) ].
-	anEntity childScopes do: [ :cs | 
-		self addChildScope: (aVisitor visit: cs) ].
-	anEntity functions do: [ :f | "empty loop in smalltalk models"
-		self addFunction: (aVisitor visit: f) ].
 ]
 
 { #category : #'Famix-Extensions-metrics' }

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -35,12 +35,6 @@ FamixJavaSourceAnchor class >> resetMooseQueryCaches [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaSourceAnchor >> accept: aVisitor [
-
-	aVisitor visitSourceAnchor: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaSourceAnchor >> completeText [
 	"The complete text of a FileAnchor contains all the code of the file pointed by the source anchor. On the contrary the #sourceText return only the pant of the file concerned by the entity. For example a FAMIXFileAnchon knows the start line and end line of the source anchor into the file."
 	
@@ -54,13 +48,6 @@ FamixJavaSourceAnchor >> containerFiles [
 	"I should return a collection of files corresponding to the source anchor. If there is no file just return an empty collection."
 
 	^ self subclassResponsibility
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaSourceAnchor >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self element: (aVisitor visit: anEntity)
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
@@ -15,12 +15,6 @@ FamixJavaSourcedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaSourcedEntity >> accept: aVisitor [
-
-	aVisitor visitEntity: self
-]
-
 { #category : #removing }
 FamixJavaSourcedEntity >> addComment: aComment [
 	comments add: aComment asFamixJavaComment
@@ -43,15 +37,6 @@ FamixJavaSourcedEntity >> containerFiles: aColl [
 	"This method is a hack for now because we need an opposite to the files."
 
 	
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaSourcedEntity >> copyFrom: anEntity within: aVisitor [
-
-	sourceAnchor := aVisitor visit: anEntity sourceAnchor.
-	anEntity comments do: [:com | 
-		self comments add: (aVisitor visit: com) ].
-
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaStructuralEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaStructuralEntity.class.st
@@ -16,20 +16,6 @@ FamixJavaStructuralEntity class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaStructuralEntity >> accept: aVisitor [
-
-	aVisitor visitStructuralEntity: self
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaStructuralEntity >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self declaredType: (aVisitor visit: anEntity declaredType).
-
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaStructuralEntity >> entityHasOutgoingTypeDeclarations [
 	^ self declaredType isNotNil
 ]

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -22,12 +22,6 @@ FamixJavaType class >> requirements [
 	^ { FamixJavaContainerEntity }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixJavaType >> accept: aVisitor [
-
-	aVisitor visitType: self
-]
-
 { #category : #'Famix-Java' }
 FamixJavaType >> allAnnotationInstances [
 	| result |
@@ -100,20 +94,6 @@ FamixJavaType >> container [
 FamixJavaType >> container: aContainer [
 
 	self typeContainer: aContainer
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaType >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-
-	anEntity superInheritances do: [:inh|
-		aVisitor visit: inh ].
-	anEntity attributes do: [:a |
-		self addAttribute: (aVisitor visit: a) ].
-	anEntity methods do: [:m|
-		self addMethod: (aVisitor visit: m) ].
-
 ]
 
 { #category : #'moosequery-queries-incoming' }

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -14,22 +14,8 @@ FamixJavaUnknownVariable class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaUnknownVariable >> accept: aVisitor [
-
-	aVisitor visitUnknownVariable: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaUnknownVariable >> belongsTo [
 	^ nil
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaUnknownVariable >> copyFrom: anEntity within: aVisitor [
-
-	super copyFrom: anEntity within: aVisitor.
-	self container: (aVisitor visit: anEntity container).
-
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -317,10 +317,6 @@ MooseEntity >> children [
 	^children
 ]
 
-{ #category : #'Famix-Extensions' }
-MooseEntity >> copyFrom: anEntity within: aVisitor [
-]
-
 { #category : #private }
 MooseEntity >> defaultStateClass [
 	"Answer the default implementator of this element's state."

--- a/src/Moose-Tests-Core/MooseEntityTest.class.st
+++ b/src/Moose-Tests-Core/MooseEntityTest.class.st
@@ -95,14 +95,6 @@ MooseEntityTest >> testBookmark [
 ]
 
 { #category : #tests }
-MooseEntityTest >> testCopyFromWithin [
-
-	| entity |
-	entity := MooseEntity new.
-	self assert: (entity copyFrom: nil within: nil) == entity
-]
-
-{ #category : #tests }
 MooseEntityTest >> testEntityBackLink [
 	"self debug: #testEntityBackLink"
 	


### PR DESCRIPTION
Remove methods that were used with visitors before since the visitors are not in the image anymore.