### PR TITLE
Remove-dependency-between-MooseQuery-and-Famix

### DIFF
--- a/src/Famix-Deprecated/MooseIncomingQueryResult.extension.st
+++ b/src/Famix-Deprecated/MooseIncomingQueryResult.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #MooseIncomingQueryResult }
+
+{ #category : #'*Famix-Deprecated' }
+MooseIncomingQueryResult >> targetClasses [
+	self deprecated: 'Use #targetsAtScope: instead' transformWith: '`@receiver targetClasses' -> '`@receiver targetsAtScope: FamixTClass'.
+	^ self targetsAtScope: FamixTClass
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseIncomingQueryResult >> targetMethods [
+	self deprecated: 'Use #targetsAtScope: instead' transformWith: '`@receiver targetMethods' -> '`@receiver targetsAtScope: FamixTMethod'.
+	^ self targetsAtScope: FamixTMethod
+]

--- a/src/Famix-Deprecated/MooseOutgoingQueryResult.extension.st
+++ b/src/Famix-Deprecated/MooseOutgoingQueryResult.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #MooseOutgoingQueryResult }
+
+{ #category : #'*Famix-Deprecated' }
+MooseOutgoingQueryResult >> sourceClasses [
+	self deprecated: 'Use #sourcesAtScope: instead' transformWith: '`@receiver sourceClasses' -> '`@receiver sourcesAtScope: FamixTClass'.
+	^ self sourcesAtScope: FamixTClass
+]

--- a/src/Moose-Query/MooseIncomingQueryResult.class.st
+++ b/src/Moose-Query/MooseIncomingQueryResult.class.st
@@ -24,21 +24,11 @@ MooseIncomingQueryResult >> opposite: aDependency [
 ]
 
 { #category : #accessing }
-MooseIncomingQueryResult >> targetClasses [
-	"flatten targets as we receive candidates instead of single elements for incoming invocations"
-
-	^ self targets deepFlatten flatCollectAsSet: [ :e | e atScope: FamixTClass ]
-]
-
-{ #category : #accessing }
-MooseIncomingQueryResult >> targetMethods [
-	"Only valid if dependencies are invocations"
-	
-	^ storage flatCollectAsSet: [ :invo | invo candidates ]
-]
-
-{ #category : #accessing }
 MooseIncomingQueryResult >> targets [
+	^ (self collectAsSet: #to) flattened
+]
 
-	^ self collectAsSet: #to
+{ #category : #accessing }
+MooseIncomingQueryResult >> targetsAtScope: aTraitOrClass [
+	^ self targets flatCollectAsSet: [ :e | e atScope: aTraitOrClass ]
 ]

--- a/src/Moose-Query/MooseOutgoingQueryResult.class.st
+++ b/src/Moose-Query/MooseOutgoingQueryResult.class.st
@@ -24,12 +24,11 @@ MooseOutgoingQueryResult >> opposite: aDependency [
 ]
 
 { #category : #accessing }
-MooseOutgoingQueryResult >> sourceClasses [
-	^ self sources flatCollectAsSet: [ :e | e atScope: FamixTClass ]
+MooseOutgoingQueryResult >> sources [
+	^ (self collectAsSet: #from) flattened
 ]
 
 { #category : #accessing }
-MooseOutgoingQueryResult >> sources [
-
-	^ self collectAsSet: #from
+MooseOutgoingQueryResult >> sourcesAtScope: aFamixTraitOrClass [
+	^ self sources flatCollectAsSet: [ :e | e atScope: aFamixTraitOrClass ]
 ]

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXClassNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXClassNavigationChefTest.class.st
@@ -1015,9 +1015,8 @@ FAMIXClassNavigationChefTest >> testSureReferencingPackages [
 { #category : #'tests - incoming invocations' }
 FAMIXClassNavigationChefTest >> testTargetMethodsInReferencingMethods [
 	self
-		assertCollection: self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations targetMethods
-		hasSameElements:
-			{(self getMethod: 'm3p7c14Mtd2()') . (self getMethod: 'm3p7c14Mtd4()') . (self getMethod: 'm3p7c14InstCreation()')}
+		assertCollection: (self c14ReferencerOutSideRefereeOutSide queryAllIncomingInvocations targetsAtScope: FamixTMethod)
+		hasSameElements: {(self getMethod: 'm3p7c14Mtd2()') . (self getMethod: 'm3p7c14Mtd4()') . (self getMethod: 'm3p7c14InstCreation()')}
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXPackageNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXPackageNavigationChefTest.class.st
@@ -180,18 +180,18 @@ FAMIXPackageNavigationChefTest >> testReferencingPackages [
 { #category : #'tests - inheritance' }
 FAMIXPackageNavigationChefTest >> testSourceClassesInInheritedClasses [
 	self
-		assertCollection: self p3InteractedReferencer queryOutgoingInheritances sourceClasses
+		assertCollection: (self p3InteractedReferencer queryOutgoingInheritances sourcesAtScope: FamixTClass)
 		hasSameElements: {self c5ReferencerInSideRefereeInSide . self c6FullReferencerInSideOutSide . self c7FullRefereeInSide . self c8FullReferencerInSide}.
 
 	self
-		assertCollection: self p3InteractedReferencer queryOutgoingInheritances withoutSelfLoops sourceClasses
+		assertCollection: (self p3InteractedReferencer queryOutgoingInheritances withoutSelfLoops sourcesAtScope: FamixTClass)
 		hasSameElements: {self c5ReferencerInSideRefereeInSide . self c6FullReferencerInSideOutSide . self c7FullRefereeInSide}
 ]
 
 { #category : #'tests - outgoing invocations' }
 FAMIXPackageNavigationChefTest >> testSourceClassesInReferencedClasses [
 	self
-		assertCollection: self p3InteractedReferencer queryAllOutgoingInvocations sourceClasses
+		assertCollection: (self p3InteractedReferencer queryAllOutgoingInvocations sourcesAtScope: FamixTClass)
 		hasSameElements: {self c5ReferencerInSideRefereeInSide . self c6FullReferencerInSideOutSide}
 ]
 
@@ -341,15 +341,15 @@ FAMIXPackageNavigationChefTest >> testSureReferencingPackages [
 
 { #category : #'tests - incoming invocations' }
 FAMIXPackageNavigationChefTest >> testTargetClassesInReferencingClasses [
-	self assertCollection: self p5FullReferee queryAllIncomingInvocations targetClasses hasSameElements: {self c11FullRefereeOutSide}
+	self assertCollection: (self p5FullReferee queryAllIncomingInvocations targetsAtScope: FamixTClass) hasSameElements: {self c11FullRefereeOutSide}
 ]
 
 { #category : #'tests - references' }
 FAMIXPackageNavigationChefTest >> testTargetClassesInStaticReferencingClasses [
 	self
-		assertCollection: self p2InteractedReferencerReferee queryIncomingReferences targetClasses
+		assertCollection: (self p2InteractedReferencerReferee queryIncomingReferences targetsAtScope: FamixTClass)
 		hasSameElements: {self c2ReferencerOutSideRefereeInSide . self c3ReferencerInSideRefereeOutSide . self c4FullRefereeInSide}.
 	self
-		assertCollection: self p2InteractedReferencerReferee queryIncomingReferences withoutSelfLoops targetClasses
+		assertCollection: (self p2InteractedReferencerReferee queryIncomingReferences withoutSelfLoops targetsAtScope: FamixTClass)
 		hasSameElements: {self c3ReferencerInSideRefereeOutSide}
 ]


### PR DESCRIPTION
Remove dependency from MooseQuery to FamixTraits by implementing more generic methods.