### PR TITLE
Remove-unused-feature-slowing-import

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -293,20 +293,6 @@ MooseAbstractGroup >> entityNamed: aMooseName ifAbsentPut: aValue [
 	^ self entityNamed: aMooseName ifAbsent: [self add: aValue]
 ]
 
-{ #category : #'public interface' }
-MooseAbstractGroup >> entityNamed: aSymbol withType: aFamixType [
-	 
-	^self 
-		entityNamed: aSymbol 
-		withType: aFamixType
-		ifAbsent: [nil]
-]
-
-{ #category : #'public interface' }
-MooseAbstractGroup >> entityNamed: aMooseName withType: aFamixType ifAbsent: aBlock [
-	^ self entityStorage at: aMooseName withType: aFamixType ifAbsent: aBlock
-]
-
 { #category : #private }
 MooseAbstractGroup >> entityStorage [ 
 	 

--- a/src/Moose-Core/MooseGroupRuntimeStorage.class.st
+++ b/src/Moose-Core/MooseGroupRuntimeStorage.class.st
@@ -31,8 +31,7 @@ Class {
 	#instVars : [
 		'byName',
 		'elements',
-		'byType',
-		'sortedCollectionList'
+		'byType'
 	],
 	#category : #'Moose-Core'
 }
@@ -59,25 +58,6 @@ MooseGroupRuntimeStorage >> at: uniqueName ifAbsent: exceptionBlock [
 	^byName at: uniqueName asSymbol ifAbsent: exceptionBlock
 ]
 
-{ #category : #accessing }
-MooseGroupRuntimeStorage >> at: uniqueName withType: aClass ifAbsent: exceptionBlock [
-	| s |
-	s := uniqueName asSymbol.
-	^ (self
-		shouldSort: (self selectAllWithType: aClass)
-		withBlock: [ :a :b | a mooseName asSymbol <= b mooseName asSymbol ]
-		type: aClass)
-		findBinary: [ :a | 
-			| aName |
-			aName := a mooseName asSymbol.
-			aName = s
-				ifTrue: [ 0 ]
-				ifFalse: [ s < aName
-						ifTrue: [ -1 ]
-						ifFalse: [ 1 ] ] ]
-		ifNone: exceptionBlock
-]
-
 { #category : #enumerating }
 MooseGroupRuntimeStorage >> do: aBlock [ 
 	 
@@ -90,11 +70,9 @@ MooseGroupRuntimeStorage >> elements [
 ]
 
 { #category : #'initialize-release' }
-MooseGroupRuntimeStorage >> initialize: capacity [ 
-	 
-	byType := Dictionary new: 24.
-	sortedCollectionList := Dictionary new: 24.
-	byName := IdentityDictionary new: capacity. 
+MooseGroupRuntimeStorage >> initialize: capacity [
+	byType := IdentityDictionary new: 24.
+	byName := IdentityDictionary new: capacity.
 	elements := OrderedCollection new: capacity
 ]
 
@@ -146,37 +124,18 @@ MooseGroupRuntimeStorage >> selectAllWithType: aSmalltalkType [
 			self class byTypeDefaultCollection addAll: result ]
 ]
 
-{ #category : #private }
-MooseGroupRuntimeStorage >> shouldSort: aCollection withBlock: aBlockClosure type: aMooseClass [
-	| isSorted |
-	isSorted := self sortedCollectionList at: aMooseClass ifAbsentPut: [ false ].
-	^ isSorted
-		ifTrue: [ aCollection ]
-		ifFalse: [ self sortedCollectionList at: aMooseClass put: true.
-			aCollection sort: aBlockClosure ]
-]
-
 { #category : #accessing }
 MooseGroupRuntimeStorage >> size [ 
 	^ elements size
 ]
 
 { #category : #private }
-MooseGroupRuntimeStorage >> sortedCollectionList [
-	^ sortedCollectionList ifNil: [ sortedCollectionList := Dictionary new ]
-]
-
-{ #category : #private }
 MooseGroupRuntimeStorage >> updateCacheOnAddingOf: anElement [
-    | group |
-    group := byType
-        at: anElement class
-        ifAbsentPut: [ self class byTypeDefaultCollection ].
-    self sortedCollectionList at: anElement put: false.
-    group add: anElement.
-    anElement hasUniqueMooseNameInModel
-        ifTrue: [ byName at: anElement mooseName asSymbol put: anElement ].
-    ^ anElement
+	| group |
+	group := byType at: anElement class ifAbsentPut: [ self class byTypeDefaultCollection ].
+	group add: anElement.
+	anElement hasUniqueMooseNameInModel ifTrue: [ byName at: anElement mooseName asSymbol put: anElement ].
+	^ anElement
 ]
 
 { #category : #private }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -334,22 +334,6 @@ MooseGroupTest >> testEntitiesDo [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testEntityNamedWithType [
-	| group result c n |
-	group := MooseGroup new.
-	c := FAMIXClass new name: 'A'.
-	n := FAMIXNamespace new name: 'A'.
-	group add: c.
-	group add: n.
-	result := group entityNamed: 'A'.
-	self assert: result equals: n.
-	result := group entityNamed: 'A' withType: FAMIXNamespace.
-	self assert: result equals: n.
-	result := group entityNamed: 'A' withType: FAMIXClass.
-	self assert: result equals: c
-]
-
-{ #category : #tests }
 MooseGroupTest >> testEnumeration [
 
 	| t group el1 el2 el3 |


### PR DESCRIPTION
The method #entityNamed:withType: is not used in Moose and make import much longer because they create a cache updated a lot.

I propose to remove it. I got an import dropping from 83 to 53sec.