### PR TITLE
1774-Moose-query-result-within-can-be-rewrite-in-a-much-more-generic-way

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -86,7 +86,7 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-TestComposed3Metamodel-Entities' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
 				package: 'Famix-TestComposedMetamodel' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
 
-				package: 'Famix-Deprecated' with: [ spec required: #('Core' 'ModelCompatibility' 'ModelJava' 'ModelSmalltalk' 'Tests') ].
+				package: 'Famix-Deprecated' with: [ spec requires: #('Core' 'ModelCompatibility' 'ModelJava' 'ModelSmalltalk' 'Tests') ].
 
 			"Groups"
 			spec

--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -16,13 +16,11 @@ Class {
 { #category : #baseline }
 BaselineOfFamix >> baseline: spec [
 	<baseline>
-	
 	repository := self packageRepositoryURL.
-	
+
 	spec
 		for: #common
-		do: [
-			"Dependencies"
+		do: [ "Dependencies"
 			self
 				deepTraverser: spec;
 				fame: spec;
@@ -41,7 +39,6 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Moose-Query-Extensions' with: [ spec requires: #('Moose-Query' 'Famix-Traits') ];
 				package: 'Famix-Groups' with: [ spec requires: #('Moose-Core' 'NeoCSV') ];
 				package: 'Famix-Traits' with: [ spec requires: #('Famix-Groups' 'Moose-Core') ];
-
 				package: 'Famix-MetamodelBuilder-Core' with: [ spec requires: #('Famix-Traits') ];
 				package: 'Famix-MetamodelGeneration' with: [ spec requires: #('Famix-MetamodelBuilder-Core') ];
 				package: 'Famix-BasicInfrastructure' with: [ spec requires: #('Famix-MetamodelBuilder-Core') ];
@@ -54,10 +51,9 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-PharoSmalltalk-Entities' with: [ spec requires: #('Famix-MetamodelBuilder-Core' 'Famix-Smalltalk-Utils' 'Famix-Traits') ];
 				package: 'Famix-PharoSmalltalk-Importer' with: [ spec requires: #('Famix-PharoSmalltalk-Entities' 'Moose-SmalltalkImporter') ];
 				package: 'Famix-PharoSmalltalk-Tests' with: [ spec requires: #('Famix-PharoSmalltalk-Entities' 'Famix-Test1-Entities' 'Moose-Core') ];
-
 				package: 'Famix-Java-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-Java-Entities' with: [ spec requires: #('Famix-MetamodelBuilder-Core' 'Famix-Traits') ];
-				package: 'Famix-Java-Tests' with: [ spec requires: #('Famix-Java-Entities' 'Famix-Java-Generator' ) ];
+				package: 'Famix-Java-Tests' with: [ spec requires: #('Famix-Java-Entities' 'Famix-Java-Generator') ];
 				package: 'Moose-TestResources-LAN';
 				package: 'Moose-TestResources-LCOM';
 				package: 'Moose-Query-Test' with: [ spec requires: #('Moose-Query' 'Famix-Compatibility-Entities') ];
@@ -88,18 +84,22 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-TestComposedMetamodel-Entities' with: [ spec requires: #('Famix-Test2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedSubmetamodel2-Entities') ];
 				package: 'Famix-TestComposedComposedMetamodel-Entities' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
 				package: 'Famix-TestComposed3Metamodel-Entities' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
-				package: 'Famix-TestComposedMetamodel' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ].
+				package: 'Famix-TestComposedMetamodel' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
+
+				package: 'Famix-Deprecated' with: [ spec required: #('Core' 'ModelCompatibility' 'ModelJava' 'ModelSmalltalk' 'Tests') ].
 
 			"Groups"
 			spec
 				group: 'Core' with: #('Famix-Traits' 'Moose-Query-Extensions');
 				group: 'Basic' with: #('Famix-BasicInfrastructure' 'Famix-MetamodelGeneration');
 				group: 'TestsResources' with: #('ReferenceTestResources' 'Moose-TestResources-LAN' 'Moose-TestResources-LCOM' 'KGBTestResources' 'PackageBlueprintTestResources');
-				group: 'ModelCompatibility' with: #('Famix-Compatibility-Generator' 'Famix-Compatibility-Entities' );
+				group: 'ModelCompatibility' with: #('Famix-Compatibility-Generator' 'Famix-Compatibility-Entities');
 				group: 'ModelJava' with: #('Famix-Java-Generator' 'Famix-Java-Entities');
 				group: 'ModelSmalltalk' with: #('Famix-PharoSmalltalk-Generator' 'Famix-PharoSmalltalk-Entities' 'Famix-PharoSmalltalk-Importer');
 				group: 'Importers' with: #('Moose-GenericImporter' 'Moose-SmalltalkImporter');
-				group: 'Tests' with: #('Famix-Tests' 'Moose-Query-Test' 'Moose-Tests-Core' 'Famix-Smalltalk-Utils-Tests' 'Moose-Tests-SmalltalkImporter-LAN' 'Moose-Tests-SmalltalkImporter-Core' 'Moose-Tests-SmalltalkImporter-KGB' 'Famix-Java-Tests' 'Famix-Groups-Tests' 'Famix-Compatibility-Tests-C' 'Famix-Compatibility-Tests-Java' 'Famix-Compatibility-Tests-Core' 'Famix-Compatibility-Tests-Extensions' 'Famix-PharoSmalltalk-Tests' 'Famix-TestGenerators' 'Famix-MetamodelBuilder-Tests' 'Famix-Test1-Entities' 'Famix-Test1-Tests' 'Famix-Test2-Entities' 'Famix-Test2-Tests' 'Famix-Test3-Entities' 'Famix-Test3-Tests' 'Famix-Test4-Entities' 'Famix-Test4-Tests' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedMetamodel-Entities' 'Famix-TestComposedMetamodel' 'Famix-TestComposedComposedMetamodel-Entities' 'Famix-TestComposed3Metamodel-Entities') ].
+				group: 'Tests'
+					with:
+					#('Famix-Tests' 'Moose-Query-Test' 'Moose-Tests-Core' 'Famix-Smalltalk-Utils-Tests' 'Moose-Tests-SmalltalkImporter-LAN' 'Moose-Tests-SmalltalkImporter-Core' 'Moose-Tests-SmalltalkImporter-KGB' 'Famix-Java-Tests' 'Famix-Groups-Tests' 'Famix-Compatibility-Tests-C' 'Famix-Compatibility-Tests-Java' 'Famix-Compatibility-Tests-Core' 'Famix-Compatibility-Tests-Extensions' 'Famix-PharoSmalltalk-Tests' 'Famix-TestGenerators' 'Famix-MetamodelBuilder-Tests' 'Famix-Test1-Entities' 'Famix-Test1-Tests' 'Famix-Test2-Entities' 'Famix-Test2-Tests' 'Famix-Test3-Entities' 'Famix-Test3-Tests' 'Famix-Test4-Entities' 'Famix-Test4-Tests' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedMetamodel-Entities' 'Famix-TestComposedMetamodel' 'Famix-TestComposedComposedMetamodel-Entities' 'Famix-TestComposed3Metamodel-Entities') ].
 
 	"We need different versions of Ring for Pharo 7 and 8."
 	spec

--- a/src/Famix-Compatibility-Entities/FAMIXClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXClass.class.st
@@ -136,11 +136,6 @@ FAMIXClass >> methodsWithoutSutbsAndConstructors [
 		each isStub not and: [each isConstructor not]]) asSet
 ]
 
-{ #category : #'moosechef-scoping-filtering' }
-FAMIXClass >> selectWithinYourScope: aMooseQueryResult [
-	^ aMooseQueryResult withinClass: self
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXClass >> smalltalkClass [ 
 	"Returns the associated smalltalk class if it exist in the system."

--- a/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
@@ -81,9 +81,3 @@ FAMIXFunction >> mooseNameOn: stream [
 FAMIXFunction >> parentScope [
 	^ self functionOwner
 ]
-
-{ #category : #accessing }
-FAMIXFunction >> parentScope: aScopingEntity [ 
-	self deprecated: 'Please use container: instead of parentScope:'.
-	self container: aScopingEntity
-]

--- a/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
@@ -38,18 +38,6 @@ FAMIXImplicitVariable >> belongsTo: anObject [
 
 ]
 
-{ #category : #accessing }
-FAMIXImplicitVariable >> container [
-	self deprecated: 'Please use parentBehaviouralEntity instead'.  
-	^ self parentBehaviouralEntity
-]
-
-{ #category : #accessing }
-FAMIXImplicitVariable >> container: aBehaviouralEntity [
-	self deprecated: 'Please use #parentBehaviouralEntity: instead'.
-	^ self parentBehaviouralEntity: aBehaviouralEntity
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXImplicitVariable >> isImplicitVariable [
 	^true

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -102,12 +102,3 @@ FAMIXInvocation >> printOn: aStream [
 FAMIXInvocation >> receiverSourceCode [
 	^ self receiver sourceText
 ]
-
-{ #category : #accessing }
-FAMIXInvocation >> receiverSourceCode: aString [
-	"CyrilFerlicot: Deprecated the 19 sept 2017"
-
-	self
-		deprecated:
-			'The source code of the receiver should not be saved as a property. Instead access it via the receiver entity and it should be created as a sourceAnchor in the receiver.'
-]

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -40,11 +40,6 @@ FAMIXNamedEntity >> belongsTo: anObject [
 
 ]
 
-{ #category : #'moosechef-scoping-filtering' }
-FAMIXNamedEntity >> selectWithinYourScope: aMooseQueryResult [
-	self subclassResponsibility
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXNamedEntity >> stubFormattedName [
 	 ^ self isStub 
@@ -52,16 +47,4 @@ FAMIXNamedEntity >> stubFormattedName [
 					string: self name
 					attribute: TextEmphasis italic ]
 		ifFalse: [ Text fromString: self name ] 
-]
-
-{ #category : #'moosechef-scoping-filtering' }
-FAMIXNamedEntity >> yourScope [
-	"Empty default scope"
-
-	self
-		deprecated:
-			'#yourScope was used by MooseChef for queries. Now, MooseQuery does not need it anymore. Example of code update: "myEntity queryAllIncoming perform: mySecondEntity yourScope" => "myEntity queryAllIncoming withScope: mySecondEntity class"'
-		on: '12 january 2018'
-		in: 'Moose6.1'.
-	^ nil
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
@@ -63,15 +63,14 @@ FAMIXNamespace >> bunchCouplingWith: aNamespace [
 	myClasses := myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
 	otherClasses := aNamespace classes.
 	otherClasses := otherClasses union: (otherClasses flatCollect: [ :c | c allRecursiveTypes ]).
-	(myClasses size == 0 or: [ otherClasses size == 0 ])
-		ifTrue: [ ^ nil ].
+	(myClasses size == 0 or: [ otherClasses size == 0 ]) ifTrue: [ ^ nil ].
 
 	"All outgoing dependencies"
-	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) withinNamespace: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ].
+	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) within: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ].
 
 	"Plus all incoming dependencies"
 	interConnectivities := interConnectivities
-		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) withinNamespace: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
+		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) within: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
 	^ interConnectivities / (2 * myClasses size * otherClasses size) asFloat
 ]
 
@@ -270,11 +269,6 @@ FAMIXNamespace >> printOn: aStream [
 			nextPut: $: ].
 	self name ifNotNil: [ aStream nextPutAll: self name ].
 	aStream nextPutAll: ' (Namespace)'
-]
-
-{ #category : #'moosechef-scoping-filtering' }
-FAMIXNamespace >> selectWithinYourScope: aMooseQueryResult [
-	^ aMooseQueryResult withinNamespace: self
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
@@ -88,14 +88,14 @@ FAMIXPackage >> bunchCouplingWith: aPackage [
 		ifTrue: [ ^ nil ].
 
 	"All outgoing dependencies"
-	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) withinPackage: aPackage ])
+	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) within: aPackage ])
 		inject: 0
 		into: [ :subTotal :each | subTotal + (each select: [ :c | c isInstanceSide ]) size ].
 
 	"Plus all incoming dependencies"
 	interConnectivities := interConnectivities
 		+
-			((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) withinPackage: aPackage ])
+			((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) within: aPackage ])
 				inject: 0
 				into: [ :subTotal :each | subTotal + (each select: [ :c | c isInstanceSide ]) size ]).
 	^ interConnectivities / (2 * myClasses size * otherClasses size) asFloat
@@ -138,7 +138,7 @@ FAMIXPackage >> childNamedEntities: aNamedEntity [
 
 { #category : #'Famix-Extensions' }
 FAMIXPackage >> childrenOfMyKind [
-	^ self childNamedEntities allWithSubTypesOf: self class
+	^ self childEntities allWithSubTypesOf: self class
 ]
 
 { #category : #'Famix-Implementation' }
@@ -158,7 +158,7 @@ FAMIXPackage >> concernedClassesCollection [
 
 { #category : #'Famix-Extensions' }
 FAMIXPackage >> containedEntities [
-	^ super containedEntities union: self childNamedEntities
+	^ super containedEntities union: self childEntities
 ]
 
 { #category : #'Famix-Extensions-accessing' }
@@ -366,9 +366,4 @@ FAMIXPackage >> relativeImportanceForSystem [
 							]
 						ifFalse: [0]
 						]
-]
-
-{ #category : #'moosechef-scoping-filtering' }
-FAMIXPackage >> selectWithinYourScope: aMooseQueryResult [
-	^ aMooseQueryResult withinPackage: self
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -50,12 +50,6 @@ FAMIXScopingEntity >> allClassesGroup [
 	^ FAMIXTypeGroup withAll: self allClasses withDescription: 'All classes from ', self printString
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXScopingEntity >> allRecursiveClasses [
-	self deprecated: 'Use allClasses'.
-	^ self allClasses 
-]
-
 { #category : #accessing }
 FAMIXScopingEntity >> belongsTo [
 

--- a/src/Famix-Compatibility-Tests-Core/FAMIXTypeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXTypeTest.class.st
@@ -16,8 +16,8 @@ FAMIXTypeTest >> testBehaviorsWithDeclaredType [
 	behaviour := FAMIXBehaviouralEntity new.
 	behaviour declaredType: type.
 	self assert: behaviour declaredType == type.
-	self assert: type behavioursWithDeclaredType size equals: 1.
-	self assert: (type behavioursWithDeclaredType includes: behaviour)
+	self assert: type structuresWithDeclaredType size equals: 1.
+	self assert: (type structuresWithDeclaredType includes: behaviour)
 ]
 
 { #category : #tests }

--- a/src/Famix-Deprecated/FamixStClass.extension.st
+++ b/src/Famix-Deprecated/FamixStClass.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #FamixStClass }
+
+{ #category : #'*Famix-Deprecated' }
+FamixStClass >> hasMethodWithSignature: aSignature [
+	self deprecated: 'Use #implements: instead' transformWith: '`@receiver hasMethodWithSignature: `@statements1' -> '`@receiver implements: `@statements1'.
+	^ self implements: aSignature
+]
+
+{ #category : #'*Famix-Deprecated' }
+FamixStClass >> isSUnitTestCase [
+	self deprecated: 'Use #isTestCase instead' transformWith: '`@receiver isSUnitTestCase' -> '`@receiver isTestCase'.
+	^ self isTestCase
+]

--- a/src/Famix-Deprecated/FamixTMethod.extension.st
+++ b/src/Famix-Deprecated/FamixTMethod.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #FamixTMethod }
+
+{ #category : #'*Famix-Deprecated' }
+FamixTMethod >> hasClassScope [
+	<MSEProperty: #hasClassScope type: #Boolean>
+	<MSEComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
+	^ self isClassSide
+]
+
+{ #category : #'*Famix-Deprecated' }
+FamixTMethod >> hasClassScope: aBoolean [
+	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope: `@statements1' -> '`@receiver isClassSide: `@statements1'.
+	^ self isClassSide: aBoolean
+]

--- a/src/Famix-Deprecated/MooseEntity.extension.st
+++ b/src/Famix-Deprecated/MooseEntity.extension.st
@@ -1,0 +1,117 @@
+Extension { #name : #MooseEntity }
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> clientMethods [
+	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientMethods' -> '`@receiver allClientsAtScope: FamixTMethod'.
+	^ self allClientsAtScope: FamixTMethod
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> clientNamespaces [
+	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientNamespaces' -> '`@receiver allClientsAtScope: FamixTNamespace'.
+	^ self allClientsAtScope: FamixTNamespace
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> clientPackages [
+	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientPackages' -> '`@receiver allClientsAtScope: FamixTPackage'.
+	^ self allClientsAtScope: FamixTPackage
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> clientTypes [
+	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientTypes' -> '`@receiver allClientsAtScope: FamixTType'.
+	^ self allClientsAtScope: FamixTType
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> methodScope [
+	self
+		deprecated:
+			'methodScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
+	- `self allAtScope: FamixTMethod` if you want a collection of all the methods up in the containment tree of your entity
+	- `self allToScope: FamixTMethod` if you want a collection of all the methods down in the containment tree of your entity
+	- `self allWithScope: FamixTMethod` if you want a collection of all the methods up and down in the containment tree of your entity
+	- `self atScope: FamixTMethod` if you want a collection of the first encountered methods up in the containment tree of your entity
+	- `self toScope: FamixTMethod` if you want a collection of the first encountered methods down in the containment tree of your entity
+	- `self withScope: FamixTMethod` if you want a collection of the first encountered methods up and down in the containment tree of your entity
+	
+	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
+	"This implementation seems to be the most common"
+	^ (self toScope: FamixTMethod) anyOne
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> namespaceScope [
+	self
+		deprecated:
+			'namespaceScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
+	- `self allAtScope: FamixTNamespace` if you want a collection of all the namespaces up in the containment tree of your entity
+	- `self allToScope: FamixTNamespace` if you want a collection of all the namespaces down in the containment tree of your entity
+	- `self allWithScope: FamixTNamespace` if you want a collection of all the namespaces up and down in the containment tree of your entity
+	- `self atScope: FamixTNamespace` if you want a collection of the first encountered namespaces up in the containment tree of your entity
+	- `self toScope: FamixTNamespace` if you want a collection of the first encountered namespaces down in the containment tree of your entity
+	- `self withScope: FamixTNamespace` if you want a collection of the first encountered namespaces up and down in the containment tree of your entity
+	
+	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
+	"This implementation seems to be the most common"
+	^ (self atScope: FamixTNamespace) anyOne
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> packageScope [
+	self
+		deprecated:
+			'packageScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
+	- `self allAtScope: FamixTPackage` if you want a collection of all the packages up in the containment tree of your entity
+	- `self allToScope: FamixTPackage` if you want a collection of all the packages down in the containment tree of your entity
+	- `self allWithScope: FamixTPackage` if you want a collection of all the packages up and down in the containment tree of your entity
+	- `self atScope: FamixTPackage` if you want a collection of the first encountered packages up in the containment tree of your entity
+	- `self toScope: FamixTPackage` if you want a collection of the first encountered packages down in the containment tree of your entity
+	- `self withScope: FamixTPackage` if you want a collection of the first encountered packages up and down in the containment tree of your entity
+	
+	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
+	"This implementation seems to be the most common"
+	^ (self atScope: FamixTPackage) anyOne
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> providerMethods [
+	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerMethods' -> '`@receiver allProvidersAtScope: FamixTMethod'.
+	^ self allProvidersAtScope: FamixTMethod
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> providerNamespaces [
+	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerNamespaces' -> '`@receiver allProvidersAtScope: FamixTNamespace'.
+	^ self allProvidersAtScope: FamixTNamespace
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> providerPackages [
+	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerPackages' -> '`@receiver allProvidersAtScope: FamixTPackage'.
+	^ self allProvidersAtScope: FamixTPackage
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> providerTypes [
+	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerTypes' -> '`@receiver allProvidersAtScope: FamixTType'.
+	^ self allProvidersAtScope: FamixTType
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseEntity >> typeScope [
+	self
+		deprecated:
+			'typeScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
+	- `self allAtScope: FamixTType` if you want a collection of all the types up in the containment tree of your entity
+	- `self allToScope: FamixTType` if you want a collection of all the types down in the containment tree of your entity
+	- `self allWithScope: FamixTType` if you want a collection of all the types up and down in the containment tree of your entity
+	- `self atScope: FamixTType` if you want a collection of the first encountered types up in the containment tree of your entity
+	- `self toScope: FamixTType` if you want a collection of the first encountered types down in the containment tree of your entity
+	- `self withScope: FamixTType` if you want a collection of the first encountered types up and down in the containment tree of your entity
+	
+	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
+	"This implementation seems to be the most common"
+	^ (self atScope: FamixTType) anyOne
+]

--- a/src/Famix-Deprecated/MooseQueryResult.extension.st
+++ b/src/Famix-Deprecated/MooseQueryResult.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #MooseQueryResult }
+
+{ #category : #'*Famix-Deprecated' }
+MooseQueryResult >> withinClass: aFAMIXClass [
+	self deprecated: 'Use #within: instead' transformWith: '`@receiver withinClass: `@statements1' -> '`@receiver within: `@statements1'.
+	^ self within: aFAMIXClass
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseQueryResult >> withinNamespace: aFamixPackage [
+	self deprecated: 'Use #within: instead' transformWith: '`@receiver withinNamespace: `@statements1' -> '`@receiver within: `@statements1'.
+	^ self within: aFamixPackage
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseQueryResult >> withinPackage: aFamixPackage [
+	self deprecated: 'Use #within: instead' transformWith: '`@receiver withinPackage: `@statements1' -> '`@receiver within: `@statements1'.
+	^ self within: aFamixPackage
+]

--- a/src/Famix-Deprecated/package.st
+++ b/src/Famix-Deprecated/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Deprecated' }

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -116,11 +116,6 @@ FamixJavaClass >> methodsWithoutSutbsAndConstructors [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaClass >> selectWithinYourScope: aMooseQueryResult [
-	^ aMooseQueryResult withinClass: self
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaClass >> structuralChildren [
 	^ (OrderedCollection withAll: self methods), self attributes
 ]

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -15,22 +15,6 @@ FamixJavaException class >> annotation [
 	^self
 ]
 
-{ #category : #deprecated }
-FamixJavaException >> definingMethod [
-
-	^ self definingEntity
-	
-
-]
-
-{ #category : #deprecated }
-FamixJavaException >> definingMethod: aMethod [ 
-
-	^ self definingEntity: aMethod 
-	
-
-]
-
 { #category : #accessing }
 FamixJavaException >> mooseNameOn: aStream [ 
 	aStream nextPutAll: (self class name withoutPrefix: 'FamixJava').

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -32,18 +32,6 @@ FamixJavaImplicitVariable >> belongsTo: anObject [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaImplicitVariable >> container [
-	self deprecated: 'Please use parentBehaviouralEntity instead'.  
-	^ self parentBehaviouralEntity
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaImplicitVariable >> container: aBehaviouralEntity [
-	self deprecated: 'Please use #parentBehaviouralEntity: instead'.
-	^ self parentBehaviouralEntity: aBehaviouralEntity
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaImplicitVariable >> isImplicitVariable [
 	^true
 ]

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -102,12 +102,3 @@ FamixJavaInvocation >> printOn: aStream [
 FamixJavaInvocation >> receiverSourceCode [
 	^ self receiver sourceText
 ]
-
-{ #category : #'as yet unclassified' }
-FamixJavaInvocation >> receiverSourceCode: aString [
-	"CyrilFerlicot: Deprecated the 19 sept 2017"
-
-	self
-		deprecated:
-			'The source code of the receiver should not be saved as a property. Instead access it via the receiver entity and it should be created as a sourceAnchor in the receiver.'
-]

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -36,27 +36,10 @@ FamixJavaNamedEntity >> belongsTo: anObject [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaNamedEntity >> selectWithinYourScope: aMooseQueryResult [
-	self subclassResponsibility
-]
-
-{ #category : #'as yet unclassified' }
 FamixJavaNamedEntity >> stubFormattedName [
 	 ^ self isStub 
 		ifTrue: [ Text 
 					string: self name
 					attribute: TextEmphasis italic ]
 		ifFalse: [ Text fromString: self name ] 
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaNamedEntity >> yourScope [
-	"Empty default scope"
-
-	self
-		deprecated:
-			'#yourScope was used by MooseChef for queries. Now, MooseQuery does not need it anymore. Example of code update: "myEntity queryAllIncoming perform: mySecondEntity yourScope" => "myEntity queryAllIncoming withScope: mySecondEntity class"'
-		on: '12 january 2018'
-		in: 'Moose6.1'.
-	^ nil
 ]

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -89,11 +89,11 @@ FamixJavaNamespace >> bunchCouplingWith: aNamespace [
 		ifTrue: [ ^ nil ].
 
 	"All outgoing dependencies"
-	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) withinNamespace: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ].
+	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) within: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ].
 
 	"Plus all incoming dependencies"
 	interConnectivities := interConnectivities
-		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) withinNamespace: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
+		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) within: aNamespace ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
 	^ interConnectivities / (2 * myClasses size * otherClasses size) asFloat
 ]
 
@@ -321,11 +321,6 @@ FamixJavaNamespace >> printOn: aStream [
 			nextPut: $: ].
 	self name ifNotNil: [ aStream nextPutAll: self name ].
 	aStream nextPutAll: ' (Namespace)'
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaNamespace >> selectWithinYourScope: aMooseQueryResult [
-	^ aMooseQueryResult withinNamespace: self
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -83,11 +83,11 @@ FamixJavaPackage >> bunchCouplingWith: aPackage [
 	(myClasses size == 0 or: [ otherClasses size == 0 ]) ifTrue: [ ^ nil ].
 
 	"All outgoing dependencies"
-	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) withinPackage: aPackage ]) inject: 0 into: [ :subTotal :each | subTotal + each size ].
+	interConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) within: aPackage ]) inject: 0 into: [ :subTotal :each | subTotal + each size ].
 
 	"Plus all incoming dependencies"
 	interConnectivities := interConnectivities
-		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) withinPackage: aPackage ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
+		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) within: aPackage ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
 	^ interConnectivities / (2 * myClasses size * otherClasses size) asFloat
 ]
 
@@ -108,18 +108,6 @@ FamixJavaPackage >> bunchCouplingWithAll [
 	interConnectivities := interConnectivities
 		+ ((myClasses collect: [ :c | (c queryIncomingDependencies atScope: FamixTType) outOfMyPackage ]) inject: 0 into: [ :subTotal :each | subTotal + each size ]).
 	^ interConnectivities / (2 * myClasses size * (allClasses size - myClasses size)) asFloat
-]
-
-{ #category : #deprecated }
-FamixJavaPackage >> childNamedEntities [
-
-	^ self childEntities
-]
-
-{ #category : #deprecated }
-FamixJavaPackage >> childNamedEntities: aNamedEntity [
-
-	^ self childEntities: aNamedEntity
 ]
 
 { #category : #'as yet unclassified' }
@@ -288,9 +276,4 @@ FamixJavaPackage >> relativeImportanceForSystem [
 							]
 						ifFalse: [0]
 						]
-]
-
-{ #category : #'as yet unclassified' }
-FamixJavaPackage >> selectWithinYourScope: aMooseQueryResult [
-	^ aMooseQueryResult withinPackage: self
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -46,12 +46,6 @@ FamixStClass >> extendedMethods [
 ]
 
 { #category : #testing }
-FamixStClass >> hasMethodWithSignature: aSignature [
-	self deprecated: 'Use #implements: instead' transformWith: '`@receiver hasMethodWithSignature: `@statements1' -> '`@receiver implements: `@statements1'.
-	^ self implements: aSignature
-]
-
-{ #category : #testing }
 FamixStClass >> implements: aString [
 	"Was changed from match: for performances and because signature is case sensitive"
 
@@ -81,12 +75,6 @@ FamixStClass >> isExtended [
 { #category : #testing }
 FamixStClass >> isInstanceSide [
 	^ self isClassSide not
-]
-
-{ #category : #testing }
-FamixStClass >> isSUnitTestCase [
-	self deprecated: 'Use #isTestCase instead' transformWith: '`@receiver isSUnitTestCase' -> '`@receiver isTestCase'.
-	^ self isTestCase
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -48,20 +48,6 @@ FamixTMethod >> cyclomaticComplexity: aNumber [
 	self privateState propertyAt: #cyclomaticComplexity put: aNumber
 ]
 
-{ #category : #testing }
-FamixTMethod >> hasClassScope [
-	<MSEProperty: #hasClassScope type: #Boolean>
-	<MSEComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
-	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
-	^ self isClassSide
-]
-
-{ #category : #testing }
-FamixTMethod >> hasClassScope: aBoolean [
-	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope: `@statements1' -> '`@receiver isClassSide: `@statements1'.
-	^ self isClassSide: aBoolean
-]
-
 { #category : #accessing }
 FamixTMethod >> isAbstract [
 

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -53,12 +53,6 @@ FamixTScopingEntity >> allParentScopesDo: aBlock [
 ]
 
 { #category : #accessing }
-FamixTScopingEntity >> allRecursiveScopes [
-	self deprecated: 'Use allChildScopes'.
-	^ self allChildScopes 
-]
-
-{ #category : #accessing }
 FamixTScopingEntity >> childScopes [
 
 	<generated>

--- a/src/Famix-Traits/FamixTWithTypedStructures.trait.st
+++ b/src/Famix-Traits/FamixTWithTypedStructures.trait.st
@@ -15,7 +15,7 @@ FamixTWithTypedStructures classSide >> annotation [
 	^self
 ]
 
-{ #category : #deprecated }
+{ #category : #adding }
 FamixTWithTypedStructures >> addBehaviourWithDeclaredType: aBehaviour [
 	self structuresWithDeclaredType add: aBehaviour
 ]
@@ -23,18 +23,6 @@ FamixTWithTypedStructures >> addBehaviourWithDeclaredType: aBehaviour [
 { #category : #adding }
 FamixTWithTypedStructures >> addStructureWithDeclaredType: aStructuralEntity [
 	structuresWithDeclaredType add: aStructuralEntity
-]
-
-{ #category : #deprecated }
-FamixTWithTypedStructures >> behavioursWithDeclaredType [
-
-	^ self structuresWithDeclaredType
-]
-
-{ #category : #deprecated }
-FamixTWithTypedStructures >> behavioursWithDeclaredType: anObject [
-
-	^ self structuresWithDeclaredType: anObject
 ]
 
 { #category : #testing }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -426,12 +426,6 @@ MooseAbstractGroup >> insertInto: aSequenceableCollection from: anInteger to: an
 	^ self entities insertInto: aSequenceableCollection from: anInteger to: anotherInteger
 ]
 
-{ #category : #'set operations' }
-MooseAbstractGroup >> intersect: aGroup [ 
-	self deprecated: 'use intersection: instead, as it is polymorphic with the Collection protocol'.
-	^ self intersection: aGroup 
-]
-
 { #category : #'entity collection' }
 MooseAbstractGroup >> intersection: aCollection [
 	^ self species withAll: (self entities intersection: aCollection)

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -312,30 +312,6 @@ MooseEntity >> children [
 	^children
 ]
 
-{ #category : #deprecated }
-MooseEntity >> clientMethods [
-	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientMethods' -> '`@receiver allClientsAtScope: FamixTMethod'.
-	^ self allClientsAtScope: FamixTMethod
-]
-
-{ #category : #deprecated }
-MooseEntity >> clientNamespaces [
-	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientNamespaces' -> '`@receiver allClientsAtScope: FamixTNamespace'.
-	^ self allClientsAtScope: FamixTNamespace
-]
-
-{ #category : #deprecated }
-MooseEntity >> clientPackages [
-	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientPackages' -> '`@receiver allClientsAtScope: FamixTPackage'.
-	^ self allClientsAtScope: FamixTPackage
-]
-
-{ #category : #deprecated }
-MooseEntity >> clientTypes [
-	self deprecated: 'Use #allClientsAtScope: instead.' transformWith: '`@receiver clientTypes' -> '`@receiver allClientsAtScope: FamixTType'.
-	^ self allClientsAtScope: FamixTType
-]
-
 { #category : #private }
 MooseEntity >> defaultStateClass [
 	"Answer the default implementator of this element's state."
@@ -467,23 +443,6 @@ MooseEntity >> metamodel [
 
 ]
 
-{ #category : #deprecated }
-MooseEntity >> methodScope [
-	self
-		deprecated:
-			'methodScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
-	- `self allAtScope: FamixTMethod` if you want a collection of all the methods up in the containment tree of your entity
-	- `self allToScope: FamixTMethod` if you want a collection of all the methods down in the containment tree of your entity
-	- `self allWithScope: FamixTMethod` if you want a collection of all the methods up and down in the containment tree of your entity
-	- `self atScope: FamixTMethod` if you want a collection of the first encountered methods up in the containment tree of your entity
-	- `self toScope: FamixTMethod` if you want a collection of the first encountered methods down in the containment tree of your entity
-	- `self withScope: FamixTMethod` if you want a collection of the first encountered methods up and down in the containment tree of your entity
-	
-	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
-	"This implementation seems to be the most common"
-	^ (self toScope: FamixTMethod) anyOne
-]
-
 { #category : #accessing }
 MooseEntity >> mooseDescription [
 
@@ -557,23 +516,6 @@ MooseEntity >> name [
 	^#noname
 ]
 
-{ #category : #deprecated }
-MooseEntity >> namespaceScope [
-	self
-		deprecated:
-			'namespaceScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
-	- `self allAtScope: FamixTNamespace` if you want a collection of all the namespaces up in the containment tree of your entity
-	- `self allToScope: FamixTNamespace` if you want a collection of all the namespaces down in the containment tree of your entity
-	- `self allWithScope: FamixTNamespace` if you want a collection of all the namespaces up and down in the containment tree of your entity
-	- `self atScope: FamixTNamespace` if you want a collection of the first encountered namespaces up in the containment tree of your entity
-	- `self toScope: FamixTNamespace` if you want a collection of the first encountered namespaces down in the containment tree of your entity
-	- `self withScope: FamixTNamespace` if you want a collection of the first encountered namespaces up and down in the containment tree of your entity
-	
-	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
-	"This implementation seems to be the most common"
-	^ (self atScope: FamixTNamespace) anyOne
-]
-
 { #category : #'meta information' }
 MooseEntity >> navigationSelectors [
 	^ (Pragma allNamed: #navigation: from: self class to: MooseEntity)
@@ -584,23 +526,6 @@ MooseEntity >> navigationSelectors [
 MooseEntity >> notExistentMetricValue [
 	
 	^-1
-]
-
-{ #category : #deprecated }
-MooseEntity >> packageScope [
-	self
-		deprecated:
-			'packageScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
-	- `self allAtScope: FamixTPackage` if you want a collection of all the packages up in the containment tree of your entity
-	- `self allToScope: FamixTPackage` if you want a collection of all the packages down in the containment tree of your entity
-	- `self allWithScope: FamixTPackage` if you want a collection of all the packages up and down in the containment tree of your entity
-	- `self atScope: FamixTPackage` if you want a collection of the first encountered packages up in the containment tree of your entity
-	- `self toScope: FamixTPackage` if you want a collection of the first encountered packages down in the containment tree of your entity
-	- `self withScope: FamixTPackage` if you want a collection of the first encountered packages up and down in the containment tree of your entity
-	
-	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
-	"This implementation seems to be the most common"
-	^ (self atScope: FamixTPackage) anyOne
 ]
 
 { #category : #printing }
@@ -703,30 +628,6 @@ MooseEntity >> propertyNamed: name put: value [
 	^self privateState propertyAt: name put: value
 ]
 
-{ #category : #deprecated }
-MooseEntity >> providerMethods [
-	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerMethods' -> '`@receiver allProvidersAtScope: FamixTMethod'.
-	^ self allProvidersAtScope: FamixTMethod
-]
-
-{ #category : #deprecated }
-MooseEntity >> providerNamespaces [
-	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerNamespaces' -> '`@receiver allProvidersAtScope: FamixTNamespace'.
-	^ self allProvidersAtScope: FamixTNamespace
-]
-
-{ #category : #deprecated }
-MooseEntity >> providerPackages [
-	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerPackages' -> '`@receiver allProvidersAtScope: FamixTPackage'.
-	^ self allProvidersAtScope: FamixTPackage
-]
-
-{ #category : #deprecated }
-MooseEntity >> providerTypes [
-	self deprecated: 'Use #allProvidersAtScope: instead.' transformWith: '`@receiver providerTypes' -> '`@receiver allProvidersAtScope: FamixTType'.
-	^ self allProvidersAtScope: FamixTType
-]
-
 { #category : #accessing }
 MooseEntity >> removeFromModel [
 	^ self mooseModel ifNil: [ self ] ifNotNil: [ self mooseModel removeEntity: self ]
@@ -762,23 +663,6 @@ MooseEntity >> suspendAllAnnouncementsDuring: aBlock [
 	[ 	self announcer: Announcer new.
 		aBlock value ]
 			ensure: [ self announcer: currentAnnouncer ]
-]
-
-{ #category : #deprecated }
-MooseEntity >> typeScope [
-	self
-		deprecated:
-			'typeScope does not have a coherent behavior and should be replaced with a query. The query will depend on your needs. It can either be:
-	- `self allAtScope: FamixTType` if you want a collection of all the types up in the containment tree of your entity
-	- `self allToScope: FamixTType` if you want a collection of all the types down in the containment tree of your entity
-	- `self allWithScope: FamixTType` if you want a collection of all the types up and down in the containment tree of your entity
-	- `self atScope: FamixTType` if you want a collection of the first encountered types up in the containment tree of your entity
-	- `self toScope: FamixTType` if you want a collection of the first encountered types down in the containment tree of your entity
-	- `self withScope: FamixTType` if you want a collection of the first encountered types up and down in the containment tree of your entity
-	
-	In case you know there is only one type (for example in java a #atScope: on a structural entity), you can call #anyOne on the result of the query.'.
-	"This implementation seems to be the most common"
-	^ (self atScope: FamixTType) anyOne
 ]
 
 { #category : #accessing }

--- a/src/Moose-Query/MooseObjectQueryResult.class.st
+++ b/src/Moose-Query/MooseObjectQueryResult.class.st
@@ -91,26 +91,9 @@ MooseObjectQueryResult >> withScope: aClassFamix [
 	^ self newObjectResultWith: (self storage inject: OrderedCollection new into: [ :res :entity | entity withScope: aClassFamix in: res ]) asSet
 ]
 
-{ #category : #filtering }
+{ #category : #evaluating }
 MooseObjectQueryResult >> within: aFAMIXEntity [
-	"Copy from TDependencyQueryResult because trait is not to be used"
-	^aFAMIXEntity selectWithinYourScope: self.
-	
-]
-
-{ #category : #filtering }
-MooseObjectQueryResult >> withinClass: aFAMIXClass [
-	^ self newObjectResultWith: (storage select: [ :obj | (obj atScope: FamixTClass) includes: aFAMIXClass ])
-]
-
-{ #category : #filtering }
-MooseObjectQueryResult >> withinNamespace: aFAMIXNamespace [
-	^ self newObjectResultWith: (storage select: [ :obj | (obj atScope: FamixTNamespace) includes: aFAMIXNamespace ])
-]
-
-{ #category : #filtering }
-MooseObjectQueryResult >> withinPackage: aFAMIXPackage [
-	^ self newObjectResultWith: (storage select: [ :obj | (obj atScope: FamixTPackage) includes: aFAMIXPackage ])
+	^ self newObjectResultWith: (storage select: [ :obj | (obj atScope: aFAMIXEntity class) includes: aFAMIXEntity ])
 ]
 
 { #category : #filtering }

--- a/src/Moose-Query/MooseOutgoingQueryResult.class.st
+++ b/src/Moose-Query/MooseOutgoingQueryResult.class.st
@@ -14,9 +14,7 @@ Class {
 
 { #category : #private }
 MooseOutgoingQueryResult >> isOppositeMultivalued: aDependency [
-
-	^ (aDependency attributesTogetherWithGenerated
-		detect: [ :att | att isTarget ]) isMultivalued
+	^ (aDependency attributesTogetherWithGenerated detect: [ :att | att isTarget ]) isMultivalued
 ]
 
 { #category : #private }

--- a/src/Moose-Query/MooseQueryResult.class.st
+++ b/src/Moose-Query/MooseQueryResult.class.st
@@ -243,37 +243,21 @@ MooseQueryResult >> withScope: aSymbol [
 ]
 
 { #category : #evaluating }
-MooseQueryResult >> within: aFAMIXEntity [ 
-	 self subclassResponsibility
-]
-
-{ #category : #filtering }
-MooseQueryResult >> withinClass: aFAMIXClass [ 
-	self subclassResponsibility 
+MooseQueryResult >> within: aFAMIXEntity [
+	^ self subclassResponsibility
 ]
 
 { #category : #filtering }
 MooseQueryResult >> withinMyClass [
-	^ self withinClass: (self receiver atScope: FamixTClass) anyOne
+	^ self within: (self receiver atScope: FamixTClass) anyOne
 ]
 
 { #category : #filtering }
 MooseQueryResult >> withinMyNamespace [
-
-	^ self withinNamespace: (self receiver atScope: FamixTNamespace) anyOne   
+	^ self within: (self receiver atScope: FamixTNamespace) anyOne
 ]
 
 { #category : #filtering }
 MooseQueryResult >> withinMyPackage [
-	^ self withinPackage: (self receiver atScope: FamixTPackage) anyOne
-]
-
-{ #category : #filtering }
-MooseQueryResult >> withinNamespace: aFAMIXNamespace [ 
-	self subclassResponsibility 
-]
-
-{ #category : #filtering }
-MooseQueryResult >> withinPackage: aFAMIXPackage [ 
-	self subclassResponsibility 
+	^ self within: (self receiver atScope: FamixTPackage) anyOne
 ]

--- a/src/Moose-Query/TDependencyQueryResult.trait.st
+++ b/src/Moose-Query/TDependencyQueryResult.trait.st
@@ -157,29 +157,7 @@ TDependencyQueryResult >> withScope: aClassFamix [
 
 { #category : #filtering }
 TDependencyQueryResult >> within: aFamixEntity [
-	^self newAssocResultWith:
-		(self storage select: [ :dep | 
-			(self isOppositeMultivalued: dep)
-				ifTrue: [ (self opposite: dep) anySatisfy: [ :entity |  {aFamixEntity} = (entity atScope: aFamixEntity class) ] ]
-				ifFalse: [ {aFamixEntity} = ((self opposite: dep) atScope: aFamixEntity class) ] ])
-]
-
-{ #category : #filtering }
-TDependencyQueryResult >> withinClass: aFAMIXClass [ 
-	
-	^ self within: aFAMIXClass 
-]
-
-{ #category : #filtering }
-TDependencyQueryResult >> withinNamespace: aFAMIXNamespace [ 
-
-	^ self within: aFAMIXNamespace 
-]
-
-{ #category : #filtering }
-TDependencyQueryResult >> withinPackage: aFAMIXPackage [ 
-	
-	^ self within: aFAMIXPackage 
+	^ self newAssocResultWith: (self storage select: [ :dep | (self opposite: dep) asCollection anySatisfy: [ :entity | {aFamixEntity} = (entity atScope: aFamixEntity class) ] ])
 ]
 
 { #category : #filtering }

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXClassNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXClassNavigationChefTest.class.st
@@ -82,17 +82,17 @@ FAMIXClassNavigationChefTest >> testClientClassesInto [
 	| p1 p2 |
 	p1 := self packageP1FullReferencer.
 	p2 := self packageP2InteractedReferencerReferee.
-	self assert: ((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinPackage: p2) size equals: 1.
-	self assert: (((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinPackage: p2) equalsTo: (Set with: self c2ReferencerOutSideRefereeInSide)).
-	self assert: ((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinNamespace: self namespace1InteractedReferencerReferee) size equals: 1.
+	self assert: ((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: p2) size equals: 1.
+	self assert: (((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: p2) equalsTo: (Set with: self c2ReferencerOutSideRefereeInSide)).
+	self assert: ((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 1.
 	self
 		assert:
-			(((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinNamespace: self namespace1InteractedReferencerReferee) equalsTo: (Set with: self c2ReferencerOutSideRefereeInSide)).
-	self assert: (((self c3ReferencerInSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinPackage: p1) equalsTo: (Set with: self c1FullReferencerOutSide)).
-	self assert: ((self c3ReferencerInSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinNamespace: self namespace1InteractedReferencerReferee) size equals: 2.
+			(((self c14ReferencerOutSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: self namespace1InteractedReferencerReferee) equalsTo: (Set with: self c2ReferencerOutSideRefereeInSide)).
+	self assert: (((self c3ReferencerInSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide)).
+	self assert: ((self c3ReferencerInSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 2.
 	self
 		assert:
-			(((self c3ReferencerInSideRefereeOutSide queryAllIncoming atScope: FamixTType) withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c3ReferencerInSideRefereeOutSide queryAllIncoming atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo: (Set with: self c1FullReferencerOutSide with: self c6FullReferencerInSideOutSide))
 ]
 
@@ -220,14 +220,9 @@ FAMIXClassNavigationChefTest >> testInheritedByClasses [
 ]
 
 { #category : #inheritance }
-FAMIXClassNavigationChefTest >> testInheritedByClassesInto [ 
-
-	self assert: ((self c11FullRefereeOutSide queryIncomingInheritances opposites
-						withinNamespace: self namespace1InteractedReferencerReferee) 
-		equalsTo: (Set with: self c3ReferencerInSideRefereeOutSide)). 
-	self assert: ((self c11FullRefereeOutSide queryIncomingInheritances opposites
-						withinPackage: self packageP2InteractedReferencerReferee) 
-		equalsTo: (Set with: self c3ReferencerInSideRefereeOutSide))
+FAMIXClassNavigationChefTest >> testInheritedByClassesInto [
+	self assert: ((self c11FullRefereeOutSide queryIncomingInheritances opposites within: self namespace1InteractedReferencerReferee) equalsTo: (Set with: self c3ReferencerInSideRefereeOutSide)).
+	self assert: ((self c11FullRefereeOutSide queryIncomingInheritances opposites within: self packageP2InteractedReferencerReferee) equalsTo: (Set with: self c3ReferencerInSideRefereeOutSide))
 ]
 
 { #category : #inheritance }
@@ -293,19 +288,11 @@ FAMIXClassNavigationChefTest >> testInheritedClasses [
 ]
 
 { #category : #inheritance }
-FAMIXClassNavigationChefTest >> testInheritedClassesInto [ 
-	 
-	| p6 | 
-	p6 := self packageP6InteractedReferee. 
-	self 
-		assert: 
-			((self c11FullRefereeOutSide queryOutgoingInheritances opposites withinPackage: p6) 
-				equalsTo: (Set with: self c12FullReferencerInSide)). 
-	self 
-		assert: 
-			((self c11FullRefereeOutSide 
-				queryOutgoingInheritances opposites withinNamespace: self namespace2FullReferee) 
-				equalsTo: (Set with: self c12FullReferencerInSide))
+FAMIXClassNavigationChefTest >> testInheritedClassesInto [
+	| p6 |
+	p6 := self packageP6InteractedReferee.
+	self assert: ((self c11FullRefereeOutSide queryOutgoingInheritances opposites within: p6) equalsTo: (Set with: self c12FullReferencerInSide)).
+	self assert: ((self c11FullRefereeOutSide queryOutgoingInheritances opposites within: self namespace2FullReferee) equalsTo: (Set with: self c12FullReferencerInSide))
 ]
 
 { #category : #inheritance }
@@ -408,8 +395,8 @@ FAMIXClassNavigationChefTest >> testProviderClasses [
 FAMIXClassNavigationChefTest >> testProviderClassesInto [
 	| p11 |
 	p11 := self packageP11FullReferee.
-	self assert: (((self c15FullReferencerOutSide queryAllOutgoing atScope: FamixTType) withinPackage: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self assert: (((self c15FullReferencerOutSide queryAllOutgoing atScope: FamixTType) withinNamespace: self namespace6InteractedReferee) equalsTo: (Set with: self c19FullRefereeOutSide))
+	self assert: (((self c15FullReferencerOutSide queryAllOutgoing atScope: FamixTType) within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: (((self c15FullReferencerOutSide queryAllOutgoing atScope: FamixTType) within: self namespace6InteractedReferee) equalsTo: (Set with: self c19FullRefereeOutSide))
 ]
 
 { #category : #allDependencies }
@@ -507,16 +494,8 @@ FAMIXClassNavigationChefTest >> testReferencedClasses [
 FAMIXClassNavigationChefTest >> testReferencedClassesInto [
 	| p3 |
 	p3 := self packageP3InteractedReferencer.
-	self
-		assert:
-			((self c6FullReferencerInSideOutSide queryAllOutgoingInvocations
-				atScope: FamixTType) withinPackage: p3) size
-		equals: 1.
-	self
-		assert:
-			(((self c6FullReferencerInSideOutSide queryAllOutgoingInvocations
-				atScope: FamixTType) withinPackage: p3)
-				equalsTo: (Set with: self c5ReferencerInSideRefereeInSide))
+	self assert: ((self c6FullReferencerInSideOutSide queryAllOutgoingInvocations atScope: FamixTType) within: p3) size equals: 1.
+	self assert: (((self c6FullReferencerInSideOutSide queryAllOutgoingInvocations atScope: FamixTType) within: p3) equalsTo: (Set with: self c5ReferencerInSideRefereeInSide))
 ]
 
 { #category : #allOutgoingInvocations }
@@ -680,50 +659,27 @@ FAMIXClassNavigationChefTest >> testReferencingClassesInto [
 	| p1 p2 |
 	p1 := self packageP1FullReferencer.
 	p2 := self packageP2InteractedReferencerReferee.
+	self assert: ((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: p2) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType) withinPackage: p2) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType) withinPackage: p2)
+			(((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: p2)
 				equalsTo:
 					(Set new
 						add: self c2ReferencerOutSideRefereeInSide;
 						yourself)).
+	self assert: ((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo:
 					(Set new
 						add: self c2ReferencerOutSideRefereeInSide;
 						yourself)).
+	self assert: (((self c3ReferencerInSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide)).
+	self assert: ((self c3ReferencerInSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 2.
 	self
 		assert:
-			(((self c3ReferencerInSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType) withinPackage: p1)
-				equalsTo: (Set with: self c1FullReferencerOutSide)).
-	self
-		assert:
-			((self c3ReferencerInSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee) size
-		equals: 2.
-	self
-		assert:
-			(((self c3ReferencerInSideRefereeOutSide queryAllIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c3ReferencerInSideRefereeOutSide queryAllIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo:
 					(Set new
 						add: self c1FullReferencerOutSide;
@@ -936,9 +892,7 @@ FAMIXClassNavigationChefTest >> testStaticClientClassesInto [
 	p3 := self packageP3InteractedReferencer.
 	self
 		assert:
-			(((self c11FullRefereeOutSide queryStaticIncomingAssociations
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c11FullRefereeOutSide queryStaticIncomingAssociations atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo:
 					(Set new
 						add: self c3ReferencerInSideRefereeOutSide;
@@ -947,8 +901,7 @@ FAMIXClassNavigationChefTest >> testStaticClientClassesInto [
 						yourself)).
 	self
 		assert:
-			(((self c11FullRefereeOutSide queryStaticIncomingAssociations
-				atScope: FamixTType) withinPackage: p3)
+			(((self c11FullRefereeOutSide queryStaticIncomingAssociations atScope: FamixTType) within: p3)
 				equalsTo:
 					(Set new
 						add: self c6FullReferencerInSideOutSide;
@@ -1054,19 +1007,11 @@ FAMIXClassNavigationChefTest >> testStaticProviderClasses [
 FAMIXClassNavigationChefTest >> testStaticProviderClassesInto [
 	| p6 |
 	p6 := self packageP6InteractedReferee.
+	self assert: (((self c11FullRefereeOutSide queryStaticOutgoingAssociations atScope: FamixTType) within: p6) equalsTo: (Set with: self c12FullReferencerInSide)).
 	self
 		assert:
-			(((self c11FullRefereeOutSide queryStaticOutgoingAssociations
-				atScope: FamixTType) withinPackage: p6)
-				equalsTo: (Set with: self c12FullReferencerInSide)).
-	self
-		assert:
-			(((self c11FullRefereeOutSide queryStaticOutgoingAssociations
-				atScope: FamixTType) withinNamespace: self namespace2FullReferee)
-				equalsTo:
-					(Set
-						with: self c12FullReferencerInSide
-						with: self c11FullRefereeOutSide))
+			(((self c11FullRefereeOutSide queryStaticOutgoingAssociations atScope: FamixTType) within: self namespace2FullReferee)
+				equalsTo: (Set with: self c12FullReferencerInSide with: self c11FullRefereeOutSide))
 ]
 
 { #category : #staticDependencies }
@@ -1145,10 +1090,10 @@ FAMIXClassNavigationChefTest >> testStaticReferencedClasses [
 FAMIXClassNavigationChefTest >> testStaticReferencedClassesInto [
 	| p3 |
 	p3 := self packageP3InteractedReferencer.
-	self assert: (self c6FullReferencerInSideOutSide queryOutgoingReferences opposites withinPackage: p3) size equals: 1.
+	self assert: (self c6FullReferencerInSideOutSide queryOutgoingReferences opposites within: p3) size equals: 1.
 	self
 		assert:
-			((self c6FullReferencerInSideOutSide queryOutgoingReferences opposites withinPackage: p3)
+			((self c6FullReferencerInSideOutSide queryOutgoingReferences opposites within: p3)
 				equalsTo:
 					(Set new
 						add: self c5ReferencerInSideRefereeInSide;
@@ -1315,49 +1260,27 @@ FAMIXClassNavigationChefTest >> testStaticReferencingClassesInto [
 	| p1 p2 |
 	p1 := self packageP1FullReferencer.
 	p2 := self packageP2InteractedReferencerReferee.
+	self assert: ((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: p2) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType) withinPackage: p2) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType) withinPackage: p2)
+			(((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: p2)
 				equalsTo:
 					(Set new
 						add: self c2ReferencerOutSideRefereeInSide;
 						yourself)).
+	self assert: ((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c14ReferencerOutSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo:
 					(Set new
 						add: self c2ReferencerOutSideRefereeInSide;
 						yourself)).
+	self assert: ((self c3ReferencerInSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: p1) isEmpty.
+	self assert: ((self c3ReferencerInSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 1.
 	self
 		assert:
-			((self c3ReferencerInSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType) withinPackage: p1) isEmpty.
-	self
-		assert:
-			((self c3ReferencerInSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee) size
-		equals: 1.
-	self
-		assert:
-			(((self c3ReferencerInSideRefereeOutSide queryIncomingReferences
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c3ReferencerInSideRefereeOutSide queryIncomingReferences atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo:
 					(Set new
 						add: self c6FullReferencerInSideOutSide;
@@ -1548,15 +1471,10 @@ FAMIXClassNavigationChefTest >> testSureReferencedClassesIncludeAllStaticReferen
 FAMIXClassNavigationChefTest >> testSureReferencedClassesInto [
 	| p5 |
 	p5 := self packageP5FullReferee.
+	self assert: ((self c14ReferencerOutSideRefereeOutSide querySureOutgoingInvocations atScope: FamixTType) within: p5) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide querySureOutgoingInvocations
-				atScope: FamixTType) withinPackage: p5) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide
-				querySureOutgoingInvocations atScope: FamixTType) withinPackage: p5)
+			(((self c14ReferencerOutSideRefereeOutSide querySureOutgoingInvocations atScope: FamixTType) within: p5)
 				equalsTo:
 					(Set new
 						add: self c11FullRefereeOutSide;
@@ -1721,48 +1639,27 @@ FAMIXClassNavigationChefTest >> testSureReferencingClassesInto [
 	| p1 p2 |
 	p1 := self packageP1FullReferencer.
 	p2 := self packageP2InteractedReferencerReferee.
+	self assert: ((self c14ReferencerOutSideRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: p2) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide querySureIncomingInvocations
-				atScope: FamixTType) withinPackage: p2) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide
-				querySureIncomingInvocations atScope: FamixTType) withinPackage: p2)
+			(((self c14ReferencerOutSideRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: p2)
 				equalsTo:
 					(Set new
 						add: self c2ReferencerOutSideRefereeInSide;
 						yourself)).
+	self assert: ((self c14ReferencerOutSideRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size equals: 1.
 	self
 		assert:
-			((self c14ReferencerOutSideRefereeOutSide querySureIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee) size
-		equals: 1.
-	self
-		assert:
-			(((self c14ReferencerOutSideRefereeOutSide
-				querySureIncomingInvocations atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
+			(((self c14ReferencerOutSideRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee)
 				equalsTo:
 					(Set new
 						add: self c2ReferencerOutSideRefereeInSide;
 						yourself)).
+	self assert: ((self c3ReferencerInSideRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: p1) isEmpty.
+	self assert: ((self c19FullRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: self namespace4FullReferencer) size equals: 1.
 	self
 		assert:
-			((self c3ReferencerInSideRefereeOutSide querySureIncomingInvocations
-				atScope: FamixTType) withinPackage: p1) isEmpty.
-	self
-		assert:
-			((self c19FullRefereeOutSide querySureIncomingInvocations
-				atScope: FamixTType) withinNamespace: self namespace4FullReferencer)
-				size
-		equals: 1.
-	self
-		assert:
-			(((self c19FullRefereeOutSide querySureIncomingInvocations
-				atScope: FamixTType) withinNamespace: self namespace4FullReferencer)
+			(((self c19FullRefereeOutSide querySureIncomingInvocations atScope: FamixTType) within: self namespace4FullReferencer)
 				equalsTo:
 					(Set new
 						add: self c15FullReferencerOutSide;

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXMethodNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXMethodNavigationChefTest.class.st
@@ -25,30 +25,12 @@ FAMIXMethodNavigationChefTest >> testReferencedClasses [
 { #category : #allOutgoingInvocations }
 FAMIXMethodNavigationChefTest >> testReferencedClassesInto [
 	| c1Mtd4 p6 |
-	c1Mtd4 := self
-		getMethod: 'm1p1c1Mtd4:(Object)'
-		from: self c1FullReferencerOutSide.
+	c1Mtd4 := self getMethod: 'm1p1c1Mtd4:(Object)' from: self c1FullReferencerOutSide.
 	p6 := self packageP6InteractedReferee.
-	self
-		assert:
-			((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType)
-				withinPackage: p6) size
-		equals: 1.
-	self
-		assert:
-			(((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType)
-				withinPackage: p6)
-				equalsTo: (Set with: self c13FullRefereeInSideOutSide)).
-	self
-		assert: 1
-		equals:
-			((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType)
-				withinNamespace: self namespace2FullReferee) size.
-	self
-		assert:
-			(((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType)
-				withinNamespace: self namespace2FullReferee)
-				equalsTo: (Set with: self c13FullRefereeInSideOutSide))
+	self assert: ((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType) within: p6) size equals: 1.
+	self assert: (((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType) within: p6) equalsTo: (Set with: self c13FullRefereeInSideOutSide)).
+	self assert: 1 equals: ((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType) within: self namespace2FullReferee) size.
+	self assert: (((c1Mtd4 queryAllOutgoingInvocations atScope: FamixTType) within: self namespace2FullReferee) equalsTo: (Set with: self c13FullRefereeInSideOutSide))
 ]
 
 { #category : #allOutgoingInvocations }
@@ -72,11 +54,9 @@ FAMIXMethodNavigationChefTest >> testReferencedMethodsDefinedInto [
 	c15m3 := self getMethod: 'm4p8c15Mtd3()' from: self c15FullReferencerOutSide.
 	c19InstCreation1 := self getMethod: 'm6p11c19InstCreation1()' from: self c19FullRefereeOutSide.
 	c19m2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide.
-	
-	self assert: 2
-		equals: (c15m3 queryAllOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) size.
-	self assert: ((c15m3 queryAllOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide)
-		equalsTo: (Set with: c19InstCreation1 with: c19m2))
+
+	self assert: 2 equals: (c15m3 queryAllOutgoingInvocations opposites within: self c19FullRefereeOutSide) size.
+	self assert: ((c15m3 queryAllOutgoingInvocations opposites within: self c19FullRefereeOutSide) equalsTo: (Set with: c19InstCreation1 with: c19m2))
 ]
 
 { #category : #allOutgoingInvocations }
@@ -86,7 +66,7 @@ FAMIXMethodNavigationChefTest >> testReferencedMethodsDefinedIntoAndPackagedInto
 	c19InstCreation1 := self getMethod: 'm6p11c19InstCreation1()' from: self c19FullRefereeOutSide.
 	c19m2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide.
 
-	self assertCollection: ((c15m3 queryAllOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: self packagePExtensions) hasSameElements: {c19InstCreation1 . c19m2}
+	self assertCollection: ((c15m3 queryAllOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: self packagePExtensions) hasSameElements: {c19InstCreation1 . c19m2}
 ]
 
 { #category : #allOutgoingInvocations }
@@ -149,30 +129,12 @@ FAMIXMethodNavigationChefTest >> testReferencingClasses [
 { #category : #allIncomingInvocations }
 FAMIXMethodNavigationChefTest >> testReferencingClassesInto [
 	| c19m2 p9 |
-	c19m2 := self
-		getMethod: 'm6p11c19Mtd2()'
-		from: self c19FullRefereeOutSide.
+	c19m2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide.
 	p9 := self packageP9FullReferencer.
-	self
-		assert: 1
-		equals:
-			((c19m2 queryAllIncomingInvocations atScope: FamixTType)
-				withinPackage: p9) size.
-	self
-		assert:
-			(((c19m2 queryAllIncomingInvocations atScope: FamixTType)
-				withinPackage: p9)
-				equalsTo: (Set with: self c16FullReferencerOutSideInSide)).
-	self
-		assert: 1
-		equals:
-			((c19m2 queryAllIncomingInvocations atScope: FamixTType)
-				withinNamespace: self namespace4FullReferencer) size.
-	self
-		assert:
-			(((c19m2 queryAllIncomingInvocations atScope: FamixTType)
-				withinNamespace: self namespace4FullReferencer)
-				equalsTo: (Set with: self c15FullReferencerOutSide))
+	self assert: 1 equals: ((c19m2 queryAllIncomingInvocations atScope: FamixTType) within: p9) size.
+	self assert: (((c19m2 queryAllIncomingInvocations atScope: FamixTType) within: p9) equalsTo: (Set with: self c16FullReferencerOutSideInSide)).
+	self assert: 1 equals: ((c19m2 queryAllIncomingInvocations atScope: FamixTType) within: self namespace4FullReferencer) size.
+	self assert: (((c19m2 queryAllIncomingInvocations atScope: FamixTType) within: self namespace4FullReferencer) equalsTo: (Set with: self c15FullReferencerOutSide))
 ]
 
 { #category : #allIncomingInvocations }
@@ -193,18 +155,11 @@ FAMIXMethodNavigationChefTest >> testReferencingMethods [
 { #category : #allIncomingInvocations }
 FAMIXMethodNavigationChefTest >> testReferencingMethodsDefinedInto [
 	| c19m2 c19m1 |
-	c19m1 := self 
-		getMethod: 'm6p11c19Mtd1()'
-		from: self c19FullRefereeOutSide.
-	c19m2 := self 
-		getMethod: 'm6p11c19Mtd2()'
-		from: self c19FullRefereeOutSide.
-	
-	self assert: 1
-		equals: (c19m1 queryAllIncomingInvocations opposites withinClass: c19m1 belongsTo) size.
-	self assert: ((c19m1 queryAllIncomingInvocations opposites withinClass: c19m1 belongsTo)
-					equalsTo: (Set with: c19m2))
-		description: 'Unexpected query result'
+	c19m1 := self getMethod: 'm6p11c19Mtd1()' from: self c19FullRefereeOutSide.
+	c19m2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide.
+
+	self assert: 1 equals: (c19m1 queryAllIncomingInvocations opposites within: c19m1 belongsTo) size.
+	self assert: ((c19m1 queryAllIncomingInvocations opposites within: c19m1 belongsTo) equalsTo: (Set with: c19m2)) description: 'Unexpected query result'
 ]
 
 { #category : #allIncomingInvocations }
@@ -214,8 +169,8 @@ FAMIXMethodNavigationChefTest >> testReferencingMethodsDefinedIntoAndPackagedInt
 	c19m2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide.
 	pExtensions := self packagePExtensions.
 
-	self assert: 1 equals: ((c19m1 queryAllIncomingInvocations opposites withinClass: c19m1 belongsTo) withinPackage: pExtensions) size.
-	self assert: (((c19m1 queryAllIncomingInvocations opposites withinClass: c19m1 belongsTo) withinPackage: pExtensions) equalsTo: (Set with: c19m2)) description: 'Unexpected query result'
+	self assert: 1 equals: ((c19m1 queryAllIncomingInvocations opposites within: c19m1 belongsTo) within: pExtensions) size.
+	self assert: (((c19m1 queryAllIncomingInvocations opposites within: c19m1 belongsTo) within: pExtensions) equalsTo: (Set with: c19m2)) description: 'Unexpected query result'
 ]
 
 { #category : #allIncomingInvocations }
@@ -284,15 +239,10 @@ FAMIXMethodNavigationChefTest >> testStaticReferencedClassesInto [
 	| c15m3 p11 |
 	c15m3 := self getMethod: 'm4p8c15Mtd3()' from: self c15FullReferencerOutSide.
 	p11 := self packageP11FullReferee.
-	self assert: (c15m3 queryOutgoingReferences opposites withinPackage: p11) size equals: 1.
-	self
-		assert:
-			((c15m3 queryOutgoingReferences opposites withinPackage: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self assert: 1 equals: (c15m3 queryOutgoingReferences opposites withinNamespace: self namespace6InteractedReferee) size.
-	self
-		assert:
-			((c15m3 queryOutgoingReferences opposites withinNamespace: self namespace6InteractedReferee)
-				equalsTo: (Set with: self c19FullRefereeOutSide))
+	self assert: (c15m3 queryOutgoingReferences opposites within: p11) size equals: 1.
+	self assert: ((c15m3 queryOutgoingReferences opposites within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: 1 equals: (c15m3 queryOutgoingReferences opposites within: self namespace6InteractedReferee) size.
+	self assert: ((c15m3 queryOutgoingReferences opposites within: self namespace6InteractedReferee) equalsTo: (Set with: self c19FullRefereeOutSide))
 ]
 
 { #category : #references }
@@ -343,24 +293,12 @@ FAMIXMethodNavigationChefTest >> testSureReferencedClasses [
 { #category : #sureOutgoingInvocations }
 FAMIXMethodNavigationChefTest >> testSureReferencedClassesInto [
 	| c20Mtd1 p11 pEx |
-	c20Mtd1 := self
-		getMethod: 'm6p12c20Mtd1()'
-		from: self c20FullReferencerOutSide.
+	c20Mtd1 := self getMethod: 'm6p12c20Mtd1()' from: self c20FullReferencerOutSide.
 	p11 := self packageP11FullReferee.
 	pEx := self packagePExtensions.
-	self
-		assert:
-			((c20Mtd1 querySureOutgoingInvocations atScope: FamixTType)
-				withinPackage: pEx) isEmpty.
-	self
-		assert:
-			((c20Mtd1 querySureOutgoingInvocations atScope: FamixTType)
-				withinPackage: p11) size
-		equals: 1.
-	self
-		assert:
-			(((c20Mtd1 querySureOutgoingInvocations atScope: FamixTType)
-				withinPackage: p11) includes: self c19FullRefereeOutSide)
+	self assert: ((c20Mtd1 querySureOutgoingInvocations atScope: FamixTType) within: pEx) isEmpty.
+	self assert: ((c20Mtd1 querySureOutgoingInvocations atScope: FamixTType) within: p11) size equals: 1.
+	self assert: (((c20Mtd1 querySureOutgoingInvocations atScope: FamixTType) within: p11) includes: self c19FullRefereeOutSide)
 ]
 
 { #category : #sureOutgoingInvocations }
@@ -377,24 +315,17 @@ FAMIXMethodNavigationChefTest >> testSureReferencedMethods [
 ]
 
 { #category : #sureOutgoingInvocations }
-FAMIXMethodNavigationChefTest >> testSureReferencedMethodsDefinedInto [ 
-	 
-	| c19Mtd1 c19Mtd2 c19InstCreation c20Mtd1 | 
-	c19Mtd1 := self getMethod: 'm6p11c19Mtd1()' from: self c19FullRefereeOutSide. 
-	c19Mtd2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide. 
-	c19InstCreation := self getMethod: 'm6p11c19InstCreation()' from: self c19FullRefereeOutSide. 
-	c20Mtd1 := self getMethod: 'm6p12c20Mtd1()' from: self c20FullReferencerOutSide. 
-	
-	self assert: 1
-		equals: (c19Mtd2 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) size. 
-	self assert: 
-			((c19Mtd2 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) 
-		includes: c19Mtd1). 
-	self assert: 1
-		equals: (c20Mtd1 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) size. 
-	self assert: 
-			((c20Mtd1 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) 
-		includes: c19InstCreation)
+FAMIXMethodNavigationChefTest >> testSureReferencedMethodsDefinedInto [
+	| c19Mtd1 c19Mtd2 c19InstCreation c20Mtd1 |
+	c19Mtd1 := self getMethod: 'm6p11c19Mtd1()' from: self c19FullRefereeOutSide.
+	c19Mtd2 := self getMethod: 'm6p11c19Mtd2()' from: self c19FullRefereeOutSide.
+	c19InstCreation := self getMethod: 'm6p11c19InstCreation()' from: self c19FullRefereeOutSide.
+	c20Mtd1 := self getMethod: 'm6p12c20Mtd1()' from: self c20FullReferencerOutSide.
+
+	self assert: 1 equals: (c19Mtd2 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) size.
+	self assert: ((c19Mtd2 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) includes: c19Mtd1).
+	self assert: 1 equals: (c20Mtd1 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) size.
+	self assert: ((c20Mtd1 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) includes: c19InstCreation)
 ]
 
 { #category : #sureOutgoingInvocations }
@@ -406,30 +337,12 @@ FAMIXMethodNavigationChefTest >> testSureReferencedMethodsDefinedIntoAndPackaged
 	c20Mtd1 := self getMethod: 'm6p12c20Mtd1()' from: self c20FullReferencerOutSide.
 	p11 := self packageP11FullReferee.
 	pExtensions := self packagePExtensions.
-	self
-		assert:
-			((c19Mtd2 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: pExtensions)
-				isEmpty.
-	self
-		assert:
-			((c19Mtd2 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: p11) size
-		equals: 1.
-	self
-		assert:
-			(((c19Mtd2 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: p11)
-				includes: c19Mtd1).
-	self
-		assert:
-			((c20Mtd1 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: pExtensions)
-				isEmpty.
-	self
-		assert:
-			((c20Mtd1 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: p11) size
-		equals: 1.
-	self
-		assert:
-			(((c20Mtd1 querySureOutgoingInvocations opposites withinClass: self c19FullRefereeOutSide) withinPackage: p11)
-				includes: c19InstCreation)
+	self assert: ((c19Mtd2 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: pExtensions) isEmpty.
+	self assert: ((c19Mtd2 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: p11) size equals: 1.
+	self assert: (((c19Mtd2 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: p11) includes: c19Mtd1).
+	self assert: ((c20Mtd1 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: pExtensions) isEmpty.
+	self assert: ((c20Mtd1 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: p11) size equals: 1.
+	self assert: (((c20Mtd1 querySureOutgoingInvocations opposites within: self c19FullRefereeOutSide) within: p11) includes: c19InstCreation)
 ]
 
 { #category : #sureOutgoingInvocations }
@@ -496,30 +409,12 @@ FAMIXMethodNavigationChefTest >> testSureReferencingClasses [
 { #category : #sureIncomingInvocations }
 FAMIXMethodNavigationChefTest >> testSureReferencingClassesInto [
 	| c13InstCreation p6 |
-	c13InstCreation := self
-		getMethod: 'm2p6c13InstCreation()'
-		from: self c13FullRefereeInSideOutSide.
+	c13InstCreation := self getMethod: 'm2p6c13InstCreation()' from: self c13FullRefereeInSideOutSide.
 	p6 := self packageP6InteractedReferee.
-	self
-		assert: 1
-		equals:
-			((c13InstCreation querySureIncomingInvocations atScope: FamixTType)
-				withinPackage: p6) size.
-	self
-		assert:
-			(((c13InstCreation querySureIncomingInvocations atScope: FamixTType)
-				withinPackage: p6)
-				equalsTo: (Set with: self c12FullReferencerInSide)).
-	self
-		assert: 1
-		equals:
-			((c13InstCreation querySureIncomingInvocations atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee) size.
-	self
-		assert:
-			(((c13InstCreation querySureIncomingInvocations atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
-				equalsTo: (Set with: self c1FullReferencerOutSide))
+	self assert: 1 equals: ((c13InstCreation querySureIncomingInvocations atScope: FamixTType) within: p6) size.
+	self assert: (((c13InstCreation querySureIncomingInvocations atScope: FamixTType) within: p6) equalsTo: (Set with: self c12FullReferencerInSide)).
+	self assert: 1 equals: ((c13InstCreation querySureIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee) size.
+	self assert: (((c13InstCreation querySureIncomingInvocations atScope: FamixTType) within: self namespace1InteractedReferencerReferee) equalsTo: (Set with: self c1FullReferencerOutSide))
 ]
 
 { #category : #sureIncomingInvocations }
@@ -542,43 +437,27 @@ FAMIXMethodNavigationChefTest >> testSureReferencingMethods [
 ]
 
 { #category : #sureIncomingInvocations }
-FAMIXMethodNavigationChefTest >> testSureReferencingMethodsDefinedInto [ 
-	 
-	| c13InstCreation c1Mtd1 c1Mtd4 | 
-	c13InstCreation := self 	getMethod: 'm2p6c13InstCreation()' from: self c13FullRefereeInSideOutSide. 
-	c1Mtd1 := self getMethod: 'm1p1c1Mtd1()' from: self c1FullReferencerOutSide. 
-	c1Mtd4 := self getMethod: 'm1p1c1Mtd4:(Object)' from: self c1FullReferencerOutSide. 
-	self assert: 2
-		equals: (c13InstCreation querySureIncomingInvocations opposites
-					withinClass: self c1FullReferencerOutSide) size. 
-	self assert: ((c13InstCreation querySureIncomingInvocations opposites
-					withinClass: self c1FullReferencerOutSide) 
-				equalsTo: (Set with: c1Mtd1 with: c1Mtd4))
+FAMIXMethodNavigationChefTest >> testSureReferencingMethodsDefinedInto [
+	| c13InstCreation c1Mtd1 c1Mtd4 |
+	c13InstCreation := self getMethod: 'm2p6c13InstCreation()' from: self c13FullRefereeInSideOutSide.
+	c1Mtd1 := self getMethod: 'm1p1c1Mtd1()' from: self c1FullReferencerOutSide.
+	c1Mtd4 := self getMethod: 'm1p1c1Mtd4:(Object)' from: self c1FullReferencerOutSide.
+	self assert: 2 equals: (c13InstCreation querySureIncomingInvocations opposites within: self c1FullReferencerOutSide) size.
+	self assert: ((c13InstCreation querySureIncomingInvocations opposites within: self c1FullReferencerOutSide) equalsTo: (Set with: c1Mtd1 with: c1Mtd4))
 ]
 
 { #category : #sureIncomingInvocations }
-FAMIXMethodNavigationChefTest >> testSureReferencingMethodsDefinedIntoAndPackagedInto [ 
-	 
-	| c13InstCreation c1Mtd1 c1Mtd4 p1 p6 | 
-	c13InstCreation := self getMethod: 'm2p6c13InstCreation()' from: self c13FullRefereeInSideOutSide. 
-	c1Mtd1 := self getMethod: 'm1p1c1Mtd1()' from: self c1FullReferencerOutSide. 
-	c1Mtd4 := self getMethod: 'm1p1c1Mtd4:(Object)' from: self c1FullReferencerOutSide. 
-	p1 := self packageP1FullReferencer. 
+FAMIXMethodNavigationChefTest >> testSureReferencingMethodsDefinedIntoAndPackagedInto [
+	| c13InstCreation c1Mtd1 c1Mtd4 p1 p6 |
+	c13InstCreation := self getMethod: 'm2p6c13InstCreation()' from: self c13FullRefereeInSideOutSide.
+	c1Mtd1 := self getMethod: 'm1p1c1Mtd1()' from: self c1FullReferencerOutSide.
+	c1Mtd4 := self getMethod: 'm1p1c1Mtd4:(Object)' from: self c1FullReferencerOutSide.
+	p1 := self packageP1FullReferencer.
 	p6 := self packageP6InteractedReferee.
-	
-	self assert: 2
-		equals: ((c13InstCreation querySureIncomingInvocations opposites
-					withinClass: self c1FullReferencerOutSide)
-					withinPackage: p1) size. 
-	self assert: 
-			(((c13InstCreation querySureIncomingInvocations opposites
-					withinClass: self c1FullReferencerOutSide)
-					withinPackage: p1) 
-				equalsTo: (Set with: c1Mtd1 with: c1Mtd4)). 
-	self assert: 
-			((c13InstCreation querySureIncomingInvocations opposites
-					withinClass: self c1FullReferencerOutSide)
-					withinPackage: 6) isEmpty
+
+	self assert: 2 equals: ((c13InstCreation querySureIncomingInvocations opposites within: self c1FullReferencerOutSide) within: p1) size.
+	self assert: (((c13InstCreation querySureIncomingInvocations opposites within: self c1FullReferencerOutSide) within: p1) equalsTo: (Set with: c1Mtd1 with: c1Mtd4)).
+	self assert: ((c13InstCreation querySureIncomingInvocations opposites within: self c1FullReferencerOutSide) within: 6) isEmpty
 ]
 
 { #category : #sureIncomingInvocations }

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXNamespaceNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXNamespaceNavigationChefTest.class.st
@@ -22,7 +22,7 @@ FAMIXNamespaceNavigationChefTest >> testClientClasses [
 
 { #category : #allDependencies }
 FAMIXNamespaceNavigationChefTest >> testClientClassesInto [
-	self assert: (((self namespace2FullReferee queryAllIncoming atScope: FamixTType) withinNamespace: self namespace3ReferencerReferee) equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
+	self assert: (((self namespace2FullReferee queryAllIncoming atScope: FamixTType) within: self namespace3ReferencerReferee) equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
 ]
 
 { #category : #allDependencies }
@@ -100,16 +100,8 @@ FAMIXNamespaceNavigationChefTest >> testInheritedByClasses [
 FAMIXNamespaceNavigationChefTest >> testInheritedByClassesInto [
 	self
 		assert:
-			(((self namespace2FullReferee queryIncomingInheritances
-				atScope: FamixTType)
-				withinNamespace: self namespace1InteractedReferencerReferee)
-				equalsTo: (Set with: self c3ReferencerInSideRefereeOutSide)).
-	self
-		assert:
-			((self namespace2FullReferee queryIncomingInheritances
-				atScope: FamixTType) withinNamespace: self namespace2FullReferee)
-				size
-		equals: 1
+			(((self namespace2FullReferee queryIncomingInheritances atScope: FamixTType) within: self namespace1InteractedReferencerReferee) equalsTo: (Set with: self c3ReferencerInSideRefereeOutSide)).
+	self assert: ((self namespace2FullReferee queryIncomingInheritances atScope: FamixTType) within: self namespace2FullReferee) size equals: 1
 ]
 
 { #category : #inheritance }
@@ -148,12 +140,7 @@ FAMIXNamespaceNavigationChefTest >> testInheritedClasses [
 
 { #category : #inheritance }
 FAMIXNamespaceNavigationChefTest >> testInheritedClassesInto [
-	self
-		assert:
-			(((self namespace1InteractedReferencerReferee
-				queryOutgoingInheritances atScope: FamixTType)
-				withinNamespace: self namespace2FullReferee)
-				equalsTo: (Set with: self c11FullRefereeOutSide))
+	self assert: (((self namespace1InteractedReferencerReferee queryOutgoingInheritances atScope: FamixTType) within: self namespace2FullReferee) equalsTo: (Set with: self c11FullRefereeOutSide))
 ]
 
 { #category : #inheritance }
@@ -196,18 +183,18 @@ FAMIXNamespaceNavigationChefTest >> testProviderClassesInto [
 	| invos refs inh |
 	self
 		assert:
-			(((self namespace1InteractedReferencerReferee queryAllOutgoing atScope: FamixTType) withinNamespace: self namespace2FullReferee)
+			(((self namespace1InteractedReferencerReferee queryAllOutgoing atScope: FamixTType) within: self namespace2FullReferee)
 				equalsTo: (Set with: self c11FullRefereeOutSide with: self c13FullRefereeInSideOutSide)).
-	self assert: 15 equals: (self namespace1InteractedReferencerReferee queryAllOutgoing withinNamespace: self namespace2FullReferee) size.
-	invos := (self namespace1InteractedReferencerReferee queryAllOutgoing withinNamespace: self namespace2FullReferee) select: [ :dep | dep usesFamixTrait: FamixTInvocation ].
+	self assert: 15 equals: (self namespace1InteractedReferencerReferee queryAllOutgoing within: self namespace2FullReferee) size.
+	invos := (self namespace1InteractedReferencerReferee queryAllOutgoing within: self namespace2FullReferee) select: [ :dep | dep usesFamixTrait: FamixTInvocation ].
 	self assert: 10 equals: invos size.
-	refs := (self namespace1InteractedReferencerReferee queryAllOutgoing withinNamespace: self namespace2FullReferee) select: [ :dep | dep usesFamixTrait: FamixTReference ].
+	refs := (self namespace1InteractedReferencerReferee queryAllOutgoing within: self namespace2FullReferee) select: [ :dep | dep usesFamixTrait: FamixTReference ].
 	self assert: 4 equals: refs size.
-	inh := (self namespace1InteractedReferencerReferee queryAllOutgoing withinNamespace: self namespace2FullReferee) select: [ :dep | dep usesFamixTrait: FamixTSubInheritance  ].
+	inh := (self namespace1InteractedReferencerReferee queryAllOutgoing within: self namespace2FullReferee) select: [ :dep | dep usesFamixTrait: FamixTSubInheritance ].
 	self assert: 1 equals: inh size.
 	self
 		assert:
-			(((self namespace1InteractedReferencerReferee queryAllOutgoing withinNamespace: self namespace2FullReferee) atScope: FamixTType)
+			(((self namespace1InteractedReferencerReferee queryAllOutgoing within: self namespace2FullReferee) atScope: FamixTType)
 				equalsTo: (Set with: self c11FullRefereeOutSide with: self c13FullRefereeInSideOutSide))
 ]
 
@@ -297,13 +284,8 @@ FAMIXNamespaceNavigationChefTest >> testReferencedClasses [
 FAMIXNamespaceNavigationChefTest >> testReferencedClassesInto [
 	self
 		assert:
-			(((self namespace1InteractedReferencerReferee
-				queryAllOutgoingInvocations atScope: FamixTType)
-				withinNamespace: self namespace2FullReferee)
-				equalsTo:
-					(Set
-						with: self c11FullRefereeOutSide
-						with: self c13FullRefereeInSideOutSide))
+			(((self namespace1InteractedReferencerReferee queryAllOutgoingInvocations atScope: FamixTType) within: self namespace2FullReferee)
+				equalsTo: (Set with: self c11FullRefereeOutSide with: self c13FullRefereeInSideOutSide))
 ]
 
 { #category : #allOutgoingInvocations }
@@ -340,12 +322,8 @@ FAMIXNamespaceNavigationChefTest >> testReferencingClasses [
 
 { #category : #allIncomingInvocations }
 FAMIXNamespaceNavigationChefTest >> testReferencingClassesInto [
-	self
-		assert:
-			(((self namespace2FullReferee queryAllIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace3ReferencerReferee)
-				equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
+	self assert:
+		(((self namespace2FullReferee queryAllIncomingInvocations atScope: FamixTType) within: self namespace3ReferencerReferee) equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
 ]
 
 { #category : #allIncomingInvocations }
@@ -379,13 +357,8 @@ FAMIXNamespaceNavigationChefTest >> testSureReferencedClasses [
 FAMIXNamespaceNavigationChefTest >> testSureReferencedClassesInto [
 	self
 		assert:
-			(((self namespace1InteractedReferencerReferee
-				querySureOutgoingInvocations atScope: FamixTType)
-				withinNamespace: self namespace2FullReferee)
-				equalsTo:
-					(Set
-						with: self c11FullRefereeOutSide
-						with: self c13FullRefereeInSideOutSide))
+			(((self namespace1InteractedReferencerReferee querySureOutgoingInvocations atScope: FamixTType) within: self namespace2FullReferee)
+				equalsTo: (Set with: self c11FullRefereeOutSide with: self c13FullRefereeInSideOutSide))
 ]
 
 { #category : #sureOutgoingInvocations }
@@ -420,12 +393,8 @@ FAMIXNamespaceNavigationChefTest >> testSureReferencingClasses [
 
 { #category : #sureIncomingInvocations }
 FAMIXNamespaceNavigationChefTest >> testSureReferencingClassesInto [
-	self
-		assert:
-			(((self namespace2FullReferee querySureIncomingInvocations
-				atScope: FamixTType)
-				withinNamespace: self namespace3ReferencerReferee)
-				equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
+	self assert:
+		(((self namespace2FullReferee querySureIncomingInvocations atScope: FamixTType) within: self namespace3ReferencerReferee) equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
 ]
 
 { #category : #sureIncomingInvocations }

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXNamespaceNavigationTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXNamespaceNavigationTest.class.st
@@ -19,7 +19,7 @@ FAMIXNamespaceNavigationTest >> testClientClasses [
 
 { #category : #'MooseKGB-TestFamix3-allDependencies' }
 FAMIXNamespaceNavigationTest >> testClientClassesInto [
-	self assert: (((self namespace2FullReferee queryAllIncoming atScope: FamixTType) withinNamespace: self namespace3ReferencerReferee) equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
+	self assert: (((self namespace2FullReferee queryAllIncoming atScope: FamixTType) within: self namespace3ReferencerReferee) equalsTo: (Set with: self c14ReferencerOutSideRefereeOutSide))
 ]
 
 { #category : #'MooseKGB-TestFamix3-allDependencies' }
@@ -44,7 +44,7 @@ FAMIXNamespaceNavigationTest >> testProviderClasses [
 FAMIXNamespaceNavigationTest >> testProviderClassesInto [
 	self
 		assert:
-			(((self namespace1InteractedReferencerReferee queryAllOutgoing atScope: FamixTType) withinNamespace: self namespace2FullReferee)
+			(((self namespace1InteractedReferencerReferee queryAllOutgoing atScope: FamixTType) within: self namespace2FullReferee)
 				equalsTo: (Set with: self c11FullRefereeOutSide with: self c13FullRefereeInSideOutSide))
 ]
 

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXPackageNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXPackageNavigationChefTest.class.st
@@ -24,7 +24,7 @@ FAMIXPackageNavigationChefTest >> testClientClassesInto [
 	| p1 p5 |
 	p1 := self packageP1FullReferencer.
 	p5 := self packageP5FullReferee.
-	self assert: (((p5 queryAllIncoming atScope: FamixTType) withinPackage: p1) equalsTo: (Set with: self c1FullReferencerOutSide))
+	self assert: (((p5 queryAllIncoming atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide))
 ]
 
 { #category : #allDependencies }
@@ -124,15 +124,11 @@ FAMIXPackageNavigationChefTest >> testInheritedByClasses [
 ]
 
 { #category : #inheritance }
-FAMIXPackageNavigationChefTest >> testInheritedByClassesInto [ 
-	 
-	| p5 p6 | 
-	p5 := self packageP5FullReferee. 
-	p6 := self packageP6InteractedReferee. 
-	self 
-		assert: 
-			((p6 queryIncomingInheritances opposites withinPackage: p5) 
-				equalsTo: (Set with: self c11FullRefereeOutSide))
+FAMIXPackageNavigationChefTest >> testInheritedByClassesInto [
+	| p5 p6 |
+	p5 := self packageP5FullReferee.
+	p6 := self packageP6InteractedReferee.
+	self assert: ((p6 queryIncomingInheritances opposites within: p5) equalsTo: (Set with: self c11FullRefereeOutSide))
 ]
 
 { #category : #inheritance }
@@ -157,15 +153,11 @@ FAMIXPackageNavigationChefTest >> testInheritedClasses [
 ]
 
 { #category : #inheritance }
-FAMIXPackageNavigationChefTest >> testInheritedClassesInto [ 
-	 
-	| p5 p6 | 
-	p5 := self packageP5FullReferee. 
-	p6 := self packageP6InteractedReferee.  
-	self 
-		assert: 
-			((p5 queryOutgoingInheritances opposites withinPackage: p6) 
-				equalsTo: (Set with: self c12FullReferencerInSide))
+FAMIXPackageNavigationChefTest >> testInheritedClassesInto [
+	| p5 p6 |
+	p5 := self packageP5FullReferee.
+	p6 := self packageP6InteractedReferee.
+	self assert: ((p5 queryOutgoingInheritances opposites within: p6) equalsTo: (Set with: self c12FullReferencerInSide))
 ]
 
 { #category : #inheritance }
@@ -192,8 +184,8 @@ FAMIXPackageNavigationChefTest >> testProviderClassesInto [
 	p8 := self packageP8FullReferencer.
 	p11 := self packageP11FullReferee.
 	pEx := self packagePExtensions.
-	self assert: (((p8 queryAllOutgoing atScope: FamixTType) withinPackage: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self assert: ((p8 queryAllOutgoing atScope: FamixTType) withinPackage: pEx) isEmpty
+	self assert: (((p8 queryAllOutgoing atScope: FamixTType) within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: ((p8 queryAllOutgoing atScope: FamixTType) within: pEx) isEmpty
 ]
 
 { #category : #allDependencies }
@@ -233,15 +225,8 @@ FAMIXPackageNavigationChefTest >> testReferencedClassesInto [
 	p8 := self packageP8FullReferencer.
 	p11 := self packageP11FullReferee.
 	pEx := self packagePExtensions.
-	self
-		assert:
-			(((p8 queryAllOutgoingInvocations atScope: FamixTType)
-				withinPackage: p11)
-				equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self
-		assert:
-			((p8 queryAllOutgoingInvocations atScope: FamixTType)
-				withinPackage: pEx) isEmpty
+	self assert: (((p8 queryAllOutgoingInvocations atScope: FamixTType) within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: ((p8 queryAllOutgoingInvocations atScope: FamixTType) within: pEx) isEmpty
 ]
 
 { #category : #allOutgoingInvocations }
@@ -280,11 +265,7 @@ FAMIXPackageNavigationChefTest >> testReferencingClassesInto [
 	| p1 p5 |
 	p1 := self packageP1FullReferencer.
 	p5 := self packageP5FullReferee.
-	self
-		assert:
-			(((p5 queryAllIncomingInvocations atScope: FamixTType)
-				withinPackage: p1)
-				equalsTo: (Set with: self c1FullReferencerOutSide))
+	self assert: (((p5 queryAllIncomingInvocations atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide))
 ]
 
 { #category : #allIncomingInvocations }
@@ -351,11 +332,7 @@ FAMIXPackageNavigationChefTest >> testStaticClientClassesInto [
 	| p1 p5 |
 	p1 := self packageP1FullReferencer.
 	p5 := self packageP5FullReferee.
-	self
-		assert:
-			(((p5 queryStaticIncomingAssociations atScope: FamixTType)
-				withinPackage: p1)
-				equalsTo: (Set with: self c1FullReferencerOutSide))
+	self assert: (((p5 queryStaticIncomingAssociations atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide))
 ]
 
 { #category : #staticDependencies }
@@ -398,15 +375,8 @@ FAMIXPackageNavigationChefTest >> testStaticProviderClassesInto [
 	p8 := self packageP8FullReferencer.
 	p11 := self packageP11FullReferee.
 	pEx := self packagePExtensions.
-	self
-		assert:
-			(((p8 queryStaticOutgoingAssociations atScope: FamixTType)
-				withinPackage: p11)
-				equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self
-		assert:
-			((p8 queryStaticOutgoingAssociations atScope: FamixTType)
-				withinPackage: pEx) isEmpty
+	self assert: (((p8 queryStaticOutgoingAssociations atScope: FamixTType) within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: ((p8 queryStaticOutgoingAssociations atScope: FamixTType) within: pEx) isEmpty
 ]
 
 { #category : #staticDependencies }
@@ -441,14 +411,8 @@ FAMIXPackageNavigationChefTest >> testStaticReferencedClassesInto [
 	p8 := self packageP8FullReferencer.
 	p11 := self packageP11FullReferee.
 	pEx := self packagePExtensions.
-	self
-		assert:
-			(((p8 queryOutgoingReferences atScope: FamixTType) withinPackage: p11)
-				equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self
-		assert:
-			((p8 queryOutgoingReferences atScope: FamixTType) withinPackage: pEx)
-				isEmpty
+	self assert: (((p8 queryOutgoingReferences atScope: FamixTType) within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: ((p8 queryOutgoingReferences atScope: FamixTType) within: pEx) isEmpty
 ]
 
 { #category : #references }
@@ -483,10 +447,7 @@ FAMIXPackageNavigationChefTest >> testStaticReferencingClassesInto [
 	| p1 p5 |
 	p1 := self packageP1FullReferencer.
 	p5 := self packageP5FullReferee.
-	self
-		assert:
-			(((p5 queryIncomingReferences atScope: FamixTType) withinPackage: p1)
-				equalsTo: (Set with: self c1FullReferencerOutSide))
+	self assert: (((p5 queryIncomingReferences atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide))
 ]
 
 { #category : #references }
@@ -536,15 +497,8 @@ FAMIXPackageNavigationChefTest >> testSureReferencedClassesInto [
 	p8 := self packageP8FullReferencer.
 	p11 := self packageP11FullReferee.
 	pEx := self packagePExtensions.
-	self
-		assert:
-			(((p8 querySureOutgoingInvocations atScope: FamixTType)
-				withinPackage: p11)
-				equalsTo: (Set with: self c19FullRefereeOutSide)).
-	self
-		assert:
-			((p8 querySureOutgoingInvocations atScope: FamixTType)
-				withinPackage: pEx) isEmpty
+	self assert: (((p8 querySureOutgoingInvocations atScope: FamixTType) within: p11) equalsTo: (Set with: self c19FullRefereeOutSide)).
+	self assert: ((p8 querySureOutgoingInvocations atScope: FamixTType) within: pEx) isEmpty
 ]
 
 { #category : #sureOutgoingInvocations }
@@ -593,11 +547,7 @@ FAMIXPackageNavigationChefTest >> testSureReferencingClassesInto [
 	| p1 p5 |
 	p1 := self packageP1FullReferencer.
 	p5 := self packageP5FullReferee.
-	self
-		assert:
-			(((p5 querySureIncomingInvocations atScope: FamixTType)
-				withinPackage: p1)
-				equalsTo: (Set with: self c1FullReferencerOutSide))
+	self assert: (((p5 querySureIncomingInvocations atScope: FamixTType) within: p1) equalsTo: (Set with: self c1FullReferencerOutSide))
 ]
 
 { #category : #sureIncomingInvocations }


### PR DESCRIPTION
- Refactor #within: to make it cleaner and easier to use 
- Add deprecated package
- Remove old deprecated methods.

Fixes #1774
Fixes #1644