### PR TITLE
1786-generateNavigationGroups-should-not-compile-methods

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -391,10 +391,6 @@ FamixMetamodelBuilder >> prepareGeneration [
 	self sortedClasses do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
 	self traits do: [ :each | each generate ].
 	self sortedClasses do: [ :each | each generate ].
-	self traits do: [ :each | each generateNavigationGroups ].
-	self sortedClasses do: [ :each | each generateNavigationGroups ].
-	self traits do: [ :each | each generateAddToCollection ].
-	self sortedClasses do: [ :each | each generateAddToCollection ].
 	self behaviorsCount > 0 ifTrue: [ self generateImportingContext ]
 ]
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -197,39 +197,24 @@ FmxMBBehavior >> generateMethodsToRemoveFromTraitCompositionFor: aBehavioral [
 
 { #category : #generating }
 FmxMBBehavior >> generateNavigationGroups [
+	self allNavigationGroups
+		do: [ :aNavigationGroup | 
+			| sideName |
+			sideName := aNavigationGroup entity name.
 
-	| allNavigationGroups |
-
-	allNavigationGroups := self allNavigationGroups.
-
-	allNavigationGroups do: [ :aGroup | 
-		| sideName |
-		sideName := aGroup entity name.
-		aGroup entity isMany ifTrue: [ 
-			self realClass instanceSide compile: ('{1}
-
+			self builder environment
+				compile:
+					((aNavigationGroup entity isMany
+						ifTrue: [ '{1}
 	<generated>
 	<navigation: ''{2}''>
-	^ MooseGroup
-			withAll: (self {3} asSet)' format: { 
-				sideName, 'Group'.
-				sideName capitalized.
-				sideName }) 
-			classified: #navigation.]
-		ifFalse: [ 
-			self realClass instanceSide compile: ('{1}
-
+	^ MooseGroup withAll: self {3} asSet' ]
+						ifFalse: [ '{1}
 	<generated>
 	<navigation: ''{2}''>
-	^ MooseGroup
-			with: (self {3})' format: { 
-				sideName, 'Group'.
-				sideName capitalized.
-				sideName }) 
-			classified: #navigation.]
-
-	].
-
+	^ MooseGroup with: self {3}' ]) format: {(sideName , 'Group') . sideName capitalized . sideName})
+				in: self realClass instanceSide
+				classified: #navigation ]
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -147,7 +147,7 @@ FmxMBBehavior >> generateAccessors [
 ]
 
 { #category : #generating }
-FmxMBBehavior >> generateAddToCollection [
+FmxMBBehavior >> generateAddToCollectionFor: aClass [
 	| sideName |
 	self allNavigationGroups
 		do: [ :aGroup | 
@@ -158,7 +158,7 @@ FmxMBBehavior >> generateAddToCollection [
 							('add{1}: anObject
 	<generated>
 	^ self {2} add: anObject' format: {sideName capitalized . sideName})
-						in: self realClass instanceSide
+						in: aClass instanceSide
 						classified: #adding ] ]
 ]
 
@@ -195,7 +195,7 @@ FmxMBBehavior >> generateMethodsToRemoveFromTraitCompositionFor: aBehavioral [
 ]
 
 { #category : #generating }
-FmxMBBehavior >> generateNavigationGroups [
+FmxMBBehavior >> generateNavigationGroupsFor: aClass [
 	self allNavigationGroups
 		do: [ :aNavigationGroup | 
 			| sideName |
@@ -212,7 +212,7 @@ FmxMBBehavior >> generateNavigationGroups [
 	<generated>
 	<navigation: ''{2}''>
 	^ MooseGroup with: self {3}' ]) format: {(sideName , 'Group') . sideName capitalized . sideName})
-				in: self realClass instanceSide
+				in: aClass instanceSide
 				classified: #navigation ]
 ]
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -148,18 +148,17 @@ FmxMBBehavior >> generateAccessors [
 
 { #category : #generating }
 FmxMBBehavior >> generateAddToCollection [
-	| sideName allNavigationGroups |
-	allNavigationGroups := self allNavigationGroups.
-	allNavigationGroups
+	| sideName |
+	self allNavigationGroups
 		do: [ :aGroup | 
 			sideName := aGroup entity name.
 			aGroup entity isMany
-				ifTrue: [ self realClass instanceSide
+				ifTrue: [ self builder environment
 						compile:
 							('add{1}: anObject
-			
 	<generated>
 	^ self {2} add: anObject' format: {sideName capitalized . sideName})
+						in: self realClass instanceSide
 						classified: #adding ] ]
 ]
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -198,7 +198,10 @@ FmxMBClass >> generate [
 	self generateRequirementsFor: aClass.
 
 	self generateMethodsMadeByTraitsFor: aClass.
-	self generateMethodsToRemoveFromTraitCompositionFor: aClass
+	self generateMethodsToRemoveFromTraitCompositionFor: aClass.
+	
+	self generateNavigationGroupsFor: aClass.
+	self generateAddToCollectionFor: aClass
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
@@ -96,7 +96,10 @@ FmxMBTrait >> generate [
 	
 	self generateTestingMethodsIn: aTrait.
 	self generateRootMetamodelMethodIn: aTrait.
-	self generateMethodsToRemoveFromTraitCompositionFor: aTrait
+	self generateMethodsToRemoveFromTraitCompositionFor: aTrait.
+	
+	self generateNavigationGroupsFor: aTrait.
+	self generateAddToCollectionFor: aTrait
 ]
 
 { #category : #generating }

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -58,9 +58,7 @@ FamixTest4Book >> person: anObject [
 
 { #category : #navigation }
 FamixTest4Book >> personGroup [
-
 	<generated>
 	<navigation: 'Person'>
-	^ MooseGroup
-			with: (self person)
+	^ MooseGroup with: self person
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -18,7 +18,6 @@ FamixTest4Person class >> annotation [
 
 { #category : #adding }
 FamixTest4Person >> addBooks: anObject [
-			
 	<generated>
 	^ self books add: anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -40,9 +40,7 @@ FamixTest4Person >> books: anObject [
 
 { #category : #navigation }
 FamixTest4Person >> booksGroup [
-
 	<generated>
 	<navigation: 'Books'>
-	^ MooseGroup
-			withAll: (self books asSet)
+	^ MooseGroup withAll: self books asSet
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -58,9 +58,7 @@ FamixTest4Principal >> school: anObject [
 
 { #category : #navigation }
 FamixTest4Principal >> schoolGroup [
-
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup
-			with: (self school)
+	^ MooseGroup with: self school
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -58,9 +58,7 @@ FamixTest4Room >> school: anObject [
 
 { #category : #navigation }
 FamixTest4Room >> schoolGroup [
-
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup
-			with: (self school)
+	^ MooseGroup with: self school
 ]

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -57,11 +57,9 @@ FamixTest4School >> principal: anObject [
 
 { #category : #navigation }
 FamixTest4School >> principalGroup [
-
 	<generated>
 	<navigation: 'Principal'>
-	^ MooseGroup
-			with: (self principal)
+	^ MooseGroup with: self principal
 ]
 
 { #category : #accessing }
@@ -81,11 +79,9 @@ FamixTest4School >> rooms: anObject [
 
 { #category : #navigation }
 FamixTest4School >> roomsGroup [
-
 	<generated>
 	<navigation: 'Rooms'>
-	^ MooseGroup
-			withAll: (self rooms asSet)
+	^ MooseGroup withAll: self rooms asSet
 ]
 
 { #category : #accessing }
@@ -105,11 +101,9 @@ FamixTest4School >> students: anObject [
 
 { #category : #navigation }
 FamixTest4School >> studentsGroup [
-
 	<generated>
 	<navigation: 'Students'>
-	^ MooseGroup
-			withAll: (self students asSet)
+	^ MooseGroup withAll: self students asSet
 ]
 
 { #category : #accessing }
@@ -129,9 +123,7 @@ FamixTest4School >> teachers: anObject [
 
 { #category : #navigation }
 FamixTest4School >> teachersGroup [
-
 	<generated>
 	<navigation: 'Teachers'>
-	^ MooseGroup
-			withAll: (self teachers asSet)
+	^ MooseGroup withAll: self teachers asSet
 ]

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -21,21 +21,18 @@ FamixTest4School class >> annotation [
 
 { #category : #adding }
 FamixTest4School >> addRooms: anObject [
-			
 	<generated>
 	^ self rooms add: anObject
 ]
 
 { #category : #adding }
 FamixTest4School >> addStudents: anObject [
-			
 	<generated>
 	^ self students add: anObject
 ]
 
 { #category : #adding }
 FamixTest4School >> addTeachers: anObject [
-			
 	<generated>
 	^ self teachers add: anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -66,11 +66,9 @@ FamixTest4Student >> school: anObject [
 
 { #category : #navigation }
 FamixTest4Student >> schoolGroup [
-
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup
-			with: (self school)
+	^ MooseGroup with: self school
 ]
 
 { #category : #accessing }
@@ -90,9 +88,7 @@ FamixTest4Student >> teachers: anObject [
 
 { #category : #navigation }
 FamixTest4Student >> teachersGroup [
-
 	<generated>
 	<navigation: 'Teachers'>
-	^ MooseGroup
-			withAll: (self teachers asSet)
+	^ MooseGroup withAll: self teachers asSet
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -26,7 +26,6 @@ FamixTest4Student class >> requirements [
 
 { #category : #adding }
 FamixTest4Student >> addTeachers: anObject [
-			
 	<generated>
 	^ self teachers add: anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -26,7 +26,6 @@ FamixTest4Teacher class >> requirements [
 
 { #category : #adding }
 FamixTest4Teacher >> addStudents: anObject [
-			
 	<generated>
 	^ self students add: anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -66,11 +66,9 @@ FamixTest4Teacher >> school: anObject [
 
 { #category : #navigation }
 FamixTest4Teacher >> schoolGroup [
-
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup
-			with: (self school)
+	^ MooseGroup with: self school
 ]
 
 { #category : #accessing }
@@ -90,9 +88,7 @@ FamixTest4Teacher >> students: anObject [
 
 { #category : #navigation }
 FamixTest4Teacher >> studentsGroup [
-
 	<generated>
 	<navigation: 'Students'>
-	^ MooseGroup
-			withAll: (self students asSet)
+	^ MooseGroup withAll: self students asSet
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -66,9 +66,7 @@ FamixTestComposedCustomEntity1 >> customEntity1: anObject [
 
 { #category : #navigation }
 FamixTestComposedCustomEntity1 >> customEntity1Group [
-
 	<generated>
 	<navigation: 'CustomEntity1'>
-	^ MooseGroup
-			with: (self customEntity1)
+	^ MooseGroup with: self customEntity1
 ]

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -56,9 +56,7 @@ FamixTAnnotationInstance >> annotatedEntity: anObject [
 
 { #category : #navigation }
 FamixTAnnotationInstance >> annotatedEntityGroup [
-
 	<generated>
 	<navigation: 'AnnotatedEntity'>
-	^ MooseGroup
-			with: (self annotatedEntity)
+	^ MooseGroup with: self annotatedEntity
 ]

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -47,11 +47,9 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstance: anObject [
 
 { #category : #navigation }
 FamixTAnnotationInstanceAttribute >> parentAnnotationInstanceGroup [
-
 	<generated>
 	<navigation: 'ParentAnnotationInstance'>
-	^ MooseGroup
-			with: (self parentAnnotationInstance)
+	^ MooseGroup with: self parentAnnotationInstance
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -58,11 +58,9 @@ FamixTAnnotationType >> annotationTypesContainer: anObject [
 
 { #category : #navigation }
 FamixTAnnotationType >> annotationTypesContainerGroup [
-
 	<generated>
 	<navigation: 'AnnotationTypesContainer'>
-	^ MooseGroup
-			with: (self annotationTypesContainer)
+	^ MooseGroup with: self annotationTypesContainer
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -48,9 +48,7 @@ FamixTAttribute >> parentType: anObject [
 
 { #category : #navigation }
 FamixTAttribute >> parentTypeGroup [
-
 	<generated>
 	<navigation: 'ParentType'>
-	^ MooseGroup
-			with: (self parentType)
+	^ MooseGroup with: self parentType
 ]

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -61,11 +61,9 @@ FamixTEnumValue >> parentEnum: anObject [
 
 { #category : #navigation }
 FamixTEnumValue >> parentEnumGroup [
-
 	<generated>
 	<navigation: 'ParentEnum'>
-	^ MooseGroup
-			with: (self parentEnum)
+	^ MooseGroup with: self parentEnum
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -38,11 +38,9 @@ FamixTFunction >> functionOwner: anObject [
 
 { #category : #navigation }
 FamixTFunction >> functionOwnerGroup [
-
 	<generated>
 	<navigation: 'FunctionOwner'>
-	^ MooseGroup
-			with: (self functionOwner)
+	^ MooseGroup with: self functionOwner
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -49,9 +49,7 @@ FamixTGlobalVariable >> parentScope: anObject [
 
 { #category : #navigation }
 FamixTGlobalVariable >> parentScopeGroup [
-
 	<generated>
 	<navigation: 'ParentScope'>
-	^ MooseGroup
-			with: (self parentScope)
+	^ MooseGroup with: self parentScope
 ]

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -48,9 +48,7 @@ FamixTImplicitVariable >> parentBehaviouralEntity: anObject [
 
 { #category : #navigation }
 FamixTImplicitVariable >> parentBehaviouralEntityGroup [
-
 	<generated>
 	<navigation: 'ParentBehaviouralEntity'>
-	^ MooseGroup
-			with: (self parentBehaviouralEntity)
+	^ MooseGroup with: self parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -41,9 +41,7 @@ FamixTLocalVariable >> parentBehaviouralEntity: anObject [
 
 { #category : #navigation }
 FamixTLocalVariable >> parentBehaviouralEntityGroup [
-
 	<generated>
 	<navigation: 'ParentBehaviouralEntity'>
-	^ MooseGroup
-			with: (self parentBehaviouralEntity)
+	^ MooseGroup with: self parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -193,11 +193,9 @@ FamixTMethod >> parentType: anObject [
 
 { #category : #navigation }
 FamixTMethod >> parentTypeGroup [
-
 	<generated>
 	<navigation: 'ParentType'>
-	^ MooseGroup
-			with: (self parentType)
+	^ MooseGroup with: self parentType
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -40,9 +40,7 @@ FamixTPackageable >> parentPackage: anObject [
 
 { #category : #navigation }
 FamixTPackageable >> parentPackageGroup [
-
 	<generated>
 	<navigation: 'ParentPackage'>
-	^ MooseGroup
-			with: (self parentPackage)
+	^ MooseGroup with: self parentPackage
 ]

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -40,9 +40,7 @@ FamixTParameter >> parentBehaviouralEntity: anObject [
 
 { #category : #navigation }
 FamixTParameter >> parentBehaviouralEntityGroup [
-
 	<generated>
 	<navigation: 'ParentBehaviouralEntity'>
-	^ MooseGroup
-			with: (self parentBehaviouralEntity)
+	^ MooseGroup with: self parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -93,11 +93,9 @@ FamixTScopingEntity >> parentScope: anObject [
 
 { #category : #navigation }
 FamixTScopingEntity >> parentScopeGroup [
-
 	<generated>
 	<navigation: 'ParentScope'>
-	^ MooseGroup
-			with: (self parentScope)
+	^ MooseGroup with: self parentScope
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -122,9 +122,7 @@ FamixTType >> typeContainer: anObject [
 
 { #category : #navigation }
 FamixTType >> typeContainerGroup [
-
 	<generated>
 	<navigation: 'TypeContainer'>
-	^ MooseGroup
-			with: (self typeContainer)
+	^ MooseGroup with: self typeContainer
 ]


### PR DESCRIPTION
generateNavigationGroups should not compile methods itself.

FIxes #1786