### PR TITLE
Remove-resetMeta

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
@@ -22,13 +22,6 @@ FAMIXAnnotationInstance class >> requirements [
 	^ { FAMIXNamedEntity }
 ]
 
-{ #category : #'Moose-Query-Extensions' }
-FAMIXAnnotationInstance class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FAMIXAnnotationInstance >> belongsTo [
 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
@@ -22,13 +22,6 @@ FAMIXAnnotationInstanceAttribute class >> requirements [
 	^ { FAMIXAnnotationInstance }
 ]
 
-{ #category : #'Moose-Query-Extensions' }
-FAMIXAnnotationInstanceAttribute class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FAMIXAnnotationInstanceAttribute >> belongsTo [
 

--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -20,22 +20,6 @@ FAMIXEntity class >> metamodel [
 	^ (self class environment at: #FamixCompatibilityGenerator) metamodel
 ]
 
-{ #category : #'Moose-Query-Extensions' }
-FAMIXEntity class >> resetMSEProperties [
-	"
-	self resetMSEProperties
-		"
-
-	self allSubclasses
-		do: [ :aSubClass | 
-			aSubClass resetMooseQueryCaches.]
-]
-
-{ #category : #'Moose-Query-Extensions' }
-FAMIXEntity class >> resetMooseQueryCaches [
-	"Here do nothing. Customize in subclasses."
-]
-
 { #category : #accessing }
 FAMIXEntity >> belongsTo [
 	"Return the primary container of the entity if it exist"

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -27,12 +27,6 @@ FAMIXNamedEntity class >> requirements [
 	^ { FAMIXPackage }
 ]
 
-{ #category : #'Moose-Query-Extensions' }
-FAMIXNamedEntity class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-]
-
 { #category : #accessing }
 FAMIXNamedEntity >> belongsTo [
 	

--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -27,13 +27,6 @@ FAMIXSourceAnchor class >> parentTypes [
 	^ {}
 ]
 
-{ #category : #generator }
-FAMIXSourceAnchor class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FAMIXSourceAnchor >> belongsTo [ 
 		

--- a/src/Famix-Compatibility-Entities/MooseModel.extension.st
+++ b/src/Famix-Compatibility-Entities/MooseModel.extension.st
@@ -47,19 +47,6 @@ MooseModel >> inferNamespaceParentsBasedOnNames [
 ]
 
 { #category : #'*Famix-Compatibility-Entities' }
-MooseModel class >> resetMeta [
-	"self resetMeta"
-
-	FAMIXEntity resetMSEProperties.
-	FAMIXNamedEntity resetMSEProperties.
-	
-	metaTower := nil.
-	
-	FamixCompatibilityGenerator metamodel: nil.
-	^self meta
-]
-
-{ #category : #'*Famix-Compatibility-Entities' }
 MooseModel >> unknownFAMIXClass [
 	^ self allClasses 
 		detect: [:each | each mooseName = #'unknownNamespace::UnknownClass'] 

--- a/src/Famix-Compatibility-Tests-C/FAMIXCImporting2Test.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCImporting2Test.class.st
@@ -11,8 +11,7 @@ Class {
 FAMIXCImporting2Test >> setUp [
 	super setUp.
 	self skip: 'Test skipped until C metamodel definition'.
-	
-	MooseModel resetMeta.
+
 	model := MooseModel new.
 	model
 		importFromMSEStream:

--- a/src/Famix-Compatibility-Tests-C/FAMIXCSourceLanguageTest.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCSourceLanguageTest.class.st
@@ -8,7 +8,6 @@ Class {
 FAMIXCSourceLanguageTest >> testIsC [
 	| model |
 	self skip: 'Test skipped until C metamodel definition'.
-	MooseModel resetMeta.
 	model := MooseModel new.
 	
 	model importFromMSEStream: '(

--- a/src/Famix-Compatibility-Tests-C/FAMIXCompilationUnitTest.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCompilationUnitTest.class.st
@@ -8,7 +8,6 @@ Class {
 FAMIXCompilationUnitTest >> testImporting [
 	| model |
 	self skip: 'Test skipped until C metamodel definition'.
-	MooseModel resetMeta.
 	model := MooseModel new.
 	
 	model importFromMSEStream: '(

--- a/src/Famix-Compatibility-Tests-Core/FAMIXAnnotationInstanceAttributeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXAnnotationInstanceAttributeTest.class.st
@@ -12,7 +12,6 @@ FAMIXAnnotationInstanceAttributeTest >> actualClass [
 { #category : #tests }
 FAMIXAnnotationInstanceAttributeTest >> testComplex [
 	| model |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:

--- a/src/Famix-Compatibility-Tests-Core/FAMIXSourceAnchorTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXSourceAnchorTest.class.st
@@ -12,7 +12,6 @@ FAMIXSourceAnchorTest class >> isAbstract [
 { #category : #tests }
 FAMIXSourceAnchorTest >> testImportFileAnchors [
 	| model aMethod |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:

--- a/src/Famix-Compatibility-Tests-Core/FAMIXSourceLanguageTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXSourceLanguageTest.class.st
@@ -12,7 +12,6 @@ FAMIXSourceLanguageTest >> actualClass [
 { #category : #tests }
 FAMIXSourceLanguageTest >> testDefaultSourceLanguage [
 	| model |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:
@@ -47,7 +46,6 @@ FAMIXSourceLanguageTest >> testName [
 { #category : #tests }
 FAMIXSourceLanguageTest >> testSourcedEntities [
 	| model |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:

--- a/src/Famix-Compatibility-Tests-Java/FAMIXJavaSourceLanguageTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FAMIXJavaSourceLanguageTest.class.st
@@ -7,7 +7,6 @@ Class {
 { #category : #tests }
 FAMIXJavaSourceLanguageTest >> testIsJava [
 	| model |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	
 	model importFromMSEStream: '(

--- a/src/Famix-Compatibility-Tests-Java/FamixJavaTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixJavaTest.class.st
@@ -7,7 +7,6 @@ Class {
 { #category : #tests }
 FamixJavaTest >> testImportAnnotations [
 	| model |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:
@@ -42,7 +41,6 @@ FamixJavaTest >> testImportAnnotations [
 { #category : #tests }
 FamixJavaTest >> testImportExceptions [
 	| model |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:

--- a/src/Famix-Compatibility-Tests-Java/FamixParameterizableClassTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixParameterizableClassTest.class.st
@@ -7,7 +7,6 @@ Class {
 { #category : #tests }
 FamixParameterizableClassTest >> testParameterTypes [
 	| model aParameterizableClass |
-	MooseModel resetMeta.
 	model := MooseModel new.
 	model
 		importFromMSEStream:

--- a/src/Famix-Compatibility-Tests-Java/FamixParameterizedTypeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixParameterizedTypeTest.class.st
@@ -11,7 +11,6 @@ Class {
 FamixParameterizedTypeTest >> setUp [
 
 	super setUp.
-	MooseModel resetMeta.
 	model := MooseModel new.
 	
 	model importFromMSEStream: '(

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -22,13 +22,6 @@ FamixJavaAnnotationInstance class >> requirements [
 	^ { FamixJavaNamedEntity }
 ]
 
-{ #category : #'Moose-Query' }
-FamixJavaAnnotationInstance class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FamixJavaAnnotationInstance >> belongsTo [
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -22,13 +22,6 @@ FamixJavaAnnotationInstanceAttribute class >> requirements [
 	^ { FamixJavaAnnotationInstance }
 ]
 
-{ #category : #generator }
-FamixJavaAnnotationInstanceAttribute class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FamixJavaAnnotationInstanceAttribute >> belongsTo [
 

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -37,22 +37,6 @@ FamixJavaEntity class >> metamodel [
 	^ (self class environment at: #FamixJavaGenerator) metamodel
 ]
 
-{ #category : #'Moose-Query' }
-FamixJavaEntity class >> resetMSEProperties [
-	"
-	self resetMSEProperties
-		"
-
-	self allSubclasses
-		do: [ :aSubClass | 
-			aSubClass resetMooseQueryCaches.]
-]
-
-{ #category : #'Moose-Query' }
-FamixJavaEntity class >> resetMooseQueryCaches [
-	"Here do nothing. Customize in subclasses."
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaEntity >> belongsTo [
 	"Return the primary container of the entity if it exist"

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -22,13 +22,6 @@ FamixJavaNamedEntity class >> requirements [
 	^ { FamixJavaPackage }
 ]
 
-{ #category : #'Moose-Query' }
-FamixJavaNamedEntity class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaNamedEntity >> belongsTo [
 	

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -27,13 +27,6 @@ FamixJavaSourceAnchor class >> parentTypes [
 	^ {}
 ]
 
-{ #category : #meta }
-FamixJavaSourceAnchor class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaSourceAnchor >> completeText [
 	"The complete text of a FileAnchor contains all the code of the file pointed by the source anchor. On the contrary the #sourceText return only the pant of the file concerned by the entity. For example a FAMIXFileAnchon knows the start line and end line of the source anchor into the file."

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -22,13 +22,6 @@ FamixStAnnotationInstance class >> requirements [
 	^ { FamixStNamedEntity }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixStAnnotationInstance class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FamixStAnnotationInstance >> belongsTo [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -22,13 +22,6 @@ FamixStAnnotationInstanceAttribute class >> requirements [
 	^ { FamixStAnnotationInstance }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixStAnnotationInstanceAttribute class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FamixStAnnotationInstanceAttribute >> belongsTo [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -20,11 +20,6 @@ FamixStEntity class >> metamodel [
 	^ (self class environment at: #FamixPharoSmalltalkGenerator) metamodel
 ]
 
-{ #category : #'as yet unclassified' }
-FamixStEntity class >> resetMooseQueryCaches [
-	"Here do nothing. Customize in subclasses."
-]
-
 { #category : #testing }
 FamixStEntity >> isAccess [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -22,13 +22,6 @@ FamixStNamedEntity class >> requirements [
 	^ { FamixStPackage }
 ]
 
-{ #category : #'as yet unclassified' }
-FamixStNamedEntity class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #accessing }
 FamixStNamedEntity >> belongsTo [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -24,13 +24,6 @@ FamixStSourceAnchor class >> parentTypes [
 	^ {}
 ]
 
-{ #category : #'as yet unclassified' }
-FamixStSourceAnchor class >> resetMooseQueryCaches [
-	super resetMooseQueryCaches.
-	self resetTEntityMetaLevelDependencyCaches.
-
-]
-
 { #category : #initialization }
 FamixStSourceAnchor >> initialize [
 	super initialize.

--- a/src/Moose-Finder/MooseMetaBrowser.class.st
+++ b/src/Moose-Finder/MooseMetaBrowser.class.st
@@ -48,13 +48,12 @@ MooseMetaBrowser >> addClassLegendOn: view [
 MooseMetaBrowser >> browserActions [
 	browser
 		morphicAct: [ :b | 
-					MooseModel resetMeta.
-					browser entity: MooseModel meta.
-					browser update ]
+			browser entity: MooseModel meta.
+			browser update ]
 			icon: GLMUIThemeExtraIcons glamorousRefresh
 			entitled: 'Reinitialize meta descriptions';
 		morphicAct: [ :b :repo | self openLintBrowserOn: repo ] entitled: 'Check metamodel rules';
-		morphicAct: [ :b :repo | MooseFameView new openOn: repo ] entitled: 'View class diagram'.
+		morphicAct: [ :b :repo | MooseFameView new openOn: repo ] entitled: 'View class diagram'
 ]
 
 { #category : #building }

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -183,12 +183,6 @@ TEntityMetaLevelDependency classSide >> privateParentTypesIn: aMetamodel [
 	^ (containerBehaviors , (containerUsers collect: #implementingClass)) asSet asArray
 ]
 
-{ #category : #'Moose-Query-Extensions' }
-TEntityMetaLevelDependency classSide >> resetTEntityMetaLevelDependencyCaches [
-
-	
-]
-
 { #category : #private }
 TEntityMetaLevelDependency >> addAllChildrenIn: aCollection [
 	aCollection addAll: self children.

--- a/src/Moose-Tests-Core/MooseModelDescriptionTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelDescriptionTest.class.st
@@ -39,13 +39,6 @@ MooseModelDescriptionTest >> testAsMooseDescriptionAttributes [
 ]
 
 { #category : #tests }
-MooseModelDescriptionTest >> testAsMooseDescriptionWithResetting [	
-	self assert: (FAMIXClass asMooseDescription isKindOf: FM3MetaDescription).
-	MooseModel resetMeta.
-	self assert: (FAMIXClass asMooseDescription isKindOf: FM3MetaDescription).
-]
-
-{ #category : #tests }
 MooseModelDescriptionTest >> testOppositeOfOppositePropertyIsMyself [
 	| allSelector dictOpposite |
 


### PR DESCRIPTION
MooseModel class>>#resetMeta is not used anymore. We can remove it and all the related code.