### PR TITLE
Use-test-resource-for-GenerateRemoteAccessor-tests

### DIFF
--- a/src/Famix-MetamodelBuilder-Tests/FamixGenerateRemoteAccessorTestResource.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixGenerateRemoteAccessorTestResource.class.st
@@ -1,0 +1,64 @@
+"
+Description
+--------------------
+
+I am a test resource used when someone needs the composed MM GenerateRemoteAccessor. 
+
+I'll generate the MM and remove it once all tests of the class are finished.
+	
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	entityA:		First entity of the model
+	entityB:		Second entity of the model
+
+"
+Class {
+	#name : #FamixGenerateRemoteAccessorTestResource,
+	#superclass : #TestResource,
+	#instVars : [
+		'entityA',
+		'entityB'
+	],
+	#category : #'Famix-MetamodelBuilder-Tests'
+}
+
+{ #category : #accessing }
+FamixGenerateRemoteAccessorTestResource >> entityA [
+	^ entityA
+]
+
+{ #category : #accessing }
+FamixGenerateRemoteAccessorTestResource >> entityB [
+	^ entityB
+]
+
+{ #category : #running }
+FamixGenerateRemoteAccessorTestResource >> setUp [
+	| mooseModel |
+	super setUp.
+	FamixMetamodelGenerateRemoteAccessorTestGeneratorA generate.
+	FamixMetamodelGenerateRemoteAccessorTestGeneratorB generate.
+	FamixMetamodelGenerateRemoteAccessorTestGeneratorAB generate.
+	mooseModel := MooseModel new.
+	"the following entities are created by the generators
+	Do not remove them (or change the all the tests)"
+	entityA := (self class environment at: #FmxTestGenerateAccessorAEntityA ifAbsent: [ self fail ]) new.
+	entityB := (self class environment at: #FmxTestGenerateAccessorBEntityB ifAbsent: [ self fail ]) new.
+	mooseModel addAll: {entityA . entityB}
+]
+
+{ #category : #running }
+FamixGenerateRemoteAccessorTestResource >> tearDown [
+	[ 'Famix-MetamodelBuilder-TestsResources-A' asPackage removeFromSystem ]
+		on: NotFound
+		do: [  ].
+	[ 'Famix-MetamodelBuilder-TestsResources-B' asPackage removeFromSystem ]
+		on: NotFound
+		do: [  ].
+	[ 'Famix-MetamodelBuilder-TestsResources-AB' asPackage removeFromSystem ]
+		on: NotFound
+		do: [  ]
+]

--- a/src/Famix-MetamodelBuilder-Tests/FamixGenerateRemoteAccessorTestResource.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixGenerateRemoteAccessorTestResource.class.st
@@ -25,6 +25,11 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Tests'
 }
 
+{ #category : #running }
+FamixGenerateRemoteAccessorTestResource >> classNamed: aSymbol [
+	^ self class environment at: aSymbol ifAbsent: [ self fail ]
+]
+
 { #category : #accessing }
 FamixGenerateRemoteAccessorTestResource >> entityA [
 	^ entityA
@@ -37,17 +42,15 @@ FamixGenerateRemoteAccessorTestResource >> entityB [
 
 { #category : #running }
 FamixGenerateRemoteAccessorTestResource >> setUp [
-	| mooseModel |
 	super setUp.
 	FamixMetamodelGenerateRemoteAccessorTestGeneratorA generate.
 	FamixMetamodelGenerateRemoteAccessorTestGeneratorB generate.
 	FamixMetamodelGenerateRemoteAccessorTestGeneratorAB generate.
-	mooseModel := MooseModel new.
 	"the following entities are created by the generators
 	Do not remove them (or change the all the tests)"
-	entityA := (self class environment at: #FmxTestGenerateAccessorAEntityA ifAbsent: [ self fail ]) new.
-	entityB := (self class environment at: #FmxTestGenerateAccessorBEntityB ifAbsent: [ self fail ]) new.
-	mooseModel addAll: {entityA . entityB}
+	entityA := (self classNamed: #FmxTestGenerateAccessorAEntityA) new.
+	entityB := (self classNamed: #FmxTestGenerateAccessorBEntityB) new.
+	(self classNamed: #FmxTestGenerateAccessorABMooseModel) new addAll: {entityA . entityB}
 ]
 
 { #category : #running }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorRemoteAccessorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorRemoteAccessorTest.class.st
@@ -9,33 +9,16 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Tests'
 }
 
-{ #category : #running }
-FmxMBGeneratorRemoteAccessorTest >> setUp [
-	super setUp.
-	FamixMetamodelGenerateRemoteAccessorTestGeneratorA generate.
-	FamixMetamodelGenerateRemoteAccessorTestGeneratorB generate.
-	FamixMetamodelGenerateRemoteAccessorTestGeneratorAB generate.
-	mm := MooseModel new.
-	"the following entities are created by the generators
-	Do not remove them (or change the all the tests)"
-	entityA := ((SmalltalkImage current classNamed: 'FmxTestGenerateAccessorAEntityA') ifNil: [ self fail ]) new.
-	entityB := ((SmalltalkImage current classNamed: 'FmxTestGenerateAccessorBEntityB') ifNil: [ self fail ]) new.
-	mm addAll: { entityA. entityB }
-	
+{ #category : #accessing }
+FmxMBGeneratorRemoteAccessorTest class >> resources [
+	^ { FamixGenerateRemoteAccessorTestResource }
 ]
 
 { #category : #running }
-FmxMBGeneratorRemoteAccessorTest >> tearDown [
-	[ 'Famix-MetamodelBuilder-TestsResources-A' asPackage removeFromSystem ]
-		on: NotFound
-		do: [  ].
-	[ 'Famix-MetamodelBuilder-TestsResources-B' asPackage removeFromSystem ]
-		on: NotFound
-		do: [  ].
-	[ 'Famix-MetamodelBuilder-TestsResources-AB' asPackage removeFromSystem ]
-		on: NotFound
-		do: [  ].
-	super tearDown
+FmxMBGeneratorRemoteAccessorTest >> setUp [
+	super setUp.
+	entityA := FamixGenerateRemoteAccessorTestResource current entityA.
+	entityB := FamixGenerateRemoteAccessorTestResource current entityB
 ]
 
 { #category : #running }


### PR DESCRIPTION
Use a test resource FamixGenerateRemoteAccessorTestResource to manage the MM needed for remote accessors tests.
This cut down the time to launch Famix tests by 20sec.