### PR TITLE
Add until for moose query

### DIFF
--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -76,6 +76,15 @@ MooseQueryTest >> testAllAtAnyScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllAtAnyScopeUntil [
+	self assertCollection: (class1 allAtAnyScope: {FAMIXPackage} until: [:famixEntity | famixEntity isOfType: FAMIXClass ]) hasSameElements: {}.
+	self assertCollection: (class1 allAtAnyScope: {FAMIXClass . FAMIXPackage} until: [:famixEntity | famixEntity isOfType: FAMIXClass ]) hasSameElements: {class1}.
+	
+	self assertCollection: (class1 allAtAnyScope: {FamixTPackage} until: [:famixEntity | famixEntity isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 allAtAnyScope: {FamixTClass . FamixTPackage}until: [:famixEntity | famixEntity isOfType: FamixTClass ]) hasSameElements: {class1}.
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAllAtScope [
 	| package3 |
 	self assertCollection: (class1 allAtScope: FamixTClass) hasSameElements: {class1}.
@@ -101,6 +110,32 @@ MooseQueryTest >> testAllAtScope [
 			{namespace.
 			package1.
 			package3}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testAllAtScopeUntil [
+	| package3 |
+	self assertCollection: (class1 allAtScope: FamixTClass until: [:famixEntity | famixEntity isOfType: FamixTClass ]) hasSameElements: {class1}.
+	self assertCollection: (class1 allAtScope: FamixTType until: [:famixEntity | famixEntity isOfType: FamixTClass ]) hasSameElements: {class1}.
+	self assertCollection: (class1 allAtScope: FamixTPackage until: [:famixEntity | famixEntity isOfType: FamixTClass ]) hasSameElements: {}.
+	self
+		assertCollection: (class1 allAtScope: FamixTScopingEntity  until: [:famixEntity | famixEntity isOfType: FamixTPackage ])
+		hasSameElements:
+			{namespace.
+			package1}.
+	package3 := FAMIXPackage new
+		name: 'package3';
+		mooseModel: model.
+	package1 parentPackage: package3.
+	self
+		assertCollection: (class1 allAtScope: FamixTPackage until: [:famixEntity | famixEntity name = 'package1' ])
+		hasSameElements:
+			{package1}.
+	self
+		assertCollection: (class1 allAtScope: FamixTScopingEntity until: [:famixEntity | famixEntity name = 'package1' ])
+		hasSameElements:
+			{namespace.
+			package1}
 ]
 
 { #category : #tests }
@@ -140,6 +175,12 @@ MooseQueryTest >> testAllToAnyScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllToAnyScopeUntil [
+	self assertCollection: (class2 allToAnyScope: {FAMIXMethod . FAMIXLocalVariable} until: [:entity | entity isOfType: FAMIXMethod ]) hasSameElements: {method2 . method3 . methodExt }.
+	self assertCollection: (class2 allToAnyScope: {FAMIXMethod . FAMIXStructuralEntity} until: [:entity | entity isOfType: FAMIXMethod ]) hasSameElements: {method2 . method3 . methodExt . var1 . var2 }.
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAllToScope [
 	| class3 |
 	self assertCollection: (class1 allToScope: FamixTMethod) hasSameElements: {method1}.
@@ -155,11 +196,33 @@ MooseQueryTest >> testAllToScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllToScopeUntil [
+	| class3 |
+	self assertCollection: (class2 allToScope: FAMIXStructuralEntity until: [:entity | entity isOfType: FamixTMethod ]) hasSameElements: {var1 . var2 }.
+	self assertCollection: (package1 allToScope: FamixTClass until: [:entity | entity isOfType: FamixTPackage ]) hasSameElements: {}.
+	self assertCollection: (package1 allToScope: FamixTClass until: [:entity | entity isOfType: FamixTClass ]) hasSameElements: {class1}.
+	class3 := FAMIXClass new
+		name: 'class3';
+		container: class1;
+		mooseModel: model.
+	self assertCollection: (class1 allToScope: FamixTClass until: [:entity | entity name = 'class1']) hasSameElements: {class1}.
+	self assertCollection: (package1 allToScope: FamixTClass until: [:entity | entity name = 'class1']) hasSameElements: {class1}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAllWithAnyScope [
 	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt}.
 	self assertCollection: (class2 allWithAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class2. package2}.
 	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}.
 	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FAMIXStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2 . localVariable}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testAllWithAnyScopeUntil [
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute} until: [:el | el isOfType: FamixTClass]) hasSameElements: {}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTClass . FamixTPackage} until: [:el | el isOfType: FamixTClass]) hasSameElements: {class2}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage} until: [:el | el isOfType: FamixTClass]) hasSameElements: {}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FAMIXStructuralEntity . FamixTPackage} until: [:el | el isOfType: FamixTMethod]) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2 }
 ]
 
 { #category : #tests }
@@ -207,6 +270,31 @@ MooseQueryTest >> testAllWithScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAllWithScopeUntil [
+	| package3 class3 |
+	self assertCollection: (class1 allWithScope: FamixTMethod until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method1}.
+	self assertCollection: (class1 allWithScope: FamixTMethod until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 allWithScope: FamixTPackage until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 allWithScope: FamixTPackage until: [ :el | el isOfType: FamixTPackage ]) hasSameElements: {package1}.
+	package3 := FAMIXPackage new
+		name: 'package3';
+		mooseModel: model.
+	package1 parentPackage: package3.
+	class3 := FAMIXClass new
+		name: 'class3';
+		container: class1;
+		mooseModel: model.
+	self assertCollection: (class1 allWithScope: FamixTClass until: [ :el | el name = 'class1' ]) hasSameElements: {class1}.
+	self assertCollection: (class1 allWithScope: FamixTClass until: [ :el | el name = 'class3' ]) hasSameElements: {class1 . class3}.
+	self assertCollection: (class1 allWithScope: FamixTType until: [ :el | el name = 'class1' ]) hasSameElements: {class1}.
+	self assertCollection: (class1 allWithScope: FamixTType until: [ :el | el name = 'class3' ]) hasSameElements: {class1 . class3}.
+	self assertCollection: (class1 allWithScope: FamixTPackage until: [ :el | el name = 'package1' ]) hasSameElements: {package1}.
+	self assertCollection: (class1 allWithScope: FamixTPackage until: [ :el | el name = 'package3' ]) hasSameElements: {package1 . package3}.
+	self assertCollection: (class1 allWithScope: FamixTScopingEntity until: [ :el | el name = 'package1' ]) hasSameElements: {package1 . namespace}.
+	self assertCollection: (class1 allWithScope: FamixTScopingEntity until: [ :el | el name = 'package3' ]) hasSameElements: {package1 . package3 . namespace}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAtAnyScope [
 	self assertCollection: (class1 atAnyScope: {FAMIXClass}) hasSameElements: {class1}.
 	self assertCollection: (class1 atAnyScope: {FAMIXPackage}) hasSameElements: {package1}.
@@ -220,6 +308,20 @@ MooseQueryTest >> testAtAnyScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testAtAnyScopeUntil [
+	self assertCollection: (class1 atAnyScope: {FAMIXPackage} until: [ :entity | entity isOfType: FamixTPackage ]) hasSameElements: {package1}.
+	self assertCollection: (class1 atAnyScope: {FAMIXPackage} until: [ :entity | entity isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 atAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {class1}.
+	self assertCollection: (class1 atAnyScope: {FamixTClass} until: [ :entity | entity isOfType: FamixTClass ]) hasSameElements: {class1}.
+	self assertCollection: (class1 atAnyScope: {FamixTPackage}) hasSameElements: {package1}.
+	self assertCollection: (class1 atAnyScope: {FamixTPackage} until: [ :entity | entity isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 atAnyScope: {FamixTClass . FamixTPackage} until: [ :entity | entity isOfType: FamixTClass ]) hasSameElements: {class1}.
+	"the lookup for the methodExt does not go through the class"
+	self assertCollection: (methodExt atAnyScope: {FAMIXPackage} until: [ :entity | entity isOfType: FamixTMethod ]) hasSameElements: {}.
+	self assertCollection: (methodExt atAnyScope: {FAMIXPackage} until: [ :entity | entity isOfType: FamixTPackage ]) hasSameElements: {package1 . package2}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testAtScope [
 	self assertCollection: (class1 atScope: FAMIXClass) hasSameElements: {class1}.
 	self assertCollection: (class1 atScope: FamixTType) hasSameElements: {class1}.
@@ -229,6 +331,13 @@ MooseQueryTest >> testAtScope [
 		hasSameElements:
 			{namespace.
 			package1}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testAtScopeUntil [
+	self assertCollection: (class1 atScope: FAMIXClass until: [:el | el isOfType: FamixTClass ]) hasSameElements: {class1}.
+	self assertCollection: (class1 atScope: FamixTPackage until: [:el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 atScope: FamixTPackage until: [:el | el isOfType: FamixTPackage ]) hasSameElements: {package1}.
 ]
 
 { #category : #tests }
@@ -489,14 +598,6 @@ MooseQueryTest >> testQueryWith [
 ]
 
 { #category : #tests }
-MooseQueryTest >> testToAnyScope [
-	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXAttribute}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
-	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXStructuralEntity}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
-	self assertCollection: (class2 toAnyScope: {FAMIXClass . FAMIXMethod}) hasSameElements: {class2}.
-	self assertCollection: (method1 toAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {}
-]
-
-{ #category : #tests }
 MooseQueryTest >> testSourceThroughAll [
 	self assertCollection: (method2 throughAllFrom) storage flattened hasSameElements: {method2 . method1 . method3}.
 	self assertCollection: (class2 throughAllFrom) storage flattened hasSameElements:  {method2 . method1 . method3 . class1}
@@ -540,11 +641,40 @@ MooseQueryTest >> testThroughAllFrom [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testToAnyScope [
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXAttribute}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXStructuralEntity}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXClass . FAMIXMethod}) hasSameElements: {class2}.
+	self assertCollection: (method1 toAnyScope: {FAMIXClass . FAMIXPackage}) hasSameElements: {}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testToAnyScopeUntil [
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXAttribute} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXAttribute} until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXStructuralEntity} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXMethod . FAMIXStructuralEntity} until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class2 toAnyScope: {FAMIXClass . FamixTLocalVariable} until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {class2}.
+	self assertCollection: (class2 toAnyScope: {FAMIXClass . FamixTLocalVariable} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {class2}.
+]
+
+{ #category : #tests }
 MooseQueryTest >> testToScope [
 	self assertCollection: (class1 toScope: FAMIXMethod) hasSameElements: {method1}.
 	self assertCollection: (class2 toScope: FAMIXAttribute) hasSameElements: {var1 . var2}.
 	self assertCollection: (class2 toScope: FAMIXStructuralEntity) hasSameElements: {var1 . var2. localVariable}.
 	self assertCollection: (package1 toScope: FAMIXMethod) hasSameElements: {method1 . methodExt}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testToScopeUntil [
+	self assertCollection: (class1 toScope: FAMIXMethod until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class1 toScope: FAMIXMethod until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method1}.
+	self assertCollection: (class2 toScope: FAMIXAttribute until: [ :el | el isOfType: FamixTAttribute ]) hasSameElements: {var1 . var2}.
+	self assertCollection: (class2 toScope: FAMIXAttribute until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {var1 . var2}.
+	self assertCollection: (class2 toScope: FAMIXStructuralEntity  until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {var1 . var2}.
+	self assertCollection: (class2 toScope: FAMIXStructuralEntity until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class2 toScope: FAMIXStructuralEntity until: [ :el | el isOfType: FamixTStructuralEntity ]) hasSameElements: {var1. var2. localVariable}.
 ]
 
 { #category : #tests }
@@ -571,6 +701,11 @@ MooseQueryTest >> testWithAnyScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testWithAnyScopeUntil [
+	self assertCollection: (class1 withAnyScope: {FamixTMethod . FAMIXStructuralEntity . FamixTPackage} until: [:el | el isOfType: FamixTClass ]) hasSameElements: {}
+]
+
+{ #category : #tests }
 MooseQueryTest >> testWithScope [
 	self assertCollection: (class1 withScope: FamixTMethod) hasSameElements: {method1}.
 	self
@@ -591,6 +726,19 @@ MooseQueryTest >> testWithScope [
 		hasSameElements:
 			{package1.
 			namespace}
+]
+
+{ #category : #tests }
+MooseQueryTest >> testWithScopeUntil [
+	self assertCollection: (class1 withScope: FamixTMethod until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method1}.
+	self assertCollection: (class1 withScope: FamixTMethod until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (class2 toScope: FamixTAttribute until: [ :el | el isOfType: FamixTAttribute ]) hasSameElements: {var1 . var2}.
+	self assertCollection: (class2 toScope: FamixTAttribute until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
+	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTPackage ]) hasSameElements: {}.
+	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTClass ]) hasSameElements: { methodExt }.
+	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method1 . methodExt}.
+	self assertCollection: (class1 withScope: FamixTPackage until: [:el | el isOfType: FamixTPackage]) hasSameElements: {package1}.
+	self assertCollection: (class1 withScope: FamixTPackage until: [:el | el isOfType: FamixTClass]) hasSameElements: {}.
 ]
 
 { #category : #tests }

--- a/src/Moose-Query/Collection.extension.st
+++ b/src/Moose-Query/Collection.extension.st
@@ -7,8 +7,20 @@ Collection >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+Collection >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) allAtAnyScope: aCollectionOfFamixClasses in: aCollection  until: aRejectBlock ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> allAtScope: aFAMIXScope in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) allAtScope: aFAMIXScope in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> allAtScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) allAtScope: aFAMIXScope in: aCollection until: aRejectBlock ].
 	^ aCollection
 ]
 
@@ -19,8 +31,20 @@ Collection >> allToAnyScope: aCollectionOfFamixClasses in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+Collection >> allToAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) allToAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> allToScope: aFAMIXScope in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) allToScope: aFAMIXScope in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> allToScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) allToScope: aFAMIXScope in: aCollection until: aRejectBlock ].
 	^ aCollection
 ]
 
@@ -31,8 +55,20 @@ Collection >> allWithScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+Collection >> allWithScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) allWithScope: aFAMIXScope in: aCollection until: aRejectBlock ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> atAnyScope: aCollectionOfFamixScopes in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) atAnyScope: aCollectionOfFamixScopes in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> atAnyScope: aCollectionOfFamixScopes in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) atAnyScope: aCollectionOfFamixScopes in: aCollection until: aRejectBlock ].
 	^ aCollection
 ]
 
@@ -43,8 +79,20 @@ Collection >> atScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+Collection >> atScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) atScope: aFAMIXScope in: aCollection until: aRejectBlock ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> toAnyScope: aCollectionOfFamixClasses in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) toAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> toAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) toAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock ].
 	^ aCollection
 ]
 
@@ -55,7 +103,19 @@ Collection >> toScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+Collection >> toScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) toScope: aFAMIXScope in: aCollection until: aRejectBlock ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 Collection >> withScope: aFAMIXScope in: aCollection [
 	1 to: self size do: [ :ind | (self at: ind) withScope: aFAMIXScope in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+Collection >> withScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	1 to: self size do: [ :ind | (self at: ind) withScope: aFAMIXScope in: aCollection until: aRejectBlock ].
 	^ aCollection
 ]

--- a/src/Moose-Query/MooseEntity.extension.st
+++ b/src/Moose-Query/MooseEntity.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #MooseEntity }
-
-{ #category : #'*Moose-Query' }
-MooseEntity class >> inheritsFromType: aClassFAMIX [
-	^ ({self} , self usedStatefulTraits flatCollect: #withAllSuperclasses as: Set) includes: aClassFAMIX
-]

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -212,13 +212,25 @@ TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses [
 
 { #category : #private }
 TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection [
+	^ self allAtAnyScope: aCollectionOfFamixClasses in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock [
 	| selectors |
 	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self isOfType: aFAMIXClass ]) ifTrue: [ aCollection add: self ].
-
-	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
-	1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	(rejectBlock value: self)
+		ifFalse: [ 1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ] ].
 
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allAtAnyScope: aCollectionOfFamixClasses until: rejectBlock [
+	"I am used to return all the encountered entities (recursively) at matching one of the class scope given as parameter that are up in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self allAtAnyScope: aCollectionOfFamixClasses in: OrderedCollection new until: rejectBlock ) asSet asArray
 ]
 
 { #category : #scoping }
@@ -231,13 +243,26 @@ TEntityMetaLevelDependency >> allAtScope: aClassFAMIX [
 
 { #category : #private }
 TEntityMetaLevelDependency >> allAtScope: aClassFAMIX in: aCollection [
+	^ self allAtScope: aClassFAMIX in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allAtScope: aClassFAMIX in: aCollection until: rejectBlock [
 	| selectors |
-	(self isOfType: aClassFAMIX) ifTrue: [ aCollection add: self ].	
-	
+	(self isOfType: aClassFAMIX) ifTrue: [ aCollection add: self ].
+
 	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
-	1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtScope: aClassFAMIX in: aCollection ].
-	
+	(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allAtScope: aClassFAMIX in: aCollection until: rejectBlock ] ].
+
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allAtScope: aClassFAMIX until: rejectBlock [
+	"I am used to return all the entities at a given famix class scope that are up in the containment tree of the metamodel on multiple levels.
+	I stop the recursion when the rejectBlock is true."
+
+	^ (self allAtScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #accessing }
@@ -304,13 +329,25 @@ TEntityMetaLevelDependency >> allToAnyScope: aCollectionOfFamixClasses [
 
 { #category : #private }
 TEntityMetaLevelDependency >> allToAnyScope: aCollectionOfFamixClasses in: aCollection [
+	^ self allToAnyScope: aCollectionOfFamixClasses in: aCollection until: self falseBlock
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allToAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock [
 	| selectors |
 	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self isOfType: aFAMIXClass ]) ifTrue: [ aCollection add: self ].
 
-	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
-	1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allToAnyScope: aCollectionOfFamixClasses in: aCollection  until: rejectBlock ] ].
 
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allToAnyScope: aCollectionOfFamixClasses until: rejectBlock [
+	"I am used to return all the encountered entities (recursively) at matching one of the class scope given as parameter that are down in the containment tree of the metamodel
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self allToAnyScope: aCollectionOfFamixClasses in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #scoping }
@@ -323,13 +360,27 @@ TEntityMetaLevelDependency >> allToScope: aClassFAMIX [
 
 { #category : #private }
 TEntityMetaLevelDependency >> allToScope: aClassFAMIX in: aCollection [
+	^ self allToScope: aClassFAMIX in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allToScope: aClassFAMIX in: aCollection until: rejectBlock [
 	| selectors |
-	(self isOfType: aClassFAMIX) ifTrue: [ aCollection add: self ].	
-		
+	(self isOfType: aClassFAMIX) ifTrue: [ aCollection add: self ].
+
 	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
-	1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allToScope: aClassFAMIX in: aCollection ].
-	
+	(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) allToScope: aClassFAMIX in: aCollection until: rejectBlock ] ].
+
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allToScope: aClassFAMIX until: rejectBlock [
+	"I am used to return all the entities at a given famix class scope that are down in the containment tree of the metamodel on multiple levels.
+	I stop the recursion when the rejectBlock is true"
+
+	self flag: #todo.	"I think we do not need the #asArray cast but it will break tests. I will probably let it now then change the tests later. Step by step."
+	^ (self allToScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #scoping }
@@ -341,15 +392,28 @@ TEntityMetaLevelDependency >> allWithAnyScope: aCollectionOfFamixClasses [
 
 { #category : #private }
 TEntityMetaLevelDependency >> allWithAnyScope: aCollectionOfFamixClasses in: aCollection [
-	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self class traits includes: aFAMIXClass ]) ifTrue: [ self allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
+	^ self allWithAnyScope: aCollectionOfFamixClasses in: aCollection until: self falseBlock
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> allWithAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock [
+	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self class traits includes: aFAMIXClass ]) ifTrue: [ self allToAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ].
 
 	self allParentTypes
 		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass inheritsFrom: class ] ] ]
-		ifFound: [ self allAtAnyScope: aCollectionOfFamixClasses in: aCollection ].
+		ifFound: [ self allAtAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ].
 	self allChildrenTypes
 		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass inheritsFrom: class ] ] ]
-		ifFound: [ self allToAnyScope: aCollectionOfFamixClasses in: aCollection ].
+		ifFound: [ self allToAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allWithAnyScope: aCollectionOfFamixClasses until: rejectBlock [
+	"I am used to return all the entities (recursively) matching one of the class scope that are up or down in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self allWithAnyScope: aCollectionOfFamixClasses in: OrderedCollection new until: rejectBlock) asSet
 ]
 
 { #category : #scoping }
@@ -361,12 +425,25 @@ TEntityMetaLevelDependency >> allWithScope: aClassFAMIX [
 
 { #category : #private }
 TEntityMetaLevelDependency >> allWithScope: aClassFAMIX in: aCollection [
+	^ self allWithScope: aClassFAMIX in: aCollection until: self falseBlock 
+]
 
-	(self class traits includes: aClassFAMIX) ifTrue: [ self allToScope: aClassFAMIX in: aCollection  ].
+{ #category : #private }
+TEntityMetaLevelDependency >> allWithScope: aClassFAMIX in: aCollection until: rejectBlock [
 
-	self allParentTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX inheritsFrom: class ] ] ifFound: [ self allAtScope: aClassFAMIX in: aCollection ].
-	self allChildrenTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX inheritsFrom: class ] ] ifFound: [ self allToScope: aClassFAMIX in: aCollection ].
+	(self class traits includes: aClassFAMIX) ifTrue: [ self allToScope: aClassFAMIX in: aCollection until: rejectBlock ].
+
+	self allParentTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX inheritsFrom: class ] ] ifFound: [ self allAtScope: aClassFAMIX in: aCollection until: rejectBlock ].
+	self allChildrenTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX inheritsFrom: class ] ] ifFound: [ self allToScope: aClassFAMIX in: aCollection until: rejectBlock ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> allWithScope: aClassFAMIX until: rejectBlock [
+	"I am used to return all the entities at a given famix class scope that are up or down in the containment tree of the metamodel on multiple levels.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self allWithScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet
 ]
 
 { #category : #scoping }
@@ -378,12 +455,25 @@ TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixClasses [
 
 { #category : #private }
 TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixScopes in: aCollection [
+	^ self atAnyScope: aCollectionOfFamixScopes in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixScopes in: aCollection until: rejectBlock [
 	(aCollectionOfFamixScopes anySatisfy: [ :aClassFAMIX | self isOfType: aClassFAMIX ])
 		ifTrue: [ aCollection add: self ]
 		ifFalse: [ "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
 			| selectors |
-			1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) atAnyScope: aCollectionOfFamixScopes in: aCollection ] ].
+			(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) atAnyScope: aCollectionOfFamixScopes in: aCollection  until: rejectBlock ] ] ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> atAnyScope: aCollectionOfFamixClasses until: rejectBlock [
+	"I am used to return all the first encountered entities matching one of the class scope given as parameter that are up in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self atAnyScope: aCollectionOfFamixClasses in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #scoping }
@@ -396,12 +486,26 @@ TEntityMetaLevelDependency >> atScope: aClassFAMIX [
 
 { #category : #private }
 TEntityMetaLevelDependency >> atScope: aClassFAMIX in: aCollection [
+	^ self atScope: aClassFAMIX in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> atScope: aClassFAMIX in: aCollection until: rejectBlock [
 	(self isOfType: aClassFAMIX)
 		ifTrue: [ aCollection add: self ]
 		ifFalse: [ "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
 			| selectors |
-			1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) atScope: aClassFAMIX in: aCollection ] ].
+			(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self parentSelectors) size do: [ :ind | (self perform: (selectors at: ind)) atScope: aClassFAMIX in: aCollection  until: rejectBlock ] ] ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> atScope: aClassFAMIX until: rejectBlock [
+	"I am used to return all the first encountered entities at a given famix class scope that are up in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	self flag: #todo.	"I think we do not need the #asArray cast but it will break tests. I will probably let it now then change the tests later. Step by step."
+	^ (self atScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #accessing }
@@ -426,6 +530,11 @@ TEntityMetaLevelDependency >> childrenTypes [
 { #category : #accessing }
 TEntityMetaLevelDependency >> dependencyFM3PropertyDescription [
 	^ self class dependencyFM3PropertyDescriptionIn: self metamodel
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> falseBlock [
+	^ [ :a | false ]
 ]
 
 { #category : #accessing }
@@ -475,12 +584,25 @@ TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses [
 
 { #category : #private }
 TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses in: aCollection [
+	^ self toAnyScope: aCollectionOfFamixClasses in: aCollection until: self falseBlock
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock [
 	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | self isOfType: aFAMIXClass ])
 		ifTrue: [ aCollection add: self ]
 		ifFalse: [ "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
 			| selectors |
-			1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) toAnyScope: aCollectionOfFamixClasses in: aCollection ] ].
+			(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) toAnyScope: aCollectionOfFamixClasses in: aCollection  until: rejectBlock ] ] ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> toAnyScope: aCollectionOfFamixClasses until: rejectBlock [
+	"I am used to return all the first encountered entities matching one of the class scope given as parameter that are down in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self toAnyScope: aCollectionOfFamixClasses in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #scoping }
@@ -493,12 +615,26 @@ TEntityMetaLevelDependency >> toScope: aClassFAMIX [
 
 { #category : #private }
 TEntityMetaLevelDependency >> toScope: aClassFAMIX in: aCollection [
+	^ self toScope: aClassFAMIX in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> toScope: aClassFAMIX in: aCollection until: rejectBlock [
 	(self isOfType: aClassFAMIX)
 		ifTrue: [ aCollection add: self ]
 		ifFalse: [ "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
 			| selectors |
-			1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) toScope: aClassFAMIX in: aCollection ] ].
+			(rejectBlock value: self) ifFalse: [ 1 to: (selectors := self childrenSelectors) size do: [ :ind | (self perform: (selectors at: ind)) toScope: aClassFAMIX in: aCollection  until: rejectBlock ] ] ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> toScope: aClassFAMIX until: rejectBlock [
+	"I am used to return all the first encountered  entities at a given famix class scope that are down in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	self flag: #todo.	"I think we do not need the #asArray cast but it will break tests. I will probably let it now then change the tests later. Step by step."
+	^ (self toScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
 { #category : #accessing }
@@ -524,16 +660,29 @@ TEntityMetaLevelDependency >> withAnyScope: aCollectionOfFamixClasses [
 
 { #category : #private }
 TEntityMetaLevelDependency >> withAnyScope: aCollectionOfFamixClasses in: aCollection [
+	^ self withAnyScope: aCollectionOfFamixClasses in: aCollection until: self falseBlock 
+]
+
+{ #category : #private }
+TEntityMetaLevelDependency >> withAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock [
 	(aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | (self class traits includes: aFAMIXClass) or: [ self class = aFAMIXClass ] ])
-		ifTrue: [ self atScope: aCollectionOfFamixClasses in: aCollection ].
+		ifTrue: [ self atScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ].
 
 	self allParentTypes
 		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass mooseInheritsFrom: class ] ] ]
-		ifFound: [ self atAnyScope: aCollectionOfFamixClasses in: aCollection ].
+		ifFound: [ self atAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ].
 	self allChildrenTypes
 		detect: [ :class | aCollectionOfFamixClasses anySatisfy: [ :aFAMIXClass | aFAMIXClass = class or: [ aFAMIXClass mooseInheritsFrom: class ] ] ]
-		ifFound: [ self toAnyScope: aCollectionOfFamixClasses in: aCollection ].
+		ifFound: [ self toAnyScope: aCollectionOfFamixClasses in: aCollection until: rejectBlock ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> withAnyScope: aCollectionOfFamixClasses until: rejectBlock [
+	"I am used to return all the first encountered entities matching one of the class scope that are up or down in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self withAnyScope: aCollectionOfFamixClasses in: OrderedCollection new until: rejectBlock) asSet
 ]
 
 { #category : #scoping }
@@ -545,9 +694,22 @@ TEntityMetaLevelDependency >> withScope: aClassFAMIX [
 
 { #category : #private }
 TEntityMetaLevelDependency >> withScope: aClassFAMIX in: aCollection [
-	((self class allGeneratedTraits includes: aClassFAMIX) or: [ self class = aClassFAMIX ]) ifTrue: [ self atScope: aClassFAMIX in: aCollection ].
+	^ self withScope: aClassFAMIX in: aCollection until: self falseBlock 
+]
 
-	self allParentTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX mooseInheritsFrom: class ] ] ifFound: [ self atScope: aClassFAMIX in: aCollection ].
-	self allChildrenTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX mooseInheritsFrom: class ] ] ifFound: [ self toScope: aClassFAMIX in: aCollection ].
+{ #category : #private }
+TEntityMetaLevelDependency >> withScope: aClassFAMIX in: aCollection until: rejectBlock [
+	((self class allGeneratedTraits includes: aClassFAMIX) or: [ self class = aClassFAMIX ]) ifTrue: [ self atScope: aClassFAMIX in: aCollection until: rejectBlock ].
+
+	self allParentTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX mooseInheritsFrom: class ] ] ifFound: [ self atScope: aClassFAMIX in: aCollection until: rejectBlock ].
+	self allChildrenTypes detect: [ :class | aClassFAMIX = class or: [ aClassFAMIX mooseInheritsFrom: class ] ] ifFound: [ self toScope: aClassFAMIX in: aCollection until: rejectBlock ].
 	^ aCollection
+]
+
+{ #category : #scoping }
+TEntityMetaLevelDependency >> withScope: aClassFAMIX until: rejectBlock [
+	"I am used to return all the first encountered  entities at a given famix class scope that are up or down in the containment tree of the metamodel.
+	I stop the recursion when the rejectBlock is true"
+
+	^ (self withScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet
 ]

--- a/src/Moose-Query/UndefinedObject.extension.st
+++ b/src/Moose-Query/UndefinedObject.extension.st
@@ -6,7 +6,17 @@ UndefinedObject >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+UndefinedObject >> allAtAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 UndefinedObject >> allAtScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> allAtScope: aFAMIXScope in: aCollection until: aRejectBlock [
 	^ aCollection
 ]
 
@@ -16,7 +26,17 @@ UndefinedObject >> allToAnyScope: aCollectionOfFamixClasses in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+UndefinedObject >> allToAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 UndefinedObject >> allToScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> allToScope: aFAMIXScope in: aCollection until: aRejectBlock [
 	^ aCollection
 ]
 
@@ -26,7 +46,17 @@ UndefinedObject >> allWithScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+UndefinedObject >> allWithScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 UndefinedObject >> atAnyScope: aCollectionOfFamixScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> atAnyScope: aCollectionOfFamixScope in: aCollection until: aRejectBlock [
 	^ aCollection
 ]
 
@@ -36,7 +66,17 @@ UndefinedObject >> atScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+UndefinedObject >> atScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 UndefinedObject >> toAnyScope: aCollectionOfFamixClasses in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> toAnyScope: aCollectionOfFamixClasses in: aCollection until: aRejectBlock [
 	^ aCollection
 ]
 
@@ -46,6 +86,16 @@ UndefinedObject >> toScope: aFAMIXScope in: aCollection [
 ]
 
 { #category : #'*Moose-Query' }
+UndefinedObject >> toScope: aFAMIXScope in: aCollection until: aRejectBlock [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
 UndefinedObject >> withScope: aFAMIXScope in: aCollection [
+	^ aCollection
+]
+
+{ #category : #'*Moose-Query' }
+UndefinedObject >> withScope: aFAMIXScope in: aCollection until: aRejectBlock [
 	^ aCollection
 ]


### PR DESCRIPTION
I want to be able to go up in the containment tree until a condition is true. 
The condition can be a match with a type of entity or the value of a property (or whatever we want about the current entity we are crawling).

So, I had to moose query the keyword until: on all the atScope/toScope methods.
It allows us to specify a block that will be executed at all level to determine if we still need to crawl or not.

I think we can duplicate the code to optimize the execution without "until", however, I thought that it will be better to have the code in one method instead of two for each possible navigation.

I've added tests for all the new request and the others are still green without modification.