### PR TITLE
Ease-development-of-composed-metamodels

### DIFF
--- a/src/Famix-BasicInfrastructure/FamixBasicInfrastructureGenerator.class.st
+++ b/src/Famix-BasicInfrastructure/FamixBasicInfrastructureGenerator.class.st
@@ -33,6 +33,11 @@ FamixBasicInfrastructureGenerator class >> isAbstract [
 	^ self = FamixBasicInfrastructureGenerator
 ]
 
+{ #category : #accessing }
+FamixBasicInfrastructureGenerator class >> submetamodels [
+	^ {FamixGenerator}
+]
+
 { #category : #definition }
 FamixBasicInfrastructureGenerator >> defineClasses [
 
@@ -84,10 +89,4 @@ FamixBasicInfrastructureGenerator >> defineHierarchy [
 	
 	unknownSourceLanguage --|> sourceLanguage.
 	unknownSourceLanguage --|> #TSourceLanguage
-]
-
-{ #category : #definition }
-FamixBasicInfrastructureGenerator >> newBuilder [
-
-	^ self builderWithStandardTraits
 ]

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -248,7 +248,7 @@ FamixJavaGenerator >> defineHierarchy [
 	type --|> #TWithTypeAliases.
 	type --|> #TParameterizedTypeUser.
 	type --|> #TClassHierarchyNavigation. 
-	
+
 	tStructuralEntity --|> #TStructuralEntity.
 	tStructuralEntity --|> #TWithDereferencedInvocations.
 
@@ -267,11 +267,7 @@ FamixJavaGenerator >> defineTraits [
 
 { #category : #definition }
 FamixJavaGenerator >> newBuilder [
-
-	^ self builderWithStandardTraits
+	^ super newBuilder
 		withImportingContext;
 		yourself
-		
-		
-	
 ]

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -77,6 +77,11 @@ FamixMetamodelBuilder >> acceptVisitor: aVisitor [
 ]
 
 { #category : #accessing }
+FamixMetamodelBuilder >> allSubBuilders [
+	^ self generator ifNil: [ Set new ] ifNotNil: #allSubBuilders
+]
+
+{ #category : #accessing }
 FamixMetamodelBuilder >> apply [
 	self environment apply
 ]
@@ -270,7 +275,7 @@ FamixMetamodelBuilder >> getTraitNamed: aSymbol [
 	| remoteTraits |
 	self flag: #todo. "Maybe we could cache the sub MM entities."
 	remoteTraits := Dictionary new.
-	self generator allSubBuilders keysAndValuesDo: [ :prefix :builder | builder traits detect: [ :each | each name = aSymbol ] ifFound: [ :trait | remoteTraits at: builder put: trait ] ].
+	self allSubBuilders do: [ :builder | builder traits detect: [ :each | each name = aSymbol ] ifFound: [ :trait | remoteTraits at: builder put: trait ] ].
 	remoteTraits size = 1
 		ifTrue: [ ^ remoteTraits values anyOne
 				isRemote: true;
@@ -421,6 +426,18 @@ FamixMetamodelBuilder >> prepareGeneration [
 	self behaviorsCount > 0 ifTrue: [ self generateImportingContext ]
 ]
 
+{ #category : #printing }
+FamixMetamodelBuilder >> printOn: aStream [
+	super printOn: aStream.
+
+	self generator
+		ifNotNil: [ :g | 
+			aStream
+				nextPut: $(;
+				print: g class;
+				nextPut: $) ]
+]
+
 { #category : #generating }
 FamixMetamodelBuilder >> regenerationIsNeeded [
 	self prepareGeneration.
@@ -486,6 +503,11 @@ FamixMetamodelBuilder >> sortedTraits [
 
 ]
 
+{ #category : #accessing }
+FamixMetamodelBuilder >> subBuilders [
+	^ self generator ifNil: [ #() ] ifNotNil: #subBuilders
+]
+
 { #category : #'tests support' }
 FamixMetamodelBuilder >> testingEnvironment [
 
@@ -516,7 +538,9 @@ FamixMetamodelBuilder >> traitsToGenerate [
 
 { #category : #accessing }
 FamixMetamodelBuilder >> traitsWithSubBuildersTraits [
-	^ self traits , (self generator allSubBuilders values flatCollect: #traits)
+	^ (self allSubBuilders flatCollect: #traits)
+		addAll: self traits;
+		yourself
 ]
 
 { #category : #initialization }

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -262,6 +262,33 @@ FamixMetamodelBuilder >> generator: aGenerator [
 
 ]
 
+{ #category : #initialization }
+FamixMetamodelBuilder >> getTraitNamed: aSymbol [
+	"Check if I contain a trait of this name. If yes, return it. 
+	If I do not contain a trait of this name, check if one of my subMM has a trait of this name. If one is found, return it. If more is found raise an error. If non is found, create a new trait of this name and return it."
+
+	| remoteTraits |
+	self flag: #todo. "Maybe we could cache the sub MM entities."
+	remoteTraits := Dictionary new.
+	self generator allSubBuilders keysAndValuesDo: [ :prefix :builder | builder traits detect: [ :each | each name = aSymbol ] ifFound: [ :trait | remoteTraits at: builder put: trait ] ].
+	remoteTraits size = 1
+		ifTrue: [ ^ remoteTraits values anyOne
+				isRemote: true;
+				remoteBuilder: self;
+				yourself ].
+	remoteTraits size > 1
+		ifTrue: [ self
+				error:
+					('Multiple remote traits named {1} where found in sub metamodels. Found in: {2}.
+In order to fix the issue you should use #remoteTrait:withPrefix: in your generator to select yourself the right trait to use. If you want to create an entity of this name in your model and not use the trait of this name from a sub metamodel, declare this trait before referencing it.'
+						format: {aSymbol . (', ' join: (remoteTraits keys collect: [ :builder | builder generator asString ]))}) ].
+	
+	self flag: #todo. "Later we should raise an error here. For local traits, they should be declared."
+	self traits detect: [ :each | each name = aSymbol ] ifFound: [ :trait | ^ trait ].
+
+	^ self ensureTraitNamed: aSymbol
+]
+
 { #category : #accessing }
 FamixMetamodelBuilder >> importingContextName [
 
@@ -387,7 +414,7 @@ FamixMetamodelBuilder >> prepareGeneration [
 	self resolveRequirementsFromContainers.
 	self registerPackages.
 
-	self traits do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
+	self traitsWithSubBuildersTraits do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
 	self sortedClasses do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
 	self traits do: [ :each | each generate ].
 	self sortedClasses do: [ :each | each generate ].
@@ -485,6 +512,11 @@ FamixMetamodelBuilder >> traits [
 FamixMetamodelBuilder >> traitsToGenerate [ 
 
 	^ self traits select: #willGenerate
+]
+
+{ #category : #accessing }
+FamixMetamodelBuilder >> traitsWithSubBuildersTraits [
+	^ self traits , (self generator allSubBuilders values flatCollect: #traits)
 ]
 
 { #category : #initialization }

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -191,8 +191,7 @@ FamixMetamodelGenerator class >> metamodelsToGenerate [
 
 { #category : #accessing }
 FamixMetamodelGenerator class >> modifyMetamodel: aMetamodel [
-
-	"override this method to do some additional modificatoins of the metamodel"
+	self submetamodels ifNotEmpty: [ self fixRemoteMetamodelRelationsIn: aMetamodel ]
 ]
 
 { #category : #accessing }
@@ -287,6 +286,14 @@ FamixMetamodelGenerator >> adoptBuilder: aBuilder [
 		packageName: self packageName;
 		packageNameForAnnotations: self packageNameForAnnotations.
 
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerator >> allSubBuilders [
+	| result |
+	result := subbuilders copy.
+	subbuilders valuesDo: [ :subBuilder | result addAll: subBuilder generator allSubBuilders ].
+	^ result
 ]
 
 { #category : #definition }
@@ -452,6 +459,11 @@ FamixMetamodelGenerator >> remoteTrait: anEntityName withPrefix: aPrefixName [
 		isRemote: true;
 		remoteBuilder: builder;
 		yourself
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerator >> subBuilders [
+	^ subbuilders
 ]
 
 { #category : #definition }

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -32,8 +32,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'builder',
-		'subbuilders',
-		'cleaningStrategy'
+		'cleaningStrategy',
+		'subBuildersMapByPrefix'
 	],
 	#classInstVars : [
 		'metamodel'
@@ -291,8 +291,11 @@ FamixMetamodelGenerator >> adoptBuilder: aBuilder [
 { #category : #accessing }
 FamixMetamodelGenerator >> allSubBuilders [
 	| result |
-	result := subbuilders copy.
-	subbuilders valuesDo: [ :subBuilder | result addAll: subBuilder generator allSubBuilders ].
+	result := self subBuilders asSet.
+	self subBuilders
+		do: [ :subBuilder | subBuilder generator allSubBuilders
+			do: [ :subSubBuilder | (result anySatisfy: [ :b | b generator class = subSubBuilder generator class ])
+				ifFalse: [ result add: subSubBuilder ] ] ].
 	^ result
 ]
 
@@ -362,7 +365,7 @@ FamixMetamodelGenerator >> generate [
 		disableDuring: [ self define.
 			self cleaningStrategy
 				withCleaningDo: [ self builder generate.
-					subbuilders do: #generateRemotes ]
+					self subBuilders do: #generateRemotes ]
 				with: self ].
 	self class resetMetamodel
 ]
@@ -394,7 +397,7 @@ FamixMetamodelGenerator >> initialize [
 	builder := self newBuilder.
 	self adoptBuilder: builder.
 	
-	subbuilders := Dictionary newFrom: (self class submetamodels collect: [ :each | 
+	subBuildersMapByPrefix := Dictionary newFrom: (self class submetamodels collect: [ :each | 
 		| subbuilder |
 		subbuilder := each builderWithDefinitions.
 		subbuilder parentBuilder: self builder.
@@ -447,7 +450,7 @@ FamixMetamodelGenerator >> regenerationIsNeeded [
 
 { #category : #definition }
 FamixMetamodelGenerator >> remoteEntity: anEntityName withPrefix: aPrefixName [
-	^ ((subbuilders at: aPrefixName) ensureClassNamed: anEntityName)
+	^ ((subBuildersMapByPrefix at: aPrefixName) ensureClassNamed: anEntityName)
 		isRemote: true;
 		remoteBuilder: builder;
 		yourself
@@ -455,7 +458,7 @@ FamixMetamodelGenerator >> remoteEntity: anEntityName withPrefix: aPrefixName [
 
 { #category : #definition }
 FamixMetamodelGenerator >> remoteTrait: anEntityName withPrefix: aPrefixName [
-	^ ((subbuilders at: aPrefixName) ensureTraitNamed: anEntityName)
+	^ ((subBuildersMapByPrefix at: aPrefixName) ensureTraitNamed: anEntityName)
 		isRemote: true;
 		remoteBuilder: builder;
 		yourself
@@ -463,7 +466,7 @@ FamixMetamodelGenerator >> remoteTrait: anEntityName withPrefix: aPrefixName [
 
 { #category : #accessing }
 FamixMetamodelGenerator >> subBuilders [
-	^ subbuilders
+	^ subBuildersMapByPrefix values
 ]
 
 { #category : #definition }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -131,7 +131,7 @@ FmxMBBehavior >> fullName [
 FmxMBBehavior >> generalization: anObject [
 
 	^ anObject isSymbol
-		ifTrue: [ self addTraitGeneralization: (self builder ensureTraitNamed: anObject) ]
+		ifTrue: [ self addTraitGeneralization: (self builder getTraitNamed: anObject) ]
 		ifFalse: [ 
 			anObject isMetamodelTrait 
 				ifTrue: [ self addTraitGeneralization: anObject ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -146,9 +146,7 @@ FmxMBClass >> classGeneralization: anObject [
 
 { #category : #accessing }
 FmxMBClass >> conditionalGlueingTraitsFor: aClass [
-
-	^ self builder traits select: [ :each | 
-		each canGlueTo: aClass ].
+	^ self builder traitsWithSubBuildersTraits select: [ :each | each canGlueTo: aClass ]
 ]
 
 { #category : #accessing }
@@ -272,13 +270,7 @@ FmxMBClass >> generateTestingMethodsIn: aClass [
 
 { #category : #accessing }
 FmxMBClass >> glueingTraitsOf: selectedTraits whenAllHierarchyHas: allTraitsInHierarchy [
-
-	| potentialGlues |
-	
-	potentialGlues := self builder traits select: [ :each | each gluesSomeOf: allTraitsInHierarchy ].
-	
-	^ potentialGlues select: [ :each | each gluesOneOf: selectedTraits ]
-	
+	^ self builder traitsWithSubBuildersTraits select: [ :each | (each gluesSomeOf: allTraitsInHierarchy) and: [ each gluesOneOf: selectedTraits ] ]
 ]
 
 { #category : #testing }

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorAB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorAB.class.st
@@ -14,14 +14,6 @@ FamixMetamodelGenerateRemoteAccessorTestGeneratorAB class >> isRealMetamodel [
 ]
 
 { #category : #accessing }
-FamixMetamodelGenerateRemoteAccessorTestGeneratorAB class >> modifyMetamodel: aMetamodel [
-
-	super modifyMetamodel: aMetamodel.
-	
-	self fixRemoteMetamodelRelationsIn: aMetamodel.
-]
-
-{ #category : #accessing }
 FamixMetamodelGenerateRemoteAccessorTestGeneratorAB class >> packageName [
 
 	<ignoreForCoverage>

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -146,6 +146,11 @@ FamixGenerator class >> prefix [
 	^ #Famix
 ]
 
+{ #category : #accessing }
+FamixGenerator class >> submetamodels [
+	^ {FamixMooseQueryGenerator}
+]
+
 { #category : #comments }
 FamixGenerator >> commentForTAccess [
 
@@ -922,14 +927,14 @@ FamixGenerator >> defineGlueingTraits [
 	tWithMethodsWithModifiersGlue := builder newTraitNamed: #TWithMethodsWithModifiersGlue.
 	tWithMethodsWithModifiersGlue glueingCondition: [ :aClass |
 		| methodClasses |
-		methodClasses := self builder classesThatDirectlyUse: tMethod.
+		methodClasses := aClass builder classesThatDirectlyUse: tMethod.
 		(aClass allLocalTraits includes: tWithMethods) 
 			and: [ methodClasses anySatisfy: [ :methodClass | methodClass allTraitsInHierarchy includes: tWithModifiers ] ] ].
 
 	tWithMethodsWithAccessesGlue := builder newTraitNamed: #TWithMethodsWithAccessesGlue.
 	tWithMethodsWithAccessesGlue glueingCondition: [ :aClass |
 		| methodClasses |
-		methodClasses := self builder classesThatDirectlyUse: tMethod.
+		methodClasses := aClass builder classesThatDirectlyUse: tMethod.
 		(aClass allLocalTraits includes: tWithMethods) 
 			and: [ methodClasses anySatisfy: [ :methodClass | methodClass allTraitsInHierarchy includes: tWithAccesses ] ] ].
 
@@ -978,6 +983,9 @@ FamixGenerator >> defineHierarchy [
 	tMethod --|> #TWithSignature.
 	tMethod --|> #TWithClassScope.
 	tMethod --|> #TTypedStructure.
+	
+	tNamed --|> #TDependencyQueries.
+	tNamed --|> #TEntityMetaLevelDependency.	
 	
 	tParameter --|> tStructuralEntity.
 

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -982,10 +982,7 @@ FamixGenerator >> defineHierarchy [
 	tMethod --|> #TWithImplicitVariables.
 	tMethod --|> #TWithSignature.
 	tMethod --|> #TWithClassScope.
-	tMethod --|> #TTypedStructure.
-	
-	tNamed --|> #TDependencyQueries.
-	tNamed --|> #TEntityMetaLevelDependency.	
+	tMethod --|> #TTypedStructure.	
 	
 	tParameter --|> tStructuralEntity.
 

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -177,11 +177,7 @@ FamixPharoSmalltalkGenerator >> defineProperties [
 
 { #category : #initialization }
 FamixPharoSmalltalkGenerator >> newBuilder [
-
-	^ self builderWithStandardTraits
+	^ super newBuilder
 		withImportingContext;
 		yourself
-		
-		
-	
 ]

--- a/src/Famix-TestGenerators/FamixTestComposed3Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposed3Generator.class.st
@@ -5,14 +5,6 @@ Class {
 }
 
 { #category : #accessing }
-FamixTestComposed3Generator class >> modifyMetamodel: aMetamodel [
-
-	super modifyMetamodel: aMetamodel.
-	
-	self fixRemoteMetamodelRelationsIn: aMetamodel.
-]
-
-{ #category : #accessing }
 FamixTestComposed3Generator class >> packageName [ 
 
 	^ 'Famix-TestComposed3Metamodel-Entities'

--- a/src/Famix-TestGenerators/FamixTestComposedComposedGenerator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedComposedGenerator.class.st
@@ -5,14 +5,6 @@ Class {
 }
 
 { #category : #accessing }
-FamixTestComposedComposedGenerator class >> modifyMetamodel: aMetamodel [
-
-	super modifyMetamodel: aMetamodel.
-	
-	self fixRemoteMetamodelRelationsIn: aMetamodel.
-]
-
-{ #category : #accessing }
 FamixTestComposedComposedGenerator class >> packageName [ 
 
 	^ 'Famix-TestComposedComposedMetamodel-Entities'

--- a/src/Famix-TestGenerators/FamixTestComposedGenerator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedGenerator.class.st
@@ -13,14 +13,6 @@ Class {
 }
 
 { #category : #accessing }
-FamixTestComposedGenerator class >> modifyMetamodel: aMetamodel [
-
-	super modifyMetamodel: aMetamodel.
-	
-	self fixRemoteMetamodelRelationsIn: aMetamodel.
-]
-
-{ #category : #accessing }
 FamixTestComposedGenerator class >> packageName [ 
 
 	^ 'Famix-TestComposedMetamodel-Entities'

--- a/src/Famix-Traits/FamixTNamed.trait.st
+++ b/src/Famix-Traits/FamixTNamed.trait.st
@@ -3,8 +3,6 @@ Trait {
 	#instVars : [
 		'#name => FMProperty'
 	],
-	#traits : 'TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Named'
 }
 

--- a/src/Famix-Traits/FamixTNamed.trait.st
+++ b/src/Famix-Traits/FamixTNamed.trait.st
@@ -3,6 +3,8 @@ Trait {
 	#instVars : [
 		'#name => FMProperty'
 	],
+	#traits : 'TDependencyQueries + TEntityMetaLevelDependency',
+	#classTraits : 'TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Named'
 }
 


### PR DESCRIPTION
- Ease the development of composed MM
- Make basic infrastructure use FamixGenerator as sub MM instead of using a hack
- FamixGenerator now use MooseQuery as sub MM
- TNamed now use MooseQuery