### PR TITLE
1777-Review-creation-of-Moose-Groups-to-take-traits-into-account

### DIFF
--- a/src/Famix-Groups/MooseEntity.extension.st
+++ b/src/Famix-Groups/MooseEntity.extension.st
@@ -2,16 +2,20 @@ Extension { #name : #MooseEntity }
 
 { #category : #'*Famix-Groups' }
 MooseEntity class >> relatedGroupType [
-
 	" The entities can specify what is the prefered type of MooseGroup they want to be stored in.
 	They do that using a class side method with uniqueName that contains pragma <mooseGroup>. 
 	Because such methods are stored mostly in traits and a class can have more than prefered group
 	type, the most specialize one selected."
 
-	| definingMethods selectedMethod |
-	definingMethods := (self class allMethods select: [ :each | each hasPragmaNamed: #mooseGroup ]).
+	| definingMethods selectedMethods selectedMethod |
+	definingMethods := self class allMethods select: [ :each | each hasPragmaNamed: #mooseGroup ].
 	definingMethods ifEmpty: [ ^ MooseGroup ].
-	selectedMethod := definingMethods detectMax: [ :each | each methodClass withAllSuperclasses size ].
 
-	^ self perform: selectedMethod selector.
+	"We need to find the most specialized method, so we select the lower in the hierarchy."
+	selectedMethods := definingMethods groupedBy: [ :each | each methodClass withAllSuperclasses size ].
+	selectedMethods := selectedMethods at: selectedMethods keys max.
+
+	"In case multiple of such methods are found, we take the one that is the closest to be a local method. This means that if a method come from a trait of the class, it will be selected over a method that comes from a trait of a trait."
+	selectedMethod := (selectedMethods sorted: [ :method1 :method2 | method1 origin allTraits includes: method2 origin ]) first.
+	^ self perform: selectedMethod selector
 ]

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -948,6 +948,7 @@ FamixGenerator >> defineHierarchy [
 	tClass --|> #TWithSubInheritances.
 	tClass --|> #TWithSuperInheritances.
 	tClass --|> #TWithAttributes.
+	tClass --|> tType.
 
 	tMethod --|> #TWithParameters.
 	tMethod --|> #TInvocable.
@@ -960,7 +961,7 @@ FamixGenerator >> defineHierarchy [
 	tMethod --|> #TWithClassScope.
 	tMethod --|> #TTypedStructure.
 	
-	tStructuralEntity --|> #TNamed.
+	tStructuralEntity --|> tNamed.
 	tStructuralEntity --|> #TAccessible.
 	tStructuralEntity --|> #TInvocationsReceiver.
 	tStructuralEntity --|> #TTypedStructure

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -113,7 +113,6 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	class --|> #TWithExceptions.
 	class --|> #TClass.
 	class --|> #TClassHierarchyNavigation.
-
 	
 	containerEntity --|> namedEntity.
 	containerEntity --|> #TWithTypes.

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -54,3 +54,10 @@ FamixTest1Entity >> isStructuralEntity [
 	<generated>
 	^ false
 ]
+
+{ #category : #testing }
+FamixTest1Entity >> isType [
+
+	<generated>
+	^ false
+]

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -114,11 +114,10 @@ TEntityMetaLevelDependencyTest >> testAllOutgoingAssociationTypes [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllParentTypes [
-	
-	self assertCollection: c1 allParentTypes hasSameElements: {  }.
-	self assertCollection: m1 allParentTypes hasSameElements: { FamixTest1Class. FamixTWithMethods }.
-	self assertCollection: anchor1 allParentTypes hasSameElements: { }.
-	self assert: anchor1 allParentTypes isEmpty.
+	self assertCollection: c1 allParentTypes hasSameElements: {FamixTWithTypes}.
+	self assertCollection: m1 allParentTypes hasSameElements: {FamixTest1Class . FamixTWithMethods . FamixTWithTypes}.
+	self assertCollection: anchor1 allParentTypes hasSameElements: {}.
+	self assert: anchor1 allParentTypes isEmpty
 ]
 
 { #category : #tests }
@@ -226,10 +225,9 @@ TEntityMetaLevelDependencyTest >> testOutgoingAssociationTypes [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testParentTypes [
-
-	self assertCollection: m1 parentTypes hasSameElements: { FamixTest1Class. FamixTWithMethods }.
- 	self assertCollection: c1 parentTypes hasSameElements: { }.
- 	self assertCollection: anchor1 parentTypes hasSameElements: { }.
+	self assertCollection: m1 parentTypes hasSameElements: {FamixTest1Class . FamixTWithMethods}.
+	self assertCollection: c1 parentTypes hasSameElements: {FamixTWithTypes}.
+	self assertCollection: anchor1 parentTypes hasSameElements: {}
 ]
 
 { #category : #tests }

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -40,3 +40,10 @@ FamixTest2Entity >> isInheritance [
 	<generated>
 	^ false
 ]
+
+{ #category : #testing }
+FamixTest2Entity >> isType [
+
+	<generated>
+	^ false
+]

--- a/src/Famix-TestGenerators/FamixTest1Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest1Generator.class.st
@@ -67,5 +67,5 @@ FamixTest1Generator >> defineHierarchy [
 
 	attribute --|> namedEntity.
 	attribute --|> #TStructuralEntity.
-	attribute --|> #TAttribute.
+	attribute --|> #TAttribute
 ]

--- a/src/Famix-TestGenerators/FamixTest2Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest2Generator.class.st
@@ -41,10 +41,5 @@ FamixTest2Generator >> defineHierarchy [
 
 	inheritance --|> association.
 	inheritance --|> #TSubInheritance.
-	inheritance --|> #TSuperInheritance.
-
-
-	
-
-
+	inheritance --|> #TSuperInheritance
 ]

--- a/src/Famix-TestGenerators/FamixTest3Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest3Generator.class.st
@@ -61,9 +61,5 @@ FamixTest3Generator >> defineHierarchy [
 	reference --|> #TReference.
 	
 	invocation --|> association.
-	invocation --|> #TInvocation.
-
-	
-
-
+	invocation --|> #TInvocation
 ]

--- a/src/Famix-TestGenerators/FamixTest4Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest4Generator.class.st
@@ -73,8 +73,7 @@ FamixTest4Generator >> defineHierarchy [
 	school --|> entity.
 	room --|> entity.
 	classroom --|> room.
-	cafeteria --|> room.
-	
+	cafeteria --|> room
 ]
 
 { #category : #definition }

--- a/src/Famix-TestGenerators/FamixTestComposedSubmetamodel1Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedSubmetamodel1Generator.class.st
@@ -61,7 +61,5 @@ FamixTestComposedSubmetamodel1Generator >> defineHierarchy [
 	customEntity5 --|> entity.
 	
 	customEntity5 --|> #TEntityMetaLevelDependency.
-	customEntity5 --|> #TDependencyQueries.
-
-	
+	customEntity5 --|> #TDependencyQueries
 ]

--- a/src/Famix-TestGenerators/FamixTestComposedSubmetamodel2Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedSubmetamodel2Generator.class.st
@@ -61,6 +61,5 @@ FamixTestComposedSubmetamodel2Generator >> defineHierarchy [
 	customEntity5 --|> entity.
 
 	customEntity5 --|> #TEntityMetaLevelDependency.
-	customEntity5 --|> #TDependencyQueries.
-
+	customEntity5 --|> #TDependencyQueries
 ]

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -7,8 +7,8 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 "
 Trait {
 	#name : #FamixTClass,
-	#traits : 'FamixTWithMethods + FamixTWithSubInheritances + FamixTWithSuperInheritances + FamixTWithAttributes',
-	#classTraits : 'FamixTWithMethods classTrait + FamixTWithSubInheritances classTrait + FamixTWithSuperInheritances classTrait + FamixTWithAttributes classTrait',
+	#traits : 'FamixTWithMethods + FamixTWithSubInheritances + FamixTWithSuperInheritances + FamixTWithAttributes + FamixTType',
+	#classTraits : 'FamixTWithMethods classTrait + FamixTWithSubInheritances classTrait + FamixTWithSuperInheritances classTrait + FamixTWithAttributes classTrait + FamixTType classTrait',
 	#category : #'Famix-Traits-Class'
 }
 

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -342,15 +342,12 @@ MooseEntity >> entityCache [
 { #category : #groups }
 MooseEntity >> groupFor: aSelector [
 	"Return a group containing elements corresponding to aSelector"
+
 	"aSelector = allPackages, allClasses, allMethods, ... "
 
-	| res groupName |
-	res := self perform: aSelector.
-	groupName := aSelector asString capitalized, ' in ', self mooseName.
-	^ res isCollection
-			ifTrue: [ MooseGroup withAll: res withDescription: groupName ]
-			ifFalse: [ MooseGroup with: res withDescription: groupName ]
-
+	| groupName |
+	groupName := aSelector asString capitalized , ' in ' , self mooseName.
+	^ MooseGroup withAll: (self perform: aSelector) asCollection withDescription: groupName
 ]
 
 { #category : #printing }

--- a/src/Moose-Tests-Core/MooseEntityTest.class.st
+++ b/src/Moose-Tests-Core/MooseEntityTest.class.st
@@ -105,20 +105,12 @@ MooseEntityTest >> testGroupFor [
 	entity1 := FAMIXClass new.
 	entity2 := FAMIXClass new.
 	model := MooseModel new.
-	model
-		addAll:
-			{entity1.
-			entity2}.
+	model addAll: {entity1 . entity2}.
 	classGroup := model groupFor: #allClasses.
-	self assert: classGroup class == FAMIXClassGroup.
-	self
-		assert:
-			(classGroup entities
-				includesAll:
-					{entity1.
-					entity2}).
+	self assert: classGroup class identicalTo: FAMIXClassGroup.
+	self assert: (classGroup entities includesAll: {entity1 . entity2}).
 	methodGroup := model groupFor: #allMethods.
-	self assert: methodGroup class == MooseGroup.
+	self assert: methodGroup class identicalTo: MooseGroup.
 	self assert: methodGroup isEmpty
 ]
 


### PR DESCRIPTION
Take traits into account when selecting the kind of a moose group.
I also make TClass use TType. This is the change I wanted to do that cause the problem since FAMIXClass now return type and class as possible group at the same level in the hierarchy.

Fixes #1777