### PR TITLE
Rewrite-containers-infos-based-on-metamodels

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
@@ -26,23 +26,7 @@ FAMIXContainerEntity >> addFunction: aFunction [
 	functions add: aFunction
 ]
 
-{ #category : #testing }
-FAMIXContainerEntity >> isContainerEntity [
-
-	<generated>
-	^ true
-]
-
 { #category : #'Famix-Java' }
 FAMIXContainerEntity >> mooseNameWithDots [
 	^ self mooseName ifNotNil: [ '.' join: (self mooseName substrings: '::') ]
-]
-
-{ #category : #accessing }
-FAMIXContainerEntity >> numberOfChildren [
-	<MSEProperty: #numberOfChildren type: #Number>
-	<MSEComment: 'Number of direct children entities in the containment tree.'>
-	<derived>
-	
-	^ self children size
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -61,13 +61,6 @@ FAMIXEntity >> isClass [
 ]
 
 { #category : #testing }
-FAMIXEntity >> isContainerEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FAMIXEntity >> isFunction [
 
 	<generated>

--- a/src/Famix-Compatibility-Generator/FamixCompatibilityGenerator.class.st
+++ b/src/Famix-Compatibility-Generator/FamixCompatibilityGenerator.class.st
@@ -162,8 +162,7 @@ FamixCompatibilityGenerator >> defineClasses [
 	trait := builder newClassNamed: #Trait.
 	traitUsage := builder newClassNamed: #TraitUsage.
 
-	primitiveType withTesting.
-	containerEntity withTesting.
+	primitiveType withTesting
 
 
 ]

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -21,23 +21,7 @@ FamixJavaContainerEntity >> addClass: aClass [
 	types add: aClass
 ]
 
-{ #category : #testing }
-FamixJavaContainerEntity >> isContainerEntity [
-
-	<generated>
-	^ true
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaContainerEntity >> mooseNameWithDots [
 	^ self mooseName ifNotNil: [ '.' join: (self mooseName substrings: '::') ]
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaContainerEntity >> numberOfChildren [
-	<MSEProperty: #numberOfChildren type: #Number>
-	<MSEComment: 'Number of direct children entities in the containment tree.'>
-	<derived>
-	
-	^ self children size
 ]

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -73,13 +73,6 @@ FamixJavaEntity >> isClass [
 ]
 
 { #category : #testing }
-FamixJavaEntity >> isContainerEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixJavaEntity >> isFunction [
 
 	<generated>

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -97,7 +97,6 @@ FamixJavaGenerator >> defineClasses [
 	unknownVariable := builder newClassNamed: #UnknownVariable.
 	
 	primitiveType withTesting.
-	containerEntity withTesting.
 
 	self defineComments
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
@@ -14,12 +14,3 @@ FamixStContainerEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #accessing }
-FamixStContainerEntity >> numberOfChildren [
-	<MSEProperty: #numberOfChildren type: #Number>
-	<MSEComment: 'Number of direct children entities in the containment tree.'>
-	<derived>
-	
-	^ self children size
-]

--- a/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #FamixTest1Attribute,
+	#superclass : #FamixTest1NamedEntity,
+	#traits : 'FamixTAttribute + FamixTStructuralEntity',
+	#classTraits : 'FamixTAttribute classTrait + FamixTStructuralEntity classTrait',
+	#category : #'Famix-Test1-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest1Attribute class >> annotation [
+
+	<MSEClass: #Attribute super: #FamixTest1NamedEntity>
+	<package: #'Famix-Test1-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #accessing }
+FamixTest1Attribute >> belongsTo [
+
+	<generated>
+	^ self parentType
+
+]
+
+{ #category : #accessing }
+FamixTest1Attribute >> belongsTo: anObject [
+
+	<generated>
+	self parentType: anObject
+
+]

--- a/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
@@ -26,6 +26,13 @@ FamixTest1ImportingContext >> importAssociation [
 ]
 
 { #category : #testing }
+FamixTest1ImportingContext >> importAttribute [
+
+	<generated>
+	^ self import: FamixTest1Attribute
+]
+
+{ #category : #testing }
 FamixTest1ImportingContext >> importClass [
 
 	<generated>
@@ -142,6 +149,13 @@ FamixTest1ImportingContext >> shouldImportAssociation [
 
 	<generated>
 	^ self shouldImport: FamixTest1Association
+]
+
+{ #category : #testing }
+FamixTest1ImportingContext >> shouldImportAttribute [
+
+	<generated>
+	^ self shouldImport: FamixTest1Attribute
 ]
 
 { #category : #testing }

--- a/src/Famix-Test1-Tests/MooseAbstractGroupWithTest1ModelTest.class.st
+++ b/src/Famix-Test1-Tests/MooseAbstractGroupWithTest1ModelTest.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #MooseAbstractGroupWithTest1ModelTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'model',
+		'c1',
+		'c2',
+		'c3',
+		'm1',
+		'm2',
+		'm3',
+		'anchor1',
+		'anchor2',
+		'anchor3',
+		'anchorC1',
+		'a1'
+	],
+	#category : #'Famix-Test1-Tests'
+}
+
+{ #category : #running }
+MooseAbstractGroupWithTest1ModelTest >> setUp [
+	super setUp.
+
+	model := FamixTest1MooseModel new.
+	c1 := FamixTest1Class named: 'Class1'.
+	c2 := FamixTest1Class named: 'Class2'.
+	m1 := FamixTest1Method named: 'method1'.
+	m2 := FamixTest1Method named: 'method2'.
+	m3 := FamixTest1Method named: 'method3'.
+	a1 := FamixTest1Attribute named: 'attribute1'.
+	anchor1 := FamixTest1SourceTextAnchor new source: 'method1\source1' withCRs.
+	anchor2 := FamixTest1SourceTextAnchor new source: 'method2\source2a\source2b' withCRs.
+	anchor3 := FamixTest1SourceTextAnchor new source: 'method3\source3a\source3b\source3c' withCRs.
+	anchorC1 := FamixTest1SourceTextAnchor new source: 'Class1 definition' withCRs.
+
+	model addAll: {c1 . c2 . m1 . m2 . m3 . a1. anchor1 . anchor2}.
+
+	c1 addMethod: m1.
+	m2 parentType: c2.	"opposite way"
+	c2 addMethod: m3.
+	c1 addAttribute: a1.
+	c1 sourceAnchor: anchorC1.
+	m1 sourceAnchor: anchor1.
+	m2 sourceAnchor: anchor2.
+	m3 sourceAnchor: anchor3
+]
+
+{ #category : #tests }
+MooseAbstractGroupWithTest1ModelTest >> testAllContainers [
+	self assertCollection: model allContainers hasSameElements: { c1. c2. m1. m2. m3 }
+]
+
+{ #category : #tests }
+MooseAbstractGroupWithTest1ModelTest >> testAllStructuralEntities [
+	self assertCollection: model allStructuralEntities hasSameElements: { a1 }
+]

--- a/src/Famix-Test1-Tests/MooseEntityWithTest1ModelTest.class.st
+++ b/src/Famix-Test1-Tests/MooseEntityWithTest1ModelTest.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : #MooseEntityWithTest1ModelTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'model',
+		'c1',
+		'c2',
+		'c3',
+		'm1',
+		'm2',
+		'm3',
+		'anchor1',
+		'anchor2',
+		'anchor3',
+		'anchorC1',
+		'a1'
+	],
+	#category : #'Famix-Test1-Tests'
+}
+
+{ #category : #running }
+MooseEntityWithTest1ModelTest >> setUp [
+	super setUp.
+
+	model := FamixTest1MooseModel new.
+	c1 := FamixTest1Class named: 'Class1'.
+	c2 := FamixTest1Class named: 'Class2'.
+	m1 := FamixTest1Method named: 'method1'.
+	m2 := FamixTest1Method named: 'method2'.
+	m3 := FamixTest1Method named: 'method3'.
+	a1 := FamixTest1Attribute named: 'attribute1'.
+	anchor1 := FamixTest1SourceTextAnchor new source: 'method1\source1' withCRs.
+	anchor2 := FamixTest1SourceTextAnchor new source: 'method2\source2a\source2b' withCRs.
+	anchor3 := FamixTest1SourceTextAnchor new source: 'method3\source3a\source3b\source3c' withCRs.
+	anchorC1 := FamixTest1SourceTextAnchor new source: 'Class1 definition' withCRs.
+
+	model addAll: {c1 . c2 . m1 . m2 . m3 . anchor1 . anchor2}.
+
+	c1 addMethod: m1.
+	m2 parentType: c2.	"opposite way"
+	c2 addMethod: m3.
+	c1 addAttribute: a1.
+	c1 sourceAnchor: anchorC1.
+	m1 sourceAnchor: anchor1.
+	m2 sourceAnchor: anchor2.
+	m3 sourceAnchor: anchor3
+]
+
+{ #category : #tests }
+MooseEntityWithTest1ModelTest >> testIsContainerEntity [
+	self assert: c1 isContainerEntity.
+	self deny: a1 isContainerEntity
+]

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -35,7 +35,7 @@ TEntityMetaLevelDependencyTest >> setUp [
 	anchor3 := FamixTest1SourceTextAnchor new source: 'method3\source3a\source3b\source3c' withCRs.
 	anchorC1 := FamixTest1SourceTextAnchor new source: 'Class1 definition' withCRs.
 	
-	model addAll: { c1. c2. m1. m2. m3. anchor1. anchor2 }.
+	model addAll: { c1. c2. m1. m2. m3. a1. anchor1. anchor2 }.
 	
 	c1 addMethod: m1.
 	m2 parentType: c2. "opposite way"

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -12,7 +12,8 @@ Class {
 		'anchor1',
 		'anchor2',
 		'anchor3',
-		'anchorC1'
+		'anchorC1',
+		'a1'
 	],
 	#category : #'Famix-Test1-Tests'
 }
@@ -23,12 +24,12 @@ TEntityMetaLevelDependencyTest >> setUp [
 	super setUp.
 
 	model := FamixTest1MooseModel new.
-	model metamodel: FamixTest1Class metamodel.
 	c1 := FamixTest1Class named: 'Class1'.
 	c2 := FamixTest1Class named: 'Class2'.
 	m1 := FamixTest1Method named: 'method1'.
 	m2 := FamixTest1Method named: 'method2'.
 	m3 := FamixTest1Method named: 'method3'.
+	a1 := FamixTest1Attribute named: 'attribute1'.
 	anchor1 := FamixTest1SourceTextAnchor new source: 'method1\source1' withCRs .
 	anchor2 := FamixTest1SourceTextAnchor new source: 'method2\source2a\source2b' withCRs.
 	anchor3 := FamixTest1SourceTextAnchor new source: 'method3\source3a\source3b\source3c' withCRs.
@@ -39,6 +40,7 @@ TEntityMetaLevelDependencyTest >> setUp [
 	c1 addMethod: m1.
 	m2 parentType: c2. "opposite way"
 	c2 addMethod: m3.
+	c1 addAttribute: a1.
 	c1 sourceAnchor: anchorC1.
 	m1 sourceAnchor: anchor1.
 	m2 sourceAnchor: anchor2.
@@ -48,12 +50,10 @@ TEntityMetaLevelDependencyTest >> setUp [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAddAllChildrenIn [
-
 	| aCollection |
-	
 	aCollection := Set new.
 	c1 addAllChildrenIn: aCollection.
-	self assertCollection: aCollection hasSameElements: { m1 }.
+	self assertCollection: aCollection hasSameElements: {m1 . a1}
 ]
 
 { #category : #tests }
@@ -88,11 +88,10 @@ TEntityMetaLevelDependencyTest >> testAllAtScope [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllChildren [
-
-	self assertCollection: c1 allChildren hasSameElements: { m1. }.
-	self assertCollection: c2 allChildren hasSameElements: { m2. m3 }.
-	self assertCollection: m1 allChildren hasSameElements: { }.
-	self assert: anchor1 allChildren isEmpty.
+	self assertCollection: c1 allChildren hasSameElements: {m1 . a1}.
+	self assertCollection: c2 allChildren hasSameElements: {m2 . m3}.
+	self assertCollection: m1 allChildren hasSameElements: {}.
+	self assert: anchor1 allChildren isEmpty
 ]
 
 { #category : #tests }
@@ -105,7 +104,7 @@ TEntityMetaLevelDependencyTest >> testAllChildrenTypes [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllIncomingAssociationTypes [
-	self assertCollection: c1 allIncomingAssociationTypes hasSameElements: {FamixTSuperInheritance . FamixTInvocation}
+	self assertCollection: c1 allIncomingAssociationTypes hasSameElements: {FamixTSuperInheritance . FamixTInvocation. FamixTAccess}
 ]
 
 { #category : #tests }
@@ -189,7 +188,7 @@ TEntityMetaLevelDependencyTest >> testBelongsTo [
 TEntityMetaLevelDependencyTest >> testChildren [
 
 	self assertCollection: m1 children hasSameElements: { }.
-	self assertCollection: c1 children hasSameElements: { m1 }.
+	self assertCollection: c1 children hasSameElements: { m1. a1 }.
 	self assertCollection: c2 children hasSameElements: { m2. m3 }.
 	self assertCollection: anchor1 children hasSameElements: { }.
 	
@@ -209,7 +208,15 @@ TEntityMetaLevelDependencyTest >> testChildrenSelectors [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testIncomingAssociationTypes [
-	self assertCollection: c1 allIncomingAssociationTypes hasSameElements: {FamixTSuperInheritance . FamixTInvocation}
+	self assertCollection: c1 allIncomingAssociationTypes hasSameElements: {FamixTSuperInheritance . FamixTInvocation. FamixTAccess}
+]
+
+{ #category : #tests }
+TEntityMetaLevelDependencyTest >> testNumberOfChildren [
+	self assert: c1 numberOfChildren equals: 2.
+	self assert: c2 numberOfChildren equals: 2.
+	self assert: m1 numberOfChildren equals: 0.
+	self assert: a1 numberOfChildren equals: 0
 ]
 
 { #category : #tests }

--- a/src/Famix-TestGenerators/FamixTest1Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest1Generator.class.st
@@ -28,7 +28,8 @@ Class {
 	#superclass : #FamixFileBasedLanguageGenerator,
 	#instVars : [
 		'classEntity',
-		'method'
+		'method',
+		'attribute'
 	],
 	#category : #'Famix-TestGenerators'
 }
@@ -47,29 +48,26 @@ FamixTest1Generator class >> prefix [
 
 { #category : #definition }
 FamixTest1Generator >> defineClasses [
-
 	super defineClasses.
 
 	classEntity := builder newClassNamed: #Class.
 	method := builder newClassNamed: #Method.
-
-
+	attribute := builder newClassNamed: #Attribute
 ]
 
 { #category : #definition }
 FamixTest1Generator >> defineHierarchy [
-
 	super defineHierarchy.
 
 	method --|> namedEntity.
 	method --|> #TMethod.
 
 	classEntity --|> namedEntity.
-	classEntity --|> #TClass
+	classEntity --|> #TClass.
 
-	
-
-
+	attribute --|> namedEntity.
+	attribute --|> #TStructuralEntity.
+	attribute --|> #TAttribute.
 ]
 
 { #category : #definition }

--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -225,6 +225,12 @@ MooseAbstractGroup >> allReferences [
 ]
 
 { #category : #'*Famix-Traits' }
+MooseAbstractGroup >> allStructuralEntities [
+	<navigation: 'All structural entities'>
+	^ self allUsing: FamixTStructuralEntity
+]
+
+{ #category : #'*Famix-Traits' }
 MooseAbstractGroup >> allTestClasses [
 	<navigation: 'All test classes'>
 	<package: #Java>

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -47,6 +47,12 @@ MooseAbstractGroup >> addAll: aCollectionOfItems [
 	^ self subclassResponsibility
 ]
 
+{ #category : #accessing }
+MooseAbstractGroup >> allContainers [
+	<navigation: 'All containers'>
+	^ self lookUpPropertyNamed: #allContainers computedAs: [ self entities select: #isContainerEntity ]
+]
+
 { #category : #groups }
 MooseAbstractGroup >> allModels [ 
 	 "returns all known Models (be them MooseModels or of a subclass of it)"

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -174,6 +174,14 @@ MooseEntity class >> implementingClassesIn: aMetamodel [
 ]
 
 { #category : #testing }
+MooseEntity class >> isContainerEntityIn: aMetamodel [
+	^ aMetamodel
+		additionalProperty: #isContainerEntity
+		for: self
+		ifAbsentPut: [ (self allDeclaredPropertiesIn: aMetamodel) anySatisfy: #isChildrenProperty ]
+]
+
+{ #category : #testing }
 MooseEntity class >> isOfType: aClassFAMIX [
 	^ self superclassesAndFamixTraits includes: aClassFAMIX
 ]
@@ -392,6 +400,11 @@ MooseEntity >> isBookmarked [
 { #category : #accessing }
 MooseEntity >> isBookmarked: aBoolean [
 	self propertyNamed: #isBookmarked put: aBoolean
+]
+
+{ #category : #testing }
+MooseEntity >> isContainerEntity [
+	^ self class isContainerEntityIn: self metamodel
 ]
 
 { #category : #testing }

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -542,6 +542,14 @@ TEntityMetaLevelDependency >> incomingMSEProperties [
 ]
 
 { #category : #accessing }
+TEntityMetaLevelDependency >> numberOfChildren [
+	<MSEProperty: #numberOfChildren type: #Number>
+	<MSEComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
+]
+
+{ #category : #accessing }
 TEntityMetaLevelDependency >> outgoingAssociationTypes [
 	^ self class outgoingAssociationTypesIn: self metamodel
 ]


### PR DESCRIPTION
The long term goal is to kill famix container entities in the hierarchy. This commit rewrite #isContainerEntity to be based on the MM. It also generalize #numberOfChildren.This PR also add #allContainers and #allStructuralEntities to groups.