### PR TITLE
Speedup-access-to-all-types-with-traits

### DIFF
--- a/src/Moose-Core/MooseGroupRuntimeStorage.class.st
+++ b/src/Moose-Core/MooseGroupRuntimeStorage.class.st
@@ -139,13 +139,11 @@ MooseGroupRuntimeStorage >> selectAllWithType: aSmalltalkType [
 	^ byType
 		at: aSmalltalkType
 		ifAbsent: [ | result |
-			result := self class byTypeDefaultCollection.
+			result := Set new.
 			byType keys
 				select: [ :aClass | aClass isOfType: aSmalltalkType ]
-				thenDo: [ :aKey | 
-					(byType at: aKey)
-						do: [ :anElement | result addIfNotPresent: anElement ] ].
-			result ]
+				thenDo: [ :aKey | (byType at: aKey) do: [ :anElement | result add: anElement ] ].
+			self class byTypeDefaultCollection addAll: result ]
 ]
 
 { #category : #private }

--- a/src/Moose-Tests-Core/MooseModelTestResource.class.st
+++ b/src/Moose-Tests-Core/MooseModelTestResource.class.st
@@ -20,8 +20,12 @@ MooseModelTestResource >> model [
 ]
 
 { #category : #setup }
-MooseModelTestResource >> setUp [ 
-	 
-	model := MooseModel new. 
+MooseModelTestResource >> modelClass [
+	^ MooseModel
+]
+
+{ #category : #setup }
+MooseModelTestResource >> setUp [
+	model := self modelClass new.
 	self importModel
 ]

--- a/src/Moose-Tests-Core/MooseModelTestResourceWithSmalltalkDependency.class.st
+++ b/src/Moose-Tests-Core/MooseModelTestResourceWithSmalltalkDependency.class.st
@@ -10,6 +10,11 @@ MooseModelTestResourceWithSmalltalkDependency >> metamodelFactory [
 	^ SmalltalkCompatibilityMetamodelFactory
 ]
 
+{ #category : #setup }
+MooseModelTestResourceWithSmalltalkDependency >> modelClass [
+	^ FamixStMooseModel
+]
+
 { #category : #'as yet unclassified' }
 MooseModelTestResourceWithSmalltalkDependency >> newImportClassesTask [
 	

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
@@ -60,17 +60,11 @@ FAMIXStepwiseImporterTest >> testCheckSelfIsCreated [
 
 { #category : #tests }
 FAMIXStepwiseImporterTest >> testClassVariable [
-
-	| model importer |
+	| model |
 	self timeLimit: 60 seconds.
-	model := MooseModel new.
-	model name: 'Morphic'.
-	importer := self newPharoImporterTask.
-	importer importingContext mergeClassAndMetaclass.
-	importer runCandidateOperator.
-	importer model: model; addFromPackagesNamed: (MooseScripts packageNamesFor: 'Morphic*'); runWithProgress.
-	 
-	self shouldnt: [(model entities select: [:e | e isKindOf: FAMIXUnknownVariable ]) do: #typeScope ] raise: Error
+	model := MooseMorphicTestResource current model.
+
+	self shouldnt: [ (model entities select: [ :e | e isKindOf: FAMIXUnknownVariable ]) do: #typeScope ] raise: Error
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/MooseMorphicTestResource.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/MooseMorphicTestResource.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #MooseMorphicTestResource,
+	#superclass : #MooseModelTestResourceWithSmalltalkDependency,
+	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+}
+
+{ #category : #setup }
+MooseMorphicTestResource >> importModel [
+	| importer |
+	importer := self newPharoImporterTask.
+	importer importingContext mergeClassAndMetaclass.
+	importer
+		runCandidateOperator;
+		model: model;
+		addFromPackagesNamed: (MooseScripts packageNamesFor: 'Morphic*');
+		runWithProgress
+]


### PR DESCRIPTION
Speedup #allWithTypes: for traits + extract the setup of a method as a test resource