### PR TITLE
Speed-up-resetMooseName

### DIFF
--- a/src/Famix-Traits/FamixTNamed.trait.st
+++ b/src/Famix-Traits/FamixTNamed.trait.st
@@ -52,7 +52,6 @@ FamixTNamed >> name: anObject [
 
 { #category : #accessing }
 FamixTNamed >> resetMooseName [
-
-	super resetMooseName.
-	self children do: [ :entity | entity resetMooseName ]
+	super resetMooseName ifTrue: [ self children do: [ :entity | entity resetMooseName ] ].
+	^ false
 ]

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -478,10 +478,15 @@ MooseEntity >> mooseName [
 	
 	Do not override this method.
 	Instead, use mooseNameOn: to customize the result."
-
-	^ self privateState
+	self privateState hasMooseModel ifFalse: [ "do not cache yet"
+			| stream |
+			stream := (String new: 64) writeStream.
+			self mooseNameOn: stream.
+			^stream contents asSymbol ].
+	^self privateState 
 		propertyAt: #mooseName
-		ifAbsentPut: [ | stream |
+		ifAbsentPut: [ 
+			| stream |
 			stream := (String new: 64) writeStream.
 			self mooseNameOn: stream.
 			stream contents asSymbol ]

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -478,15 +478,10 @@ MooseEntity >> mooseName [
 	
 	Do not override this method.
 	Instead, use mooseNameOn: to customize the result."
-	self privateState hasMooseModel ifFalse: [ "do not cache yet"
-			| stream |
-			stream := (String new: 64) writeStream.
-			self mooseNameOn: stream.
-			^stream contents asSymbol ].
-	^self privateState 
+
+	^ self privateState
 		propertyAt: #mooseName
-		ifAbsentPut: [ 
-			| stream |
+		ifAbsentPut: [ | stream |
 			stream := (String new: 64) writeStream.
 			self mooseNameOn: stream.
 			stream contents asSymbol ]
@@ -628,8 +623,13 @@ MooseEntity >> removeFromModel [
 
 { #category : #'meta information' }
 MooseEntity >> resetMooseName [
-	(self hasUniqueMooseNameInModel and: [ self privateState hasMooseModel ])
-		ifTrue: [ self mooseModel resetMooseNameFor: self ]
+	"If needed I reset my moose name in the MooseModel. I return true if my MooseName was updated and false if it was not."
+
+	(self hasUniqueMooseNameInModel and: [ self privateState hasMooseModel ]) ifFalse: [ ^ false ].
+
+	self mooseModel resetMooseNameFor: self.
+
+	^ true
 ]
 
 { #category : #initialization }

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -505,9 +505,9 @@ TEntityMetaLevelDependency >> atScope: aClassFAMIX until: rejectBlock [
 { #category : #accessing }
 TEntityMetaLevelDependency >> children [
 	| res |
-	res := OrderedCollection new.
+	res := Set new.
 	self childrenSelectors do: [ :accessor | (self perform: accessor) ifNotNil: [ :r | res addAll: r asCollection ] ].
-	^ res asSet
+	^ res
 ]
 
 { #category : #accessing }
@@ -564,9 +564,9 @@ TEntityMetaLevelDependency >> parentTypes [
 { #category : #accessing }
 TEntityMetaLevelDependency >> parents [
 	| res |
-	res := OrderedCollection new.
+	res := Set new.
 	self parentSelectors do: [ :accessor | (self perform: accessor) ifNotNil: [ :r | res addAll: r asCollection ] ].
-	^ res asSet
+	^ res
 ]
 
 { #category : #scoping }


### PR DESCRIPTION
Speed up resetMooseName in case there is no model yet. (For example while reading a MSE)