### PR TITLE
Migrate-some-tests-to-new-MMs

### DIFF
--- a/src/Moose-Tests-Core/FamixTest.class.st
+++ b/src/Moose-Tests-Core/FamixTest.class.st
@@ -8,24 +8,24 @@ Class {
 FamixTest >> classWithUnknownAttribute [
 	^ '
 (
-	(FAMIX.Class (id: 1)
+	(Famix-Test3-Entities.Class (id: 1)
 		(name ''AClass'') 
 		(unknownMetric 3)
 	)
-	(FAMIX.Class (id: 2)
+	(Famix-Test3-Entities.Class (id: 2)
 		(name ''SuperClass'')
 	)
-	(FAMIX.Inheritance (id: 3)
-		(subclass (ref: 1))
-		(superclass (ref: 2))
+	(Famix-Test3-Entities.Reference (id: 3)
+		(source (ref: 4))
+		(target (ref: 2))
 	)
-	(FAMIX.Method
+	(Famix-Test3-Entities.Method (id: 4)
 		(name ''aMethod'') 
 		(parentType (ref: 1))
 	)
 )'
 
-	"(FAMIX.UnknownElement (id: 3))"
+	"(Famix-Test3-Entities.UnknownElement (id: 3))"
 ]
 
 { #category : #tests }
@@ -33,10 +33,10 @@ FamixTest >> oneClassAndOneMethod [
 	
 	^'
 (
-	(FAMIX.Class (id: 1)
+	(Famix-Test3-Entities.Class (id: 1)
 		(name ''AClass'') 
 	)
-	(FAMIX.Method
+	(Famix-Test3-Entities.Method
 		(name ''aMethod'') 
 		(parentType (ref: 1))
 	)
@@ -52,14 +52,12 @@ FamixTest >> testMSEImport [
 
 	| importer model |
 	"MooseModel resetMeta."
-	
 	importer := FMImporter new.
-	importer repository: FamixCompatibilityGenerator newRepository.
+	importer repository: FamixTest3Generator newRepository.
 	importer fromString: self oneClassAndOneMethod.
-	importer nameTranslator: FamixCompatibilityGenerator translationDictionary.
 	importer run.
 	self assert: importer repository elements size equals: 2.
-	model := MooseModel new.
+	model := FamixTest3MooseModel new.
 	importer repository elements do: [ :each | model add: each ].
 	self assert: model allClasses size equals: 1.
 	self assert: model allMethods size equals: 1
@@ -68,20 +66,18 @@ FamixTest >> testMSEImport [
 { #category : #tests }
 FamixTest >> testRobustMSEImport [
 	| importer model |
-	
 	"MooseModel resetMeta."
 	importer := FMImporter new.
-	importer repository: FamixCompatibilityGenerator newRepository.
+	importer repository: FamixTest3Generator newRepository.
 	importer fromString: self classWithUnknownAttribute.
-	importer nameTranslator: FamixCompatibilityGenerator translationDictionary.
 	importer run.
-	
+
 	self assert: importer repository elements size equals: 4.
-	model := MooseModel new.
+	model := FamixTest3MooseModel new.
 	importer repository elements do: [ :each | model add: each ].
 	self assert: model allClasses size equals: 2.
 	self assert: model allMethods size equals: 1.
-	self assert: model allInheritanceDefinitions size equals: 1
+	self assert: model allReferences size equals: 1
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -6,13 +6,20 @@ Class {
 
 { #category : #tests }
 MooseGroupTest >> testAddLast [
-	| group |
+	| group entity class method |
 	group := MooseGroup new.
-	group addLast: MooseEntity new.
-	group addLast: MooseEntity new.
-	group addLast: MooseEntity new.
-	self assert: (group allSatisfy: [ :c | c class == MooseEntity ]).
-	self deny: (group allSatisfy: [ :c | c = 10 ])
+	group addLast: (entity := FamixTest1Entity new).
+	self assert: group last identicalTo: entity.
+
+	group addLast: (class := FamixTest1Class new).
+	self assert: group last identicalTo: class.
+
+	group addLast: (method := FamixTest1Method new).
+	self assert: group last identicalTo: method.
+
+	self assert: (group at: 1) identicalTo: entity.
+	self assert: (group at: 2) identicalTo: class.
+	self assert: (group at: 3) identicalTo: method
 ]
 
 { #category : #tests }
@@ -193,7 +200,7 @@ MooseGroupTest >> testCopy [
 
 { #category : #tests }
 MooseGroupTest >> testCount [
-	self assert: (self twoClasses count: [ :el | el class == FAMIXClass ]) equals: 2
+	self assert: (self twoClasses count: [ :el | el class == FamixTest1Class ]) equals: 2
 ]
 
 { #category : #tests }
@@ -621,10 +628,10 @@ MooseGroupTest >> testWithIndexDo [
 { #category : #utility }
 MooseGroupTest >> twoClasses [
 	| classA classB |
-	classA := FAMIXClass new.
-	classA addMethod: FAMIXMethod new.
-	classB := FAMIXClass new.
-	classB addMethod: FAMIXMethod new.
-	classB addMethod: FAMIXMethod new.
-	^ FAMIXTypeGroup withAll: {classA . classB}.
+	classA := FamixTest1Class new.
+	classA addMethod: FamixTest1Method new.
+	classB := FamixTest1Class new.
+	classB addMethod: FamixTest1Method new.
+	classB addMethod: FamixTest1Method new.
+	^ FAMIXClassGroup withAll: {classA . classB}
 ]


### PR DESCRIPTION
Cut dependencies between FamixTest class and Famix compatibility.