### PR TITLE
1711-Generator-should-generate-isXX-only-if-the-entity-is-present-in-the-MM

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -117,13 +117,6 @@ FAMIXEntity >> isReference [
 ]
 
 { #category : #testing }
-FAMIXEntity >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FAMIXEntity >> isType [
 
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -73,13 +73,6 @@ FamixJavaEntity >> isClass [
 ]
 
 { #category : #testing }
-FamixJavaEntity >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixJavaEntity >> isInheritance [
 
 	<generated>

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -278,7 +278,7 @@ FamixMetamodelBuilder >> initialize [
 	classes := OrderedCollection new.
 	traits := OrderedCollection new.
 	relations := OrderedCollection new.
-	testingSelectorsMapping := Set new.	
+	testingSelectorsMapping := Dictionary new.	
 	
 	
 ]
@@ -387,8 +387,8 @@ FamixMetamodelBuilder >> prepareGeneration [
 	self resolveRequirementsFromContainers.
 	self registerPackages.
 
-	self traits do: [ :each | self testingSelectorsMapping addAll: each testingSelectors ].
-	self sortedClasses do: [ :each | self testingSelectorsMapping addAll: each testingSelectors ].
+	self traits do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
+	self sortedClasses do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
 	self traits do: [ :each | each generate ].
 	self sortedClasses do: [ :each | each generate ].
 	self traits do: [ :each | each generateNavigationGroups ].

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -61,11 +61,23 @@ FmxMBBehavior >> addTraitGeneralization: aTrait [
 	^ aTrait
 ]
 
+{ #category : #accessing }
+FmxMBBehavior >> allLocalTraits [
+	^ self traitGeneralizations
+]
+
 { #category : #'as yet unclassified' }
 FmxMBBehavior >> allNavigationGroups [
 
 	^ self navigationGroups, (self relations flatCollect: [ :relation |
 		relation side navigationGroups ]).
+]
+
+{ #category : #accessing }
+FmxMBBehavior >> allTransitiveTraits [
+	^ (Set with: self)
+		addAll: (self allLocalTraits flatCollect: [ :trait | trait allTransitiveTraits ]);
+		yourself
 ]
 
 { #category : #converting }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -34,7 +34,7 @@ FmxMBClass >> allClassGeneralizations [
 
 { #category : #accessing }
 FmxMBClass >> allLocalTraits [
-	^ super allLocalTraits , self traitsFromRelations
+	^ self traitsFromRelations , super allLocalTraits
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -34,9 +34,7 @@ FmxMBClass >> allClassGeneralizations [
 
 { #category : #accessing }
 FmxMBClass >> allLocalTraits [
-
-	^ self traitsFromRelations, self traitGeneralizations
-
+	^ super allLocalTraits , self traitsFromRelations
 ]
 
 { #category : #accessing }
@@ -255,16 +253,16 @@ FmxMBClass >> generateRequirementsFor: aClass [
 
 { #category : #accessing }
 FmxMBClass >> generateTestingMethodsIn: aClass [
-	
-	self isRoot ifTrue: [ 
-		builder testingSelectorsMapping do: [ :sel |
-			| selectorsFromTraits |
-			selectorsFromTraits := self traitGeneralizations flatCollect: #testingSelectors.
-			(selectorsFromTraits includes: sel) 
-				ifFalse: [ 
-				aClass instanceSide 
-					compile: ('{1}\\	<generated>\	^ false' withCRs format: { sel }) 
-					classified: #testing ] ] ].
+	self isRoot
+		ifTrue: [ builder testingSelectorsMapping
+				keysAndValuesDo: [ :concernedClass :selectors | 
+					"In case a testing selector is relatif to a Trait that is not used in the current MM, then we do not need to generate the testing selector."
+					(concernedClass isMetamodelTrait and: [ builder classes noneSatisfy: [ :class | class allTransitiveTraits includes: concernedClass ] ])
+						ifFalse: [ selectors
+								do: [ :sel | 
+									| selectorsFromTraits |
+									selectorsFromTraits := self traitGeneralizations flatCollect: #testingSelectors.
+									(selectorsFromTraits includes: sel) ifFalse: [ aClass instanceSide compile: ('{1}\\	<generated>\	^ false' withCRs format: {sel}) classified: #testing ] ] ] ] ].
 
 	super generateTestingMethodsIn: aClass
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -49,13 +49,6 @@ FamixStEntity >> isClass [
 ]
 
 { #category : #testing }
-FamixStEntity >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixStEntity >> isInheritance [
 
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -21,13 +21,6 @@ FamixTest1Entity class >> metamodel [
 ]
 
 { #category : #testing }
-FamixTest1Entity >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest1Entity >> isAssociation [
 
 	<generated>
@@ -49,27 +42,6 @@ FamixTest1Entity >> isClass [
 ]
 
 { #category : #testing }
-FamixTest1Entity >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Entity >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Entity >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest1Entity >> isMethod [
 
 	<generated>
@@ -77,35 +49,7 @@ FamixTest1Entity >> isMethod [
 ]
 
 { #category : #testing }
-FamixTest1Entity >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Entity >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Entity >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest1Entity >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Entity >> isType [
 
 	<generated>
 	^ false

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -21,21 +21,7 @@ FamixTest2Entity class >> metamodel [
 ]
 
 { #category : #testing }
-FamixTest2Entity >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest2Entity >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isAttribute [
 
 	<generated>
 	^ false
@@ -49,63 +35,7 @@ FamixTest2Entity >> isClass [
 ]
 
 { #category : #testing }
-FamixTest2Entity >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest2Entity >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Entity >> isType [
 
 	<generated>
 	^ false

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -21,13 +21,6 @@ FamixTest3Entity class >> metamodel [
 ]
 
 { #category : #testing }
-FamixTest3Entity >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest3Entity >> isAssociation [
 
 	<generated>
@@ -35,28 +28,7 @@ FamixTest3Entity >> isAssociation [
 ]
 
 { #category : #testing }
-FamixTest3Entity >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest3Entity >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Entity >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Entity >> isInheritance [
 
 	<generated>
 	^ false
@@ -77,28 +49,7 @@ FamixTest3Entity >> isMethod [
 ]
 
 { #category : #testing }
-FamixTest3Entity >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Entity >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixTest3Entity >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Entity >> isStructuralEntity [
 
 	<generated>
 	^ false


### PR DESCRIPTION
Do not generate #isXX methods if it comes from a Trait that is not used in the current MM.

Fixes #1711