### PR TITLE
introduce-hierarchy-for-group-tests

### DIFF
--- a/src/Famix-Compatibility-Entities/MooseModel.extension.st
+++ b/src/Famix-Compatibility-Entities/MooseModel.extension.st
@@ -1,15 +1,6 @@
 Extension { #name : #MooseModel }
 
 { #category : #'*Famix-Compatibility-Entities' }
-MooseModel >> ensureClassesAndNamespaces [
-	<menuItem: 'Ensure Classes and Namespaces' category: 'Utilities'>
-	self allMethods
-		do: [ :each | each parentType ifNil: [ each parentType: self unknownFAMIXClass ] ].
-	self allClasses
-		do: [ :each | each container ifNil: [ each container: self unknownFAMIXNamespace ] ]
-]
-
-{ #category : #'*Famix-Compatibility-Entities' }
 MooseModel >> inferNamespaceParentsBasedOnNames [
 	<menuItem: 'Infer Namespace Parents Based on Names' category: 'Utilities'>
 	| parent parentNameSize currentPosition parentName namespaces |
@@ -44,30 +35,4 @@ MooseModel >> inferNamespaceParentsBasedOnNames [
 		] description: 'Infer namespace parents based on names' length: (namespaces size * 2);
 	runWithProgress.
 	^ self allNamespaces
-]
-
-{ #category : #'*Famix-Compatibility-Entities' }
-MooseModel >> unknownFAMIXClass [
-	^ self allClasses 
-		detect: [:each | each mooseName = #'unknownNamespace::UnknownClass'] 
-		ifNone: [
-			self add: (
-				FAMIXClass new 
-					name: 'UnknownClass'; 
-					container: self unknownFAMIXNamespace; 
-					isStub: true; 
-					yourself)
-		]
-]
-
-{ #category : #'*Famix-Compatibility-Entities' }
-MooseModel >> unknownFAMIXNamespace [
-	^ self allNamespaces
-		detect: [ :each | each mooseName = #unknownNamespace ]
-		ifNone: [ self
-				add:
-					(FAMIXNamespace new
-						name: 'unknownNamespace';
-						isStub: true;
-						yourself) ]
 ]

--- a/src/Famix-Deprecated/MooseAbstractGroup.extension.st
+++ b/src/Famix-Deprecated/MooseAbstractGroup.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #MooseAbstractGroup }
+
+{ #category : #'*Famix-Deprecated' }
+MooseAbstractGroup >> entityNamed: aMooseName ifAbsentPut: aValue [
+	self
+		deprecated:
+			'This method has a bad behavior because it will not add the entity under the name passed as parameter. This methods will be removed in the next version of Moose. If you want to keep the behavior, please inline the content.'.
+	^ self entityNamed: aMooseName ifAbsent: [ self add: aValue ]
+]

--- a/src/Famix-Deprecated/MooseGroup.extension.st
+++ b/src/Famix-Deprecated/MooseGroup.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #MooseGroup }
+
+{ #category : #'*Famix-Deprecated' }
+MooseGroup >> selectByExpression: anExpression [
+	self deprecated: 'Use #select: instead' transformWith: '`@receiver selectByExpression: `@statements1' -> '`@receiver select: `@statements1'.
+	^ self select: anExpression
+]

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -56,6 +56,12 @@ MooseAbstractGroup >> addAll: aCollectionOfItems [
 	^ self subclassResponsibility
 ]
 
+{ #category : #'adding/removing' }
+MooseAbstractGroup >> addLast: anEntity [ 
+	 
+	^self add: anEntity
+]
+
 { #category : #accessing }
 MooseAbstractGroup >> allContainers [
 	<navigation: 'All containers'>

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -320,11 +320,6 @@ MooseAbstractGroup >> entityNamed: aMooseName ifAbsent: aBlock ifPresent: anothe
 		ifFalse: [anotherBlock value: entity]
 ]
 
-{ #category : #'public interface' }
-MooseAbstractGroup >> entityNamed: aMooseName ifAbsentPut: aValue [ 
-	^ self entityNamed: aMooseName ifAbsent: [self add: aValue]
-]
-
 { #category : #private }
 MooseAbstractGroup >> entityStorage [ 
 	 
@@ -547,6 +542,11 @@ MooseAbstractGroup >> printOn: aStream [
 	aStream nextPut: $(. 
 	aStream nextPutAll: self size printString. 
 	aStream nextPut: $)
+]
+
+{ #category : #'adding/removing' }
+MooseAbstractGroup >> readStream [
+	^ self entities readStream
 ]
 
 { #category : #enumerating }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -175,6 +175,12 @@ MooseAbstractGroup >> at: anIndex [
 	^ self entities at: anIndex
 ]
 
+{ #category : #'public interface' }
+MooseAbstractGroup >> average: aSymbolOrBlock [ 
+	 
+	^ (self sumNumbers: aSymbolOrBlock) / self size
+]
+
 { #category : #enumerating }
 MooseAbstractGroup >> collect: aBlock [ 
 	^ self entities collect: aBlock

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -25,6 +25,11 @@ MooseAbstractGroup class >> annotation [
 ]
 
 { #category : #'instance creation' }
+MooseAbstractGroup class >> with: anEntity [
+	^ anEntity ifNil: [ self new ] ifNotNil: [ self withAll: (Array with: anEntity) ]
+]
+
+{ #category : #'instance creation' }
 MooseAbstractGroup class >> withAll: aCollection [
 	"Create a new collection containing all the elements from aCollection."
 

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -76,9 +76,8 @@ MooseAbstractGroup >> allModels [
 ]
 
 { #category : #'public interface' }
-MooseAbstractGroup >> allSatisfy: aBlock [ 
-	 
-	^self entities allSatisfy: aBlock
+MooseAbstractGroup >> allSatisfy: aBlock [
+	^ self entities allSatisfy: aBlock
 ]
 
 { #category : #groups }

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -442,8 +442,9 @@ MooseEntity >> metamodel [
 
 { #category : #accessing }
 MooseEntity >> mooseDescription [
-
-	^ self mooseModel ifNotNil: [:mooseModel | mooseModel metamodel descriptionOf: self class instanceSide ] ifNil: [ super mooseDescription ]  
+	^ self mooseModel
+		ifNil: [ super mooseDescription ]
+		ifNotNil: #mooseDescription
 ]
 
 { #category : #printing }

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -444,7 +444,7 @@ MooseEntity >> metamodel [
 MooseEntity >> mooseDescription [
 	^ self mooseModel
 		ifNil: [ super mooseDescription ]
-		ifNotNil: #mooseDescription
+		ifNotNil: [ :model | model mooseDescriptionFor: self class ]
 ]
 
 { #category : #printing }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -240,12 +240,6 @@ MooseGroup >> printOn: aStream [
 "	
 ]
 
-{ #category : #'adding/removing' }
-MooseGroup >> readStream [ 
-	 
-	^self entities readStream
-]
-
 { #category : #enumerating }
 MooseGroup >> reject: aBlock [
 	^ self species withAll: (self entities reject: aBlock)
@@ -268,17 +262,6 @@ MooseGroup >> removeAll: collection [
 { #category : #enumerating }
 MooseGroup >> select: aBlock [
 	^ self species withAll: (self entities select: aBlock)
-]
-
-{ #category : #'public interface' }
-MooseGroup >> selectByExpression: anExpression [ 
-	^ self select: anExpression 
-"	| resultCollection | 
-	resultCollection := self entities select: [:each | anExpression value: each value: self]. 
-	^self species 
-		withAll: resultCollection 
-		withDescription: 
-			self description , ' selected by ' , anExpression printString"
 ]
 
 { #category : #'public interface' }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -89,12 +89,6 @@ MooseGroup >> addAll: collection [
 	self updateTypeAccordingToEntities
 ]
 
-{ #category : #'adding/removing' }
-MooseGroup >> addLast: anEntity [ 
-	 
-	^self add: anEntity
-]
-
 { #category : #'public interface' }
 MooseGroup >> average: aSymbolOrBlock [ 
 	 

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -89,12 +89,6 @@ MooseGroup >> addAll: collection [
 	self updateTypeAccordingToEntities
 ]
 
-{ #category : #'public interface' }
-MooseGroup >> average: aSymbolOrBlock [ 
-	 
-	^ (self sumNumbers: aSymbolOrBlock) / self size
-]
-
 { #category : #private }
 MooseGroup >> changeTypeTo: aSmalltalkClass [
 	| group | 
@@ -196,8 +190,9 @@ MooseGroup >> min: aSymbolOrBlock [
 
 { #category : #accessing }
 MooseGroup >> mooseDescription [
-
-	^ self mooseModel ifNil: [ FM3NullDescription new ] ifNotNil: [ :mooseModel | mooseModel metamodel descriptionOf: self class instanceSide]  
+	^ self mooseModel
+		ifNil: [ FM3NullDescription new ]
+		ifNotNil: #mooseDescription
 ]
 
 { #category : #accessing }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -31,11 +31,6 @@ MooseGroup class >> new: capacity [
 ]
 
 { #category : #'instance creation' }
-MooseGroup class >> with: anEntity [
-	^ anEntity ifNil: [ self new ] ifNotNil: [ self withAll: (Array with: anEntity) ]
-]
-
-{ #category : #'instance creation' }
 MooseGroup class >> with: anEntity withDescription: aDescription [ 
 	 
 	^(self with: anEntity) description: aDescription

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -187,7 +187,7 @@ MooseGroup >> min: aSymbolOrBlock [
 MooseGroup >> mooseDescription [
 	^ self mooseModel
 		ifNil: [ FM3NullDescription new ]
-		ifNotNil: #mooseDescription
+		ifNotNil: [ :model | model mooseDescriptionFor: self class ]
 ]
 
 { #category : #accessing }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -494,8 +494,12 @@ MooseModel >> metamodel: anObject [
 
 { #category : #accessing }
 MooseModel >> mooseDescription [
+	^ self mooseDescriptionFor: self class
+]
 
-	^ self metamodel descriptionOf: self class instanceSide
+{ #category : #accessing }
+MooseModel >> mooseDescriptionFor: class [
+	^ self metamodel descriptionOf: class instanceSide
 ]
 
 { #category : #accessing }

--- a/src/Moose-Tests-Core/FamixTest3MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/FamixTest3MooseModelTest.class.st
@@ -1,0 +1,42 @@
+"
+I am test runed on FamixTest3 model to be able to tests features were you need a real model.
+"
+Class {
+	#name : #FamixTest3MooseModelTest,
+	#superclass : #MooseModelTest,
+	#category : #'Moose-Tests-Core'
+}
+
+{ #category : #helpers }
+FamixTest3MooseModelTest >> actualClass [
+	^ FamixTest3MooseModel
+]
+
+{ #category : #tests }
+FamixTest3MooseModelTest >> testExport [
+	self assert: (String streamContents: [ :s | group exportTo: s ]) equals: '()'.
+	group add: (FamixTest3Class named: 'Foo').
+	self
+		assert: (String streamContents: [ :s | group exportTo: s ])
+		equals:
+			'(
+	(Famix-Test3-Entities.Class (id: 1)
+		(name ''Foo'')))'
+]
+
+{ #category : #tests }
+FamixTest3MooseModelTest >> testPrintOn [
+	self assert: group printString equals: 'a FamixTest3MooseModel #noname(0)'.
+	group name: 'hello'.
+	self assert: group printString equals: 'a FamixTest3MooseModel #hello(0)'.
+	group name: 'hello2'.
+	group add: MooseEntity new.
+	self assert: group printString equals: 'a FamixTest3MooseModel #hello2(1)'.
+	self assert: self actualClass meta printString equals: 'a FMMetaRepository'
+]
+
+{ #category : #tests }
+FamixTest3MooseModelTest >> testRootUniqueness [
+	self skip. "This should be fixed later. https://github.com/moosetechnology/Moose/issues/1809"
+	super testRootUniqueness
+]

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -97,6 +97,53 @@ MooseAbstractGroupTest >> testAllWithTypeAtSetup [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testAnySatisfy [
+	3 timesRepeat: [ group add: MooseEntity new ].
+
+	self assert: (group anySatisfy: [ :c | c class == MooseEntity ]).
+	self deny: (group anySatisfy: [ :c | c = 10 ])
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAverage [
+	| classA classB |
+	classA := FamixTest3Class new
+		addMethod: FamixTest3Method new;
+		yourself.
+	classB := FamixTest3Class new
+		addMethod: FamixTest3Method new;
+		addMethod: FamixTest3Method new;
+		yourself.
+	group addAll: {classA . classB}.
+	self assert: (group average: #numberOfMethods) equals: 1.5
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testEntityNamedIfAbsentIfPresent [
+	| result class |
+	group add: (class := FamixTest3Class named: 'A').
+	result := group entityNamed: 'X' ifAbsent: [ 42 ] ifPresent: [ :i | self fail ].
+	self assert: result equals: 42.
+	result := group entityNamed: class mooseName ifAbsent: [ self fail ] ifPresent: [ :cls | cls name ].
+	self assert: result equals: class mooseName
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testEntityNamedIfAbsentPut [
+	| class result |
+	class := FamixTest3Class named: 'A'.
+	result := group entityNamed: 'X' ifAbsentPut: class.
+	self assert: group size equals: 1.
+	self assert: group first identicalTo: class.
+	self assert: result equals: class.
+	self flag: #todo. "The logic of this method is really weird. We should see what to do... https://github.com/moosetechnology/Moose/issues/1808"
+	"result := group entityNamed: 'X' ifAbsentPut: class.
+	self assert: group size equals: 1.
+	self assert: group first identicalTo: class.
+	self assert: result equals: class."
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testNumberOfPackages [
 	self assert: group numberOfPackages equals: 0
 ]

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -162,15 +162,47 @@ MooseAbstractGroupTest >> testDetect [
 
 { #category : #tests }
 MooseAbstractGroupTest >> testDifference [
-	group addAll: #(1 2 3).
-	self assertCollection: (group difference: (self actualClass withAll: #(2 4))) hasSameElements: #(1 3).
-	self assertCollection: ((self actualClass withAll: #(2 4)) difference: group) hasSameElements: #(4)
+	| group2 el1 el2 el3 el4 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	group2 := self actualClass with: (el4 := MooseEntity new).
+	self assertCollection: (group difference: group2) hasSameElements: group.
+	self assertCollection: (group difference: self actualClass new) hasSameElements: group.
+	self assertEmpty: (group difference: group).
+	group2 add: el1.
+	self assertCollection: (group difference: group2) hasSameElements: {el2 . el3}.
+	self assertCollection: (group2 difference: group) hasSameElements: {el4}.
+	group add: el1.
+	self assertCollection: (group difference: group2) hasSameElements: {el2 . el3}
 ]
 
 { #category : #tests }
 MooseAbstractGroupTest >> testDifferenceWithRealCollection [
 	group addAll: #(1 2 3).
 	self assertCollection: (group difference: #(2)) hasSameElements: #(1 3)
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testDoWithIndex [
+	| t el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	t := OrderedCollection new.
+	group doWithIndex: [ :x :i | t add: {x . i} ].
+	self assertCollection: t hasSameElements: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testEntitiesDo [
+	| t el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	t := OrderedCollection new.
+	group entitiesDo: [ :e | t add: e ].
+	self assertCollection: t hasSameElements: {el1 . el2 . el3}
 ]
 
 { #category : #tests }
@@ -199,8 +231,107 @@ MooseAbstractGroupTest >> testEntityNamedIfAbsentPut [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testEnumeration [
+	| el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+
+	self assert: group first identicalTo: el1.
+	self assert: group second identicalTo: el2.
+	self assert: group third identicalTo: el3.
+
+	self assert: group first identicalTo: (group at: 1).
+	self assert: group second identicalTo: (group at: 2).
+	self assert: group third identicalTo: (group at: 3)
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testFirst [
+	| el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: el1.
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	self assert: group first identicalTo: el1.
+	self assert: (group first: 2) asArray equals: {el1 . el1}.
+	self assert: (group first: 4) asArray equals: {el1 . el1 . el2 . el3}.
+	self should: [ group first: 5 ] raise: Error
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testGroupSize [
+	| classes |
+	classes := self twoClasses.
+	group addAll: classes.
+	self assert: group numberOfItems equals: classes size.
+	self assert: group size equals: 2
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testGroupedBy [
+	| v |
+	group addAll: ((1 to: 5) collect: [ :i | FamixTest3Class named: i asString ]).
+	self assert: group size equals: 5.
+	v := group groupedBy: [ :e | e name asNumber odd ].
+	self assert: v isDictionary.
+	self assert: v keys size equals: 2.
+	self assert: (v values first isKindOf: self actualClass).
+	self assert: (v values second isKindOf: self actualClass).
+	self assertCollection: ((v at: true) collect: #name) hasSameElements: #('1' '3' '5').
+	self assertCollection: ((v at: false) collect: #name) hasSameElements: #('2' '4')
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testIndexOf [
+	| el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: el1.
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	self assert: (group indexOf: el1) equals: 1.
+	self assert: (group indexOf: el2) equals: 3.
+	self assert: (group indexOf: el3) equals: 4
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testIntersection [
+	| group2 el1 el2 el3 el4 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	group2 := self actualClass with: (el4 := MooseEntity new).
+	self assertEmpty: (group intersection: group2).
+	self assertEmpty: (group intersection: self actualClass new).
+	self assertCollection: (group intersection: group) hasSameElements: {el1 . el2 . el3}.
+	group2 add: el1.
+	self assertCollection: (group intersection: group2) hasSameElements: {el1}.
+	self assertCollection: (group2 intersection: group) hasSameElements: {el1}.
+	group add: el1.
+	self assertCollection: (group intersection: group2) hasSameElements: {el1}
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testIntersectionWithRealCollection [
+	group addAll: #(1 2 3).
+	self assertCollection: (group intersection: #(2 3 4)) hasSameElements: #(2 3).
+	self assertCollection: (#(2 3 4) intersection: group) hasSameElements: #(2 3)
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testNumberOfPackages [
 	self assert: group numberOfPackages equals: 0
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testWithIndexDo [
+	| t el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	t := OrderedCollection new.
+	group withIndexDo: [ :x :i | t add: {x . i} ].
+	self assertCollection: t hasSameElements: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
 ]
 
 { #category : #utility }

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -216,21 +216,6 @@ MooseAbstractGroupTest >> testEntityNamedIfAbsentIfPresent [
 ]
 
 { #category : #tests }
-MooseAbstractGroupTest >> testEntityNamedIfAbsentPut [
-	| class result |
-	class := FamixTest3Class named: 'A'.
-	result := group entityNamed: 'X' ifAbsentPut: class.
-	self assert: group size equals: 1.
-	self assert: group first identicalTo: class.
-	self assert: result equals: class.
-	self flag: #todo. "The logic of this method is really weird. We should see what to do... https://github.com/moosetechnology/Moose/issues/1808"
-	"result := group entityNamed: 'X' ifAbsentPut: class.
-	self assert: group size equals: 1.
-	self assert: group first identicalTo: class.
-	self assert: result equals: class."
-]
-
-{ #category : #tests }
 MooseAbstractGroupTest >> testEnumeration [
 	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
@@ -319,8 +304,75 @@ MooseAbstractGroupTest >> testIntersectionWithRealCollection [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testIsCollection [
+	self assert: group isCollection
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testLast [
+	| el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: el1.
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	self assert: group last identicalTo: el3.
+	self assertCollection: (group last: 2) hasSameElements: {el2 . el3}.
+	self assertCollection: (group last: 4) hasSameElements: {el1 . el1 . el2 . el3}.
+	self should: [ group last: 5 ] raise: Error
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testNumberOfPackages [
 	self assert: group numberOfPackages equals: 0
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testOccurenceOf [
+	| el1 el2 |
+	group add: (el1 := MooseEntity new).
+	group add: el1.
+	group add: (el2 := MooseEntity new).
+	group add: MooseEntity new.
+	self assert: (group occurrencesOf: el1) equals: 2.
+	self assert: (group occurrencesOf: el2) equals: 1.
+	self assert: (group occurrencesOf: MooseEntity new) isZero
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testReadStream [
+	| el1 el2 el3 stream |
+	group add: (el1 := MooseEntity new).
+	group add: el1.
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+
+	stream := group readStream.
+	self assert: stream isStream.
+	self assert: stream next identicalTo: el1.
+	self assert: stream next identicalTo: el1.
+	self assert: stream next identicalTo: el2.
+	self assert: stream next identicalTo: el3
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testReject [
+	| el1 el2 el3 v |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	v := group reject: [ :el | el == el1 ].
+	self assertCollection: v entities hasSameElements: {el2 . el3}
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testSelect [
+	| el1 v |
+	group add: (el1 := MooseEntity new).
+	group add: MooseEntity new.
+	group add: MooseEntity new.
+	v := group select: [ :el | el == el1 ].
+	self assert: v size equals: 1.
+	self assert: v first identicalTo: el1
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -376,6 +376,25 @@ MooseAbstractGroupTest >> testSelect [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testUnion [
+	| group2 el1 el2 el3 el4 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	group2 := self actualClass with: (el4 := MooseEntity new).
+	self assertCollection: (group union: group2) hasSameElements: {el1 . el2 . el3 . el4}.
+	self assertCollection: (group2 union: group) hasSameElements: {el1 . el2 . el3 . el4}.
+	self assert: (group2 union: group) ~= (group union: group2)
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testUnionWithRealCollection [
+	group addAll: #(1 2 3).
+	self assertCollection: (group union: #(2 3 4)) hasSameElements: #(1 2 3 4).
+	self assertCollection: (#(2 3 4) union: group) hasSameElements: #(1 2 3 4)
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testWithIndexDo [
 	| t el1 el2 el3 |
 	group add: (el1 := MooseEntity new).

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -119,6 +119,61 @@ MooseAbstractGroupTest >> testAverage [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testCollect [
+	#('A' 'B' 'C') do: [ :each | group add: (FamixTest3Method named: each) ].
+	self assertCollection: (group collect: #name) entities hasSameElements: #('A' 'B' 'C')
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testContains [
+	3 timesRepeat: [ group add: MooseEntity new ].
+
+	self assert: (group contains: [ :c | c class == MooseEntity ]).
+	self deny: (group contains: [ :c | c = 10 ])
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testCopy [
+	| copy |
+	group := self actualClass with: FamixTest3Method new.
+	copy := group copy.
+	self deny: copy identicalTo: group.
+	self deny: copy entities identicalTo: group entities.
+	self assert: copy entities equals: group entities.
+	self deny: copy entityStorage identicalTo: group entityStorage.
+	copy add: FamixTest3Method new.
+	self assert: copy size equals: 2.
+	self assert: group size equals: 1
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testCount [
+	self assert: (self twoClasses count: [ :el | el class == FamixTest1Class ]) equals: 2
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testDetect [
+	| b |
+	group add: (FamixTest3Method named: 'A').
+	group add: (b := FamixTest3Method named: 'B').
+	group add: (FamixTest3Method named: 'C').
+	self assert: (group detect: [ :el | el name = 'B' ]) identicalTo: b
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testDifference [
+	group addAll: #(1 2 3).
+	self assertCollection: (group difference: (self actualClass withAll: #(2 4))) hasSameElements: #(1 3).
+	self assertCollection: ((self actualClass withAll: #(2 4)) difference: group) hasSameElements: #(4)
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testDifferenceWithRealCollection [
+	group addAll: #(1 2 3).
+	self assertCollection: (group difference: #(2)) hasSameElements: #(1 3)
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testEntityNamedIfAbsentIfPresent [
 	| result class |
 	group add: (class := FamixTest3Class named: 'A').
@@ -146,4 +201,15 @@ MooseAbstractGroupTest >> testEntityNamedIfAbsentPut [
 { #category : #tests }
 MooseAbstractGroupTest >> testNumberOfPackages [
 	self assert: group numberOfPackages equals: 0
+]
+
+{ #category : #utility }
+MooseAbstractGroupTest >> twoClasses [
+	| classA classB |
+	classA := FamixTest1Class new.
+	classA addMethod: FamixTest1Method new.
+	classB := FamixTest1Class new.
+	classB addMethod: FamixTest1Method new.
+	classB addMethod: FamixTest1Method new.
+	^ self actualClass withAll: {classA . classB}
 ]

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -4,6 +4,34 @@ Class {
 	#category : #'Moose-Tests-Core'
 }
 
+{ #category : #testing }
+MooseAbstractGroupTest class >> shouldInheritSelectors [
+	^ true
+]
+
+{ #category : #helpers }
+MooseAbstractGroupTest >> actualClass [
+	^ MooseAbstractGroup
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAddLast [
+	| group entity class method |
+	group := self actualClass new.
+	group addLast: (entity := FamixTest1Entity new).
+	self assert: group last identicalTo: entity.
+
+	group addLast: (class := FamixTest1Class new).
+	self assert: group last identicalTo: class.
+
+	group addLast: (method := FamixTest1Method new).
+	self assert: group last identicalTo: method.
+
+	self assert: (group at: 1) identicalTo: entity.
+	self assert: (group at: 2) identicalTo: class.
+	self assert: (group at: 3) identicalTo: method
+]
+
 { #category : #tests }
 MooseAbstractGroupTest >> testNumberOfPackages [
 	| abstractGroup |

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -1,8 +1,16 @@
 Class {
 	#name : #MooseAbstractGroupTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'group'
+	],
 	#category : #'Moose-Tests-Core'
 }
+
+{ #category : #testing }
+MooseAbstractGroupTest class >> isAbstract [
+	^ self = MooseAbstractGroupTest
+]
 
 { #category : #testing }
 MooseAbstractGroupTest class >> shouldInheritSelectors [
@@ -14,10 +22,15 @@ MooseAbstractGroupTest >> actualClass [
 	^ MooseAbstractGroup
 ]
 
+{ #category : #running }
+MooseAbstractGroupTest >> setUp [
+	super setUp.
+	group := self actualClass new
+]
+
 { #category : #tests }
 MooseAbstractGroupTest >> testAddLast [
-	| group entity class method |
-	group := self actualClass new.
+	| entity class method |
 	group addLast: (entity := FamixTest1Entity new).
 	self assert: group last identicalTo: entity.
 
@@ -33,8 +46,57 @@ MooseAbstractGroupTest >> testAddLast [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testAllSatisfy [
+	3 timesRepeat: [ group add: MooseEntity new ].
+
+	self assert: (group allSatisfy: [ :c | c class == MooseEntity ]).
+	self deny: (group allSatisfy: [ :c | c = 10 ])
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAllUsing [
+	group addAll: {FamixTest3Class new . FamixTest3Type new}.
+	self should: [ group allUsing: FamixTest3Type ] raise: MooseAllUsingOnClass.
+	self assert: (group allUsing: FamixTClass) size equals: 1.
+	self assert: (group allUsing: FamixTType) size equals: 2
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAllWithSubTypesOf [
+	group addAll: {FamixTest3Class new . FamixTest3Type new}.
+	self assert: (group allWithSubTypesOf: FamixTest3Type) size equals: 2.
+	self assert: (group allWithSubTypesOf: FamixTest3Class) size equals: 1.
+	self assert: (group allWithSubTypesOf: MooseEntity) size equals: 2
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAllWithType [
+	group addAll: {FamixTest3Class new . FamixTest3Type new}.
+	self assert: (group allWithType: FamixTest3Class) size equals: 1.
+	self assert: (group allWithType: FamixTest3Type) size equals: 1.
+	self should: [ (group allWithType: FamixTClass) size ] raise: MooseAllWithTypeOnTrait.
+	self assert: (group allWithType: Object) isEmpty
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAllWithTypeAtRuntime [
+	group addAll: {FamixTest3Class new . FamixTest3Method new}.
+	group entityStorage forRuntime.
+	self assert: (group allWithType: FamixTest3Class) size equals: 1.
+	self assert: (group allWithType: FamixTest3Method) size equals: 1.
+	self assert: (group allWithType: FamixTest3Invocation) isEmpty
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testAllWithTypeAtSetup [
+	group addAll: {FamixTest3Class new . FamixTest3Method new}.
+	group entityStorage forSetup.
+	self assert: (group allWithType: FamixTest3Class) size equals: 1.
+	self assert: (group allWithType: FamixTest3Method) size equals: 1.
+	self assert: (group allWithType: FamixTest3Invocation) isEmpty
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testNumberOfPackages [
-	| abstractGroup |
-	abstractGroup := MooseAbstractGroup new.
-	self assert: abstractGroup numberOfPackages equals: 0
+	self assert: group numberOfPackages equals: 0
 ]

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -359,6 +359,13 @@ MooseAbstractGroupTest >> testOccurenceOf [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testPropertyNamed [
+	self assert: (group propertyNamed: #UNKNOWN) isNil.
+	group propertyNamed: 'UNKNOWN' put: 10.
+	self assert: (group propertyNamed: #UNKNOWN) equals: 10
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testReadStream [
 	| el1 el2 el3 stream |
 	group add: (el1 := MooseEntity new).
@@ -381,7 +388,30 @@ MooseAbstractGroupTest >> testReject [
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
 	v := group reject: [ :el | el == el1 ].
-	self assertCollection: v entities hasSameElements: {el2 . el3}
+	self assertCollection: v hasSameElements: {el2 . el3}
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testRemoveAll [
+	| el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+
+	group removeAll: {el1 . el2 . el3}.
+	self assertEmpty: group
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testRemoveAll2 [
+	| el1 el2 el3 |
+	group add: (el1 := MooseEntity new).
+	group add: el1.
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	group removeAll: {el1 . el2 . el3}.
+	self denyEmpty: group.
+	self assertCollection: group entities hasSameElements: {el1}
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -29,6 +29,15 @@ MooseAbstractGroupTest >> setUp [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testAdd [
+	| entity |
+	entity := MooseEntity new.
+	group add: entity.
+	self assert: group size equals: 1.
+	self assert: group first identicalTo: entity
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testAddLast [
 	| entity class method |
 	group addLast: (entity := FamixTest1Entity new).
@@ -121,7 +130,7 @@ MooseAbstractGroupTest >> testAverage [
 { #category : #tests }
 MooseAbstractGroupTest >> testCollect [
 	#('A' 'B' 'C') do: [ :each | group add: (FamixTest3Method named: each) ].
-	self assertCollection: (group collect: #name) entities hasSameElements: #('A' 'B' 'C')
+	self assertCollection: (group collect: #name) hasSameElements: #('A' 'B' 'C')
 ]
 
 { #category : #tests }
@@ -181,6 +190,17 @@ MooseAbstractGroupTest >> testDifference [
 MooseAbstractGroupTest >> testDifferenceWithRealCollection [
 	group addAll: #(1 2 3).
 	self assertCollection: (group difference: #(2)) hasSameElements: #(1 3)
+]
+
+{ #category : #tests }
+MooseAbstractGroupTest >> testDoSeparatedBy [
+	| t el1 el2 el3 |
+	t := OrderedCollection new.
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	group do: [ :x | t add: x ] separatedBy: [ t add: 10 ].
+	self assertCollection: t hasSameElements: {el1 . 10 . el2 . 10 . el3}
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -94,24 +94,6 @@ MooseGroupTest >> testInitialization [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testIsCollection [
-	self assert: group isCollection
-]
-
-{ #category : #tests }
-MooseGroupTest >> testLast [
-	| el1 el2 el3 |
-	group add: (el1 := MooseEntity new).
-	group add: el1.
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	self assert: group last identicalTo: el3.
-	self assert: (group last: 2) asArray equals: {el2 . el3}.
-	self assert: (group last: 4) asArray equals: {el1 . el1 . el2 . el3}.
-	self should: [ group last: 5 ] raise: Error
-]
-
-{ #category : #tests }
 MooseGroupTest >> testNumberOfPackages [
 	self assert: group numberOfPackages equals: 0.
 	group add: FAMIXPackage new.
@@ -129,57 +111,6 @@ MooseGroupTest >> testObjectAsMooseGroup [
 	self assert: (group isKindOf: MooseGroup).
 	self assert: group size equals: 1.
 	self assert: group first equals: 42
-]
-
-{ #category : #tests }
-MooseGroupTest >> testOccurenceOf [
-	| el1 el2 |
-	group add: (el1 := MooseEntity new).
-	group add: el1.
-	group add: (el2 := MooseEntity new).
-	group add: MooseEntity new.
-	self assert: (group occurrencesOf: el1) equals: 2.
-	self assert: (group occurrencesOf: el2) equals: 1.
-	self assert: (group occurrencesOf: MooseEntity new) isZero
-]
-
-{ #category : #tests }
-MooseGroupTest >> testReadStream [
-	| el1 el2 el3 stream |
-	group add: (el1 := MooseEntity new).
-	group add: el1.
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-
-	stream := group readStream.
-	self assert: stream isStream.
-	self assert: stream next identicalTo: el1.
-	self assert: stream next identicalTo: el1.
-	self assert: stream next identicalTo: el2.
-	self assert: stream next identicalTo: el3
-]
-
-{ #category : #tests }
-MooseGroupTest >> testReject [
-	| el1 el2 el3 v |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	v := group reject: [ :el | el == el1 ].
-	self assert: v size equals: 2.
-	self assert: (v entities includesAll: {el2 . el3})
-]
-
-{ #category : #tests }
-MooseGroupTest >> testSelect [
-	| el1 v |
-	group add: (el1 := MooseEntity new).
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	v := group select: [ :el | el == el1 ].
-	self assert: v size equals: 1.
-	self assert: v first identicalTo: el1.
-	self assert: v entities equals: (group selectByExpression: [ :el | el == el1 ]) entities
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -115,41 +115,6 @@ MooseGroupTest >> testObjectAsMooseGroup [
 
 { #category : #tests }
 MooseGroupTest >> testSort [
-	| sorted |
-	group := MooseGroup withAll: #(4 3 1 2).
-	sorted := group sorted: [ :a :b | a < b ].
-	self assert: sorted entities asArray equals: #(1 2 3 4)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testUnion [
-	| group2 group3 el1 el2 el3 el4 |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group2 := MooseGroup new.
-	group2 add: (el4 := MooseEntity new).
-	group3 := group union: group2.
-	self assert: (group3 includesAll: {el1 . el2 . el3 . el4}).
-	self assert: group3 size equals: 4.
-	self assert: ((group2 union: group) includesAll: {el1 . el2 . el3 . el4}).
-	self assert: (group2 union: group) ~= (group union: group2)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testUnionWithRealCollection [
-	group := #(1 2 3) asMooseGroup.
-	self assertCollection: (group union: #(2 3 4)) hasSameElements: #(1 2 3 4).
-	self assertCollection: (#(2 3 4) union: group) hasSameElements: #(1 2 3 4)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testWithIndexDo [
-	| t el1 el2 el3 |
-	t := OrderedCollection new.
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group withIndexDo: [ :x :i | t add: {x . i} ].
-	self assert: t asArray equals: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
+	group addAll: #(4 3 1 2).
+	self assertCollection: (group sorted: #yourself ascending) hasSameElements: #(1 2 3 4)
 ]

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -19,72 +19,17 @@ MooseGroupTest >> testAllModelMethod [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testAllSatisfy [
-	| group |
-	group := MooseGroup new.
-	3 timesRepeat: [ group add: MooseEntity new ].
-
-	self assert: (group allSatisfy: [ :c | c class == MooseEntity ]).
-	self deny: (group allSatisfy: [ :c | c = 10 ])
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAllWithSubTypesOf [
-	| model |
-	model := FamixTest3MooseModel new.
-	model addAll: {FamixTest3Class new . FamixTest3Type new}.
-	self assert: (model allWithSubTypesOf: FamixTest3Type) size equals: 2.
-	self assert: (model allWithSubTypesOf: FamixTest3Class) size equals: 1.
-	self assert: (model allWithSubTypesOf: MooseEntity) size equals: 2
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAllWithType [
-	| model |
-	model := FamixTest3MooseModel new.
-	model addAll: {FamixTest3Class new . FamixTest3Type new}.
-	self assert: (model allWithType: FamixTest3Class) size equals: 1.
-	self assert: (model allWithType: FamixTest3Type) size equals: 1.
-	self should: [ (model allWithType: FamixTClass) size ] raise: MooseAllWithTypeOnTrait.
-	self assert: (model allWithType: Object) isEmpty
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAllWithTypeAtRuntime [
-	| group |
-	group := MooseGroup withAll: #(42 #fortytwo).
-	group entityStorage forRuntime.
-	self assert: (group allWithType: SmallInteger) size equals: 1.
-	self assert: (group allWithType: ByteSymbol) size equals: 1.
-	self assert: (group allWithType: Object) isEmpty
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAllWithTypeAtSetup [
-	| group |
-	group := MooseGroup withAll: #(42 #fortytwo).
-	group entityStorage forSetup.
-	self assert: (group allWithType: SmallInteger) size equals: 1.
-	self assert: (group allWithType: ByteSymbol) size equals: 1.
-	self assert: (group allWithType: Object) isEmpty
-]
-
-{ #category : #tests }
 MooseGroupTest >> testAnySatisfy [
-
-	| group |
-	group := MooseGroup new.
 	group add: MooseEntity new.
 	group add: MooseEntity new.
 	group add: MooseEntity new.
 
-	self assert: (group anySatisfy: [ :c | c class == MooseEntity ] ).
-	self deny: (group anySatisfy: [ :c | c = 10 ] ).
+	self assert: (group anySatisfy: [ :c | c class == MooseEntity ]).
+	self deny: (group anySatisfy: [ :c | c = 10 ])
 ]
 
 { #category : #tests }
 MooseGroupTest >> testAsMooseGroup [
-	| group |
 	group := #(1 2 3) asMooseGroup.
 	self assert: (group isKindOf: MooseGroup).
 	self assert: group size equals: 3
@@ -92,16 +37,13 @@ MooseGroupTest >> testAsMooseGroup [
 
 { #category : #tests }
 MooseGroupTest >> testAsMooseGroupDoNotCopy [
-	| group |
-	group := MooseGroup new.
-	self assert: group asMooseGroup == group
+	self assert: group asMooseGroup identicalTo: group
 ]
 
 { #category : #tests }
 MooseGroupTest >> testAsMooseGroupWithClasses [
 	"Non regression test of issue https://github.com/moosetechnology/Moose/issues/1486"
 
-	| group |
 	self shouldnt: [ group := {Object} asMooseGroup ] raise: Error.
 	self assert: group size equals: 1.
 	self assert: group anyOne equals: Object
@@ -109,8 +51,7 @@ MooseGroupTest >> testAsMooseGroupWithClasses [
 
 { #category : #tests }
 MooseGroupTest >> testAtIfAbsentIfPresent [
-	| group result |
-	group := MooseGroup new.
+	| result |
 	group add: (FAMIXClass new name: 'A').
 	result := group entityNamed: 'X' ifAbsent: [ 42 ] ifPresent: [ :i |  ].
 	self assert: result equals: 42.
@@ -120,12 +61,11 @@ MooseGroupTest >> testAtIfAbsentIfPresent [
 
 { #category : #tests }
 MooseGroupTest >> testAtIfAbsentPut [
-	| group classA |
-	group := MooseGroup new.
+	| classA |
 	classA := FAMIXClass new name: 'A'.
 	group entityNamed: 'X' ifAbsentPut: classA.
 	self assert: group size equals: 1.
-	self assert: group first == classA
+	self assert: group first identicalTo: classA
 ]
 
 { #category : #tests }
@@ -145,8 +85,6 @@ MooseGroupTest >> testAverage [
 
 { #category : #tests }
 MooseGroupTest >> testCollect [
-	| group |
-	group := MooseGroup new.
 	group add: MooseEntity new.
 	group add: MooseEntity new.
 	group add: MooseEntity new.
@@ -155,8 +93,7 @@ MooseGroupTest >> testCollect [
 
 { #category : #tests }
 MooseGroupTest >> testContains [
-	| group el1 el2 |
-	group := MooseGroup new.
+	| el1 el2 |
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: MooseEntity new.
@@ -168,7 +105,7 @@ MooseGroupTest >> testContains [
 
 { #category : #tests }
 MooseGroupTest >> testCopy [
-	| group copy |
+	| copy |
 	group := MooseGroup with: 1.
 	copy := group copy.
 	self assert: copy ~~ group.
@@ -192,19 +129,17 @@ MooseGroupTest >> testDefaultStorage [
 
 { #category : #tests }
 MooseGroupTest >> testDetect [
-	| group el1 v |
-	group := MooseGroup new.
+	| el1 v |
 	group add: (el1 := MooseEntity new).
 	group add: MooseEntity new.
 	group add: MooseEntity new.
-	
+
 	v := group detect: [ :el | el == el1 ].
 	self assert: v == el1
 ]
 
 { #category : #tests }
 MooseGroupTest >> testDifference [
-	| group |
 	group := #(1 2 3) asMooseGroup.
 	self assertCollection: (group difference: #(2 4) asMooseGroup) hasSameElements: #(1 3).
 	self assertCollection: (#(2 4) asMooseGroup difference: group) hasSameElements: #(4)
@@ -212,18 +147,16 @@ MooseGroupTest >> testDifference [
 
 { #category : #tests }
 MooseGroupTest >> testDifferenceWithRealCollection [
-	| group |
 	group := #(1 2 3) asMooseGroup.
 	self assertCollection: (group difference: #(2)) hasSameElements: #(1 3)
 ]
 
 { #category : #tests }
 MooseGroupTest >> testDistribution [
-	| referenceGroupOfGroups group |
+	| referenceGroupOfGroups |
 	referenceGroupOfGroups := MooseGroup new.
 	referenceGroupOfGroups add: (MooseGroup withAll: #(1 2 3)).
 	referenceGroupOfGroups add: (MooseGroup withAll: #(4 5 6 7 8)).
-	group := MooseGroup new.
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 0.
 	group := MooseGroup withAll: #(1 2 3).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 1.
@@ -235,11 +168,10 @@ MooseGroupTest >> testDistribution [
 
 { #category : #tests }
 MooseGroupTest >> testDistributionAndEncapsulation [
-	| referenceGroupOfGroups group |
+	| referenceGroupOfGroups |
 	referenceGroupOfGroups := MooseGroup new.
 	referenceGroupOfGroups add: (MooseGroup withAll: #(1 2 3)).
 	referenceGroupOfGroups add: (MooseGroup withAll: #(4 5 6 7 8)).
-	group := MooseGroup new.
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 0.
 	self assert: (group encapsulationOfAGroupOfGroups: referenceGroupOfGroups) equals: 0.
 	group := MooseGroup withAll: #(1 2 3).
@@ -255,90 +187,54 @@ MooseGroupTest >> testDistributionAndEncapsulation [
 
 { #category : #tests }
 MooseGroupTest >> testDoWithIndex [
-	| t group el1 el2 el3 |
+	| t el1 el2 el3 |
 	t := OrderedCollection new.
-	group := MooseGroup new.
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
-	group
-		doWithIndex: [ :x :i | 
-			t
-				add:
-					{x.
-					i} ].
-	self
-		assert: t asArray
-		equals:
-			{{el1.
-			1}.
-			{el2.
-			2}.
-			{el3.
-			3}}
+	group doWithIndex: [ :x :i | t add: {x . i} ].
+	self assert: t asArray equals: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
 ]
 
 { #category : #tests }
 MooseGroupTest >> testDoWithIndexAndWithIndexDo [
 	"Isn't that odd? Legacy method?"
 
-	| t group |
+	| t |
 	t := OrderedCollection new.
-	group := MooseGroup new.
 	group add: MooseEntity new.
 	group add: MooseEntity new.
 	group add: MooseEntity new.
 	self
-		assert:
-			(group
-				doWithIndex: [ :x :i | 
-					t
-						add:
-							{x.
-							i} ])
-		equals:
-			(group
-				withIndexDo: [ :x :i | 
-					t
-						add:
-							{x.
-							i} ])
+		assert: (group doWithIndex: [ :x :i | t add: {x . i} ])
+		equals: (group withIndexDo: [ :x :i | t add: {x . i} ])
 ]
 
 { #category : #tests }
 MooseGroupTest >> testEntitiesDo [
-	| t group el1 el2 el3 |
+	| t el1 el2 el3 |
 	t := OrderedCollection new.
-	group := MooseGroup new.
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
 	group entitiesDo: [ :e | t add: e ].
-	self
-		assert: t asArray
-		equals:
-			{el1.
-			el2.
-			el3}
+	self assert: t asArray equals: {el1 . el2 . el3}
 ]
 
 { #category : #tests }
 MooseGroupTest >> testEnumeration [
-
-	| t group el1 el2 el3 |
-	t := OrderedCollection new.
-	group := MooseGroup new.
+	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
 
-	self assert: group first == el1.
-	self assert: group second == el2.
-	self assert: group third == el3.
-	
-	self assert: group first == (group at: 1).
-	self assert: group second ==  (group at: 2).
-	self assert: group third ==  (group at: 3).
+	self assert: group first identicalTo: el1.
+	self assert: group second identicalTo: el2.
+	self assert: group third identicalTo: el3.
+
+	self assert: group first identicalTo: (group at: 1).
+	self assert: group second identicalTo: (group at: 2).
+	self assert: group third identicalTo: (group at: 3)
 ]
 
 { #category : #tests }
@@ -348,41 +244,29 @@ MooseGroupTest >> testExplicitEmptyCreation [
 
 { #category : #tests }
 MooseGroupTest >> testFirst [
-	| group el1 el2 el3 |
-	group := MooseGroup new.
+	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: el1.
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
-	self assert: group first == el1.
-	self
-		assert: (group first: 2) asArray
-		equals:
-			{el1.
-			el1}.
-	self
-		assert: (group first: 4) asArray
-		equals:
-			{el1.
-			el1.
-			el2.
-			el3}.
+	self assert: group first identicalTo: el1.
+	self assert: (group first: 2) asArray equals: {el1 . el1}.
+	self assert: (group first: 4) asArray equals: {el1 . el1 . el2 . el3}.
 	self should: [ group first: 5 ] raise: Error
 ]
 
 { #category : #tests }
 MooseGroupTest >> testGroupSize [
-	| group classes |
+	| classes |
 	classes := self twoClasses.
-	group := MooseGroup withAll: classes.
+	group addAll: classes.
 	self assert: group numberOfItems equals: classes size.
 	self assert: group size equals: 2
 ]
 
 { #category : #tests }
 MooseGroupTest >> testGroupedBy [
-	| group v |
-	group := MooseGroup new.
+	| v |
 	group addAll: (1 to: 5).
 	self assert: group size equals: 5.
 	v := group groupedBy: #odd.
@@ -396,8 +280,7 @@ MooseGroupTest >> testGroupedBy [
 
 { #category : #tests }
 MooseGroupTest >> testIndexOf [
-	| group el1 el2 el3 |
-	group := MooseGroup new.
+	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: el1.
 	group add: (el2 := MooseEntity new).
@@ -419,7 +302,6 @@ MooseGroupTest >> testInitialization [
 
 { #category : #tests }
 MooseGroupTest >> testIntersection [
-	| group |
 	group := #(1 2 3) asMooseGroup.
 	self assertCollection: (group intersection: #(2 3 4) asMooseGroup) hasSameElements: #(2 3).
 	self assertCollection: (#(2 3 4) asMooseGroup intersection: group) hasSameElements: #(2 3)
@@ -427,7 +309,6 @@ MooseGroupTest >> testIntersection [
 
 { #category : #tests }
 MooseGroupTest >> testIntersectionWithRealCollection [
-	| group |
 	group := #(1 2 3) asMooseGroup.
 	self assertCollection: (group intersection: #(2 3 4)) hasSameElements: #(2 3).
 	self assertCollection: (#(2 3 4) intersection: group) hasSameElements: #(2 3)
@@ -435,51 +316,36 @@ MooseGroupTest >> testIntersectionWithRealCollection [
 
 { #category : #tests }
 MooseGroupTest >> testIsCollection [
-	self assert: MooseGroup new isCollection
+	self assert: group isCollection
 ]
 
 { #category : #tests }
 MooseGroupTest >> testLast [
-	| group el1 el2 el3 |
-	group := MooseGroup new.
+	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: el1.
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
-	self assert: group last == el3.
-	self
-		assert: (group last: 2) asArray
-		equals:
-			{el2.
-			el3}.
-	self
-		assert: (group last: 4) asArray
-		equals:
-			{el1.
-			el1.
-			el2.
-			el3}.
+	self assert: group last identicalTo: el3.
+	self assert: (group last: 2) asArray equals: {el2 . el3}.
+	self assert: (group last: 4) asArray equals: {el1 . el1 . el2 . el3}.
 	self should: [ group last: 5 ] raise: Error
 ]
 
 { #category : #tests }
 MooseGroupTest >> testNumberOfPackages [
-	| model |
-	model := MooseModel new.
-	self assert: model numberOfPackages equals: 0.
-	model := MooseModel new.
-	model add: FAMIXPackage new.
-	model add: FAMIXPackage new.
-	self assert: model numberOfPackages equals: 2.
-	model := MooseModel new.
-	model add: FAMIXNamespace new.
-	model add: FAMIXNamespace new.
-	self assert: model numberOfPackages equals: 0
+	self assert: group numberOfPackages equals: 0.
+	group add: FAMIXPackage new.
+	group add: FAMIXPackage new.
+	self assert: group numberOfPackages equals: 2.
+	group := MooseModel new.
+	group add: FAMIXNamespace new.
+	group add: FAMIXNamespace new.
+	self assert: group numberOfPackages equals: 0
 ]
 
 { #category : #tests }
 MooseGroupTest >> testObjectAsMooseGroup [
-	| group |
 	group := 42 asMooseGroup.
 	self assert: (group isKindOf: MooseGroup).
 	self assert: group size equals: 1.
@@ -488,8 +354,7 @@ MooseGroupTest >> testObjectAsMooseGroup [
 
 { #category : #tests }
 MooseGroupTest >> testOccurenceOf [
-	| group el1 el2 |
-	group := MooseGroup new.
+	| el1 el2 |
 	group add: (el1 := MooseEntity new).
 	group add: el1.
 	group add: (el2 := MooseEntity new).
@@ -501,9 +366,7 @@ MooseGroupTest >> testOccurenceOf [
 
 { #category : #tests }
 MooseGroupTest >> testReadStream [
-
-	| group el1 el2 el3 stream |
-	group := MooseGroup new.
+	| el1 el2 el3 stream |
 	group add: (el1 := MooseEntity new).
 	group add: el1.
 	group add: (el2 := MooseEntity new).
@@ -511,48 +374,38 @@ MooseGroupTest >> testReadStream [
 
 	stream := group readStream.
 	self assert: stream isStream.
-	self assert: (stream next == el1).
-	self assert: (stream next == el1).
-	self assert: (stream next == el2).
-	self assert: (stream next == el3).
-
-
+	self assert: stream next identicalTo: el1.
+	self assert: stream next identicalTo: el1.
+	self assert: stream next identicalTo: el2.
+	self assert: stream next identicalTo: el3
 ]
 
 { #category : #tests }
 MooseGroupTest >> testReject [
-	| t group el1 el2 el3 v |
-	t := OrderedCollection new.
-	group := MooseGroup new.
+	| el1 el2 el3 v |
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
 	v := group reject: [ :el | el == el1 ].
 	self assert: v size equals: 2.
-	self
-		assert:
-			(v entities
-				includesAll:
-					{el2.
-					el3})
+	self assert: (v entities includesAll: {el2 . el3})
 ]
 
 { #category : #tests }
 MooseGroupTest >> testSelect [
-	| group el1 v |
-	group := MooseGroup new.
+	| el1 v |
 	group add: (el1 := MooseEntity new).
 	group add: MooseEntity new.
 	group add: MooseEntity new.
 	v := group select: [ :el | el == el1 ].
 	self assert: v size equals: 1.
-	self assert: v first == el1.
+	self assert: v first identicalTo: el1.
 	self assert: v entities equals: (group selectByExpression: [ :el | el == el1 ]) entities
 ]
 
 { #category : #tests }
 MooseGroupTest >> testSort [
-	| sorted group |
+	| sorted |
 	group := MooseGroup withAll: #(4 3 1 2).
 	sorted := group sorted: [ :a :b | a < b ].
 	self assert: sorted entities asArray equals: #(1 2 3 4)
@@ -560,23 +413,21 @@ MooseGroupTest >> testSort [
 
 { #category : #tests }
 MooseGroupTest >> testUnion [
-	| group1 group2 group3 el1 el2 el3 el4 |
-	group1 := MooseGroup new.
-	group1 add: (el1 := MooseEntity new).
-	group1 add: (el2 := MooseEntity new).
-	group1 add: (el3 := MooseEntity new).
+	| group2 group3 el1 el2 el3 el4 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
 	group2 := MooseGroup new.
 	group2 add: (el4 := MooseEntity new).
-	group3 := group1 union: group2.
+	group3 := group union: group2.
 	self assert: (group3 includesAll: {el1 . el2 . el3 . el4}).
 	self assert: group3 size equals: 4.
-	self assert: ((group2 union: group1) includesAll: {el1 . el2 . el3 . el4}).
-	self assert: (group2 union: group1) ~= (group1 union: group2)
+	self assert: ((group2 union: group) includesAll: {el1 . el2 . el3 . el4}).
+	self assert: (group2 union: group) ~= (group union: group2)
 ]
 
 { #category : #tests }
 MooseGroupTest >> testUnionWithRealCollection [
-	| group |
 	group := #(1 2 3) asMooseGroup.
 	self assertCollection: (group union: #(2 3 4)) hasSameElements: #(1 2 3 4).
 	self assertCollection: (#(2 3 4) union: group) hasSameElements: #(1 2 3 4)
@@ -584,37 +435,13 @@ MooseGroupTest >> testUnionWithRealCollection [
 
 { #category : #tests }
 MooseGroupTest >> testWithIndexDo [
-	| t group el1 el2 el3 |
+	| t el1 el2 el3 |
 	t := OrderedCollection new.
-	group := MooseGroup new.
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
-	group
-		withIndexDo: [ :x :i | 
-			t
-				add:
-					{x.
-					i} ].
-	self
-		assert: t asArray
-		equals:
-			{{el1.
-			1}.
-			{el2.
-			2}.
-			{el3.
-			3}}
-]
-
-{ #category : #tests }
-MooseGroupTest >> testallUsing [
-	| model |
-	model := FamixTest3MooseModel new.
-	model addAll: {FamixTest3Class new . FamixTest3Type new}.
-	self should: [ model allUsing: FamixTest3Type ] raise: MooseAllUsingOnClass.
-	self assert: (model allUsing: FamixTClass) size equals: 1.
-	self assert: (model allUsing: FamixTType) size equals: 2
+	group withIndexDo: [ :x :i | t add: {x . i} ].
+	self assert: t asArray equals: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
 ]
 
 { #category : #utility }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -1,25 +1,12 @@
 Class {
 	#name : #MooseGroupTest,
-	#superclass : #TestCase,
+	#superclass : #MooseAbstractGroupTest,
 	#category : #'Moose-Tests-Core'
 }
 
-{ #category : #tests }
-MooseGroupTest >> testAddLast [
-	| group entity class method |
-	group := MooseGroup new.
-	group addLast: (entity := FamixTest1Entity new).
-	self assert: group last identicalTo: entity.
-
-	group addLast: (class := FamixTest1Class new).
-	self assert: group last identicalTo: class.
-
-	group addLast: (method := FamixTest1Method new).
-	self assert: group last identicalTo: method.
-
-	self assert: (group at: 1) identicalTo: entity.
-	self assert: (group at: 2) identicalTo: class.
-	self assert: (group at: 3) identicalTo: method
+{ #category : #helpers }
+MooseGroupTest >> actualClass [
+	^ MooseGroup
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -19,16 +19,6 @@ MooseGroupTest >> testAllModelMethod [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testAnySatisfy [
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-
-	self assert: (group anySatisfy: [ :c | c class == MooseEntity ]).
-	self deny: (group anySatisfy: [ :c | c = 10 ])
-]
-
-{ #category : #tests }
 MooseGroupTest >> testAsMooseGroup [
 	group := #(1 2 3) asMooseGroup.
 	self assert: (group isKindOf: MooseGroup).
@@ -47,40 +37,6 @@ MooseGroupTest >> testAsMooseGroupWithClasses [
 	self shouldnt: [ group := {Object} asMooseGroup ] raise: Error.
 	self assert: group size equals: 1.
 	self assert: group anyOne equals: Object
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAtIfAbsentIfPresent [
-	| result |
-	group add: (FAMIXClass new name: 'A').
-	result := group entityNamed: 'X' ifAbsent: [ 42 ] ifPresent: [ :i |  ].
-	self assert: result equals: 42.
-	result := group entityNamed: 'A' ifAbsent: [ nil ] ifPresent: [ :cls | cls name ].
-	self assert: result equals: 'A'
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAtIfAbsentPut [
-	| classA |
-	classA := FAMIXClass new name: 'A'.
-	group entityNamed: 'X' ifAbsentPut: classA.
-	self assert: group size equals: 1.
-	self assert: group first identicalTo: classA
-]
-
-{ #category : #tests }
-MooseGroupTest >> testAverage [
-	| classes classA classB |
-	classA := FAMIXClass new.
-	classA addMethod: FAMIXMethod new.
-	classB := FAMIXClass new.
-	classB addMethod: FAMIXMethod new.
-	classB addMethod: FAMIXMethod new.
-	classes := FAMIXTypeGroup
-		withAll:
-			{classA.
-			classB}.
-	self assert: (classes average: #numberOfMethods) equals: 1.5
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -40,71 +40,8 @@ MooseGroupTest >> testAsMooseGroupWithClasses [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testCollect [
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	self assert: (group collect: #name) entities asArray equals: #(#noname #noname #noname)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testContains [
-	| el1 el2 |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: MooseEntity new.
-
-	self assert: (group anySatisfy: [ :el | el1 == el ]).
-	self assert: (group anySatisfy: [ :el | el2 == el ]).
-	self deny: (group anySatisfy: [ :el | 100 == el ])
-]
-
-{ #category : #tests }
-MooseGroupTest >> testCopy [
-	| copy |
-	group := MooseGroup with: 1.
-	copy := group copy.
-	self assert: copy ~~ group.
-	self assert: copy entities ~~ group entities.
-	self assert: copy entities equals: group entities.
-	self assert: copy entityStorage ~~ group entityStorage.
-	copy add: 2.
-	self assert: copy size equals: 2.
-	self assert: group size equals: 1
-]
-
-{ #category : #tests }
-MooseGroupTest >> testCount [
-	self assert: (self twoClasses count: [ :el | el class == FamixTest1Class ]) equals: 2
-]
-
-{ #category : #tests }
 MooseGroupTest >> testDefaultStorage [
-	self assert: (MooseGroup new entityStorage isKindOf: MooseGroupRuntimeStorage)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testDetect [
-	| el1 v |
-	group add: (el1 := MooseEntity new).
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-
-	v := group detect: [ :el | el == el1 ].
-	self assert: v == el1
-]
-
-{ #category : #tests }
-MooseGroupTest >> testDifference [
-	group := #(1 2 3) asMooseGroup.
-	self assertCollection: (group difference: #(2 4) asMooseGroup) hasSameElements: #(1 3).
-	self assertCollection: (#(2 4) asMooseGroup difference: group) hasSameElements: #(4)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testDifferenceWithRealCollection [
-	group := #(1 2 3) asMooseGroup.
-	self assertCollection: (group difference: #(2)) hasSameElements: #(1 3)
+	self assert: (group entityStorage isKindOf: MooseGroupRuntimeStorage)
 ]
 
 { #category : #tests }
@@ -398,15 +335,4 @@ MooseGroupTest >> testWithIndexDo [
 	group add: (el3 := MooseEntity new).
 	group withIndexDo: [ :x :i | t add: {x . i} ].
 	self assert: t asArray equals: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
-]
-
-{ #category : #utility }
-MooseGroupTest >> twoClasses [
-	| classA classB |
-	classA := FamixTest1Class new.
-	classA addMethod: FamixTest1Method new.
-	classB := FamixTest1Class new.
-	classB addMethod: FamixTest1Method new.
-	classB addMethod: FamixTest1Method new.
-	^ FAMIXClassGroup withAll: {classA . classB}
 ]

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -47,87 +47,35 @@ MooseGroupTest >> testDefaultStorage [
 { #category : #tests }
 MooseGroupTest >> testDistribution [
 	| referenceGroupOfGroups |
-	referenceGroupOfGroups := MooseGroup new.
-	referenceGroupOfGroups add: (MooseGroup withAll: #(1 2 3)).
-	referenceGroupOfGroups add: (MooseGroup withAll: #(4 5 6 7 8)).
+	referenceGroupOfGroups := self actualClass new.
+	referenceGroupOfGroups add: (self actualClass withAll: #(1 2 3)).
+	referenceGroupOfGroups add: (self actualClass withAll: #(4 5 6 7 8)).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 0.
-	group := MooseGroup withAll: #(1 2 3).
+	group := self actualClass withAll: #(1 2 3).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 1.
-	group := MooseGroup withAll: #(1 2).
+	group := self actualClass withAll: #(1 2).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 2 / 3.
-	group := MooseGroup withAll: #(1 2 4 5).
+	group := self actualClass withAll: #(1 2 4 5).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 2 / 3 + (2 / 5)
 ]
 
 { #category : #tests }
 MooseGroupTest >> testDistributionAndEncapsulation [
 	| referenceGroupOfGroups |
-	referenceGroupOfGroups := MooseGroup new.
-	referenceGroupOfGroups add: (MooseGroup withAll: #(1 2 3)).
-	referenceGroupOfGroups add: (MooseGroup withAll: #(4 5 6 7 8)).
+	referenceGroupOfGroups := self actualClass new.
+	referenceGroupOfGroups add: (self actualClass withAll: #(1 2 3)).
+	referenceGroupOfGroups add: (self actualClass withAll: #(4 5 6 7 8)).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 0.
 	self assert: (group encapsulationOfAGroupOfGroups: referenceGroupOfGroups) equals: 0.
-	group := MooseGroup withAll: #(1 2 3).
+	group := self actualClass withAll: #(1 2 3).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 1.
 	self assert: (group encapsulationOfAGroupOfGroups: referenceGroupOfGroups) equals: 1.
-	group := MooseGroup withAll: #(1 2).
+	group := self actualClass withAll: #(1 2).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 2 / 3.
 	self assert: (group encapsulationOfAGroupOfGroups: referenceGroupOfGroups) equals: 2 / 3.
-	group := MooseGroup withAll: #(1 2 4 5).
+	group := self actualClass withAll: #(1 2 4 5).
 	self assert: (group distributionOverAGroupOfGroups: referenceGroupOfGroups) equals: 2 / 3 + (2 / 5).
 	self assert: (group encapsulationOfAGroupOfGroups: referenceGroupOfGroups) equals: 4 / 12 + (4 / 20)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testDoWithIndex [
-	| t el1 el2 el3 |
-	t := OrderedCollection new.
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group doWithIndex: [ :x :i | t add: {x . i} ].
-	self assert: t asArray equals: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
-]
-
-{ #category : #tests }
-MooseGroupTest >> testDoWithIndexAndWithIndexDo [
-	"Isn't that odd? Legacy method?"
-
-	| t |
-	t := OrderedCollection new.
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	self
-		assert: (group doWithIndex: [ :x :i | t add: {x . i} ])
-		equals: (group withIndexDo: [ :x :i | t add: {x . i} ])
-]
-
-{ #category : #tests }
-MooseGroupTest >> testEntitiesDo [
-	| t el1 el2 el3 |
-	t := OrderedCollection new.
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group entitiesDo: [ :e | t add: e ].
-	self assert: t asArray equals: {el1 . el2 . el3}
-]
-
-{ #category : #tests }
-MooseGroupTest >> testEnumeration [
-	| el1 el2 el3 |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-
-	self assert: group first identicalTo: el1.
-	self assert: group second identicalTo: el2.
-	self assert: group third identicalTo: el3.
-
-	self assert: group first identicalTo: (group at: 1).
-	self assert: group second identicalTo: (group at: 2).
-	self assert: group third identicalTo: (group at: 3)
 ]
 
 { #category : #tests }
@@ -136,75 +84,13 @@ MooseGroupTest >> testExplicitEmptyCreation [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testFirst [
-	| el1 el2 el3 |
-	group add: (el1 := MooseEntity new).
-	group add: el1.
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	self assert: group first identicalTo: el1.
-	self assert: (group first: 2) asArray equals: {el1 . el1}.
-	self assert: (group first: 4) asArray equals: {el1 . el1 . el2 . el3}.
-	self should: [ group first: 5 ] raise: Error
-]
-
-{ #category : #tests }
-MooseGroupTest >> testGroupSize [
-	| classes |
-	classes := self twoClasses.
-	group addAll: classes.
-	self assert: group numberOfItems equals: classes size.
-	self assert: group size equals: 2
-]
-
-{ #category : #tests }
-MooseGroupTest >> testGroupedBy [
-	| v |
-	group addAll: (1 to: 5).
-	self assert: group size equals: 5.
-	v := group groupedBy: #odd.
-	self assert: v isDictionary.
-	self assert: v keys size equals: 2.
-	self assert: (v values first isKindOf: MooseGroup).
-	self assert: (v values second isKindOf: MooseGroup).
-	self assert: (v at: true) asArray equals: #(1 3 5).
-	self assert: (v at: false) asArray equals: #(2 4)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testIndexOf [
-	| el1 el2 el3 |
-	group add: (el1 := MooseEntity new).
-	group add: el1.
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	self assert: (group indexOf: el1) equals: 1.
-	self assert: (group indexOf: el2) equals: 3.
-	self assert: (group indexOf: el3) equals: 4
-]
-
-{ #category : #tests }
 MooseGroupTest >> testInitialization [
 	| group1 group2 |
-	group1 := MooseGroup with: 1.
-	group2 := MooseGroup with: 1 withDescription: 'Group number 2'.
+	group1 := self actualClass with: 1.
+	group2 := self actualClass with: 1 withDescription: 'Group number 2'.
 	self assert: group1 entities equals: group2 entities.
 	self assert: group2 description equals: 'Group number 2'.
 	self assert: group1 description equals: 'Group'
-]
-
-{ #category : #tests }
-MooseGroupTest >> testIntersection [
-	group := #(1 2 3) asMooseGroup.
-	self assertCollection: (group intersection: #(2 3 4) asMooseGroup) hasSameElements: #(2 3).
-	self assertCollection: (#(2 3 4) asMooseGroup intersection: group) hasSameElements: #(2 3)
-]
-
-{ #category : #tests }
-MooseGroupTest >> testIntersectionWithRealCollection [
-	group := #(1 2 3) asMooseGroup.
-	self assertCollection: (group intersection: #(2 3 4)) hasSameElements: #(2 3).
-	self assertCollection: (#(2 3 4) intersection: group) hasSameElements: #(2 3)
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -14,11 +14,8 @@ MooseModelTest >> actualClass [
 
 { #category : #tests }
 MooseModelTest >> testAdd [
-	| entity |
-	entity := MooseEntity new.
-	group add: entity.
-	self assert: group entities size equals: 1.
-	self assert: entity mooseModel identicalTo: group
+	super testAdd.
+	self assert: group first mooseModel identicalTo: group
 ]
 
 { #category : #tests }
@@ -72,15 +69,15 @@ MooseModelTest >> testBookmarkAsRaisesAnnouncement [
 { #category : #tests }
 MooseModelTest >> testCacheInvalidationAfterAdd [
 	self assertEmpty: group allClasses.
-	group add: FAMIXClass new.
+	group add: FamixTest3Class new.
 	self assert: group allClasses size equals: 1
 ]
 
 { #category : #tests }
 MooseModelTest >> testCacheInvalidationAfterMultipleAddRemove [
 	| classA classB |
-	classA := FAMIXClass new name: 'ClassA'.
-	classB := FAMIXClass new name: 'ClassB'.
+	classA := FamixTest3Class named: 'ClassA'.
+	classB := FamixTest3Class named: 'ClassB'.
 	group add: classA.
 	self assert: group allClasses size equals: 1.
 	group add: classB.
@@ -98,19 +95,11 @@ MooseModelTest >> testCacheInvalidationAfterMultipleAddRemove [
 { #category : #tests }
 MooseModelTest >> testCacheInvalidationAfterRemove [
 	| class |
-	class := FAMIXClass new name: 'AClass'.
+	class := FamixTest3Class named: 'AClass'.
 	group add: class.
 	self assert: group allClasses size equals: 1.
 	group remove: class.
 	self assertEmpty: group allClasses
-]
-
-{ #category : #tests }
-MooseModelTest >> testCollect [
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	self assert: (group collect: #name) asArray equals: #(#noname #noname #noname)
 ]
 
 { #category : #tests }
@@ -121,33 +110,6 @@ MooseModelTest >> testDifferenceWithRealCollection [
 		should: [ group addAll: #(1 2 3).
 			self assertCollection: (group difference: #(2)) hasSameElements: #(1 3) ]
 		raise: Error
-]
-
-{ #category : #tests }
-MooseModelTest >> testDoSeparatedBy [
-	| t el1 el2 el3 |
-	t := OrderedCollection new.
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group do: [ :x | t add: x ] separatedBy: [ t add: 10 ].
-	self assert: t asArray equals: {el1 . 10 . el2 . 10 . el3}
-]
-
-{ #category : #tests }
-MooseModelTest >> testEnsureClassesAndNamespaces [
-	| aMethod |
-	group add: (aMethod := FAMIXMethod new).
-	self assert: aMethod parentType isNil.
-	self should: [ aMethod parentScope isNil ] raise: Error.
-
-
-	group ensureClassesAndNamespaces.
-	self deny: aMethod parentType isNil.
-	self deny: aMethod parentScope isNil.
-
-	self assert: aMethod parentType == group unknownFAMIXClass.
-	self assert: aMethod parentScope == group unknownFAMIXNamespace
 ]
 
 { #category : #tests }
@@ -343,13 +305,6 @@ MooseModelTest >> testUnionWithRealCollection [
 		should: [ group addAll: #(1 2 3).
 			group union: #(2 3 4) ]
 		raise: Error
-]
-
-{ #category : #tests }
-MooseModelTest >> testUnknownFAMIXClass [
-	self assert: (group unknownFAMIXClass isKindOf: FAMIXClass).
-	self assert: group unknownFAMIXClass identicalTo: group unknownFAMIXClass.
-	self assert: group unknownFAMIXClass isStub
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -114,23 +114,13 @@ MooseModelTest >> testCollect [
 ]
 
 { #category : #tests }
-MooseModelTest >> testDifference [
-	| group2 el1 el2 el3 |
-	group := MooseModel new.
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group2 := MooseModel new.
-	group2 add: MooseEntity new.
-	self assert: (group difference: group2) entities asSet equals: group entities asSet.
-	self assert: (group difference: MooseModel new) entities asSet equals: group entities asSet.
-	self assert: (group difference: group) entities isEmpty.
-	group2 add: el1.
-	self assert: (group difference: group2) entities size equals: 2.
-	self assert: ((group difference: group2) entities includesAll: {el2 . el3}).
-	group add: el1.
-	self assert: (group difference: group2) entities size equals: 2.
-	self assert: ((group difference: group2) entities includesAll: {el2 . el3})
+MooseModelTest >> testDifferenceWithRealCollection [
+	"A MooseModel should only contains Moose entities."
+
+	self
+		should: [ group addAll: #(1 2 3).
+			self assertCollection: (group difference: #(2)) hasSameElements: #(1 3) ]
+		raise: Error
 ]
 
 { #category : #tests }
@@ -187,17 +177,13 @@ MooseModelTest >> testExportMetamodelTo [
 ]
 
 { #category : #tests }
-MooseModelTest >> testIntersect [
-	| group2 el1 |
-	group add: (el1 := MooseEntity new).
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	group2 := MooseModel new.
-	group2 add: MooseEntity new.
-	group2 add: el1.
-	self assert: (group intersection: MooseModel new) entities isEmpty.
-	self assert: (group intersection: group2) entities asArray equals: {el1}.
-	self assertEmpty: (MooseModel new intersection: MooseModel new) entities
+MooseModelTest >> testIntersectionWithRealCollection [
+	"A MooseModel should only contains Moose entities."
+
+	self
+		should: [ group addAll: #(1 2 3).
+			group intersection: #(2 3 4) ]
+		raise: Error
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -3,12 +3,17 @@ Just a test about mooseModel root and so on.
 "
 Class {
 	#name : #MooseModelTest,
-	#superclass : #TestCase,
+	#superclass : #MooseAbstractGroupTest,
 	#instVars : [
 		'model'
 	],
 	#category : #'Moose-Tests-Core'
 }
+
+{ #category : #helpers }
+MooseModelTest >> actualClass [
+	^ MooseModel
+]
 
 { #category : #running }
 MooseModelTest >> setUp [

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -4,9 +4,6 @@ Just a test about mooseModel root and so on.
 Class {
 	#name : #MooseModelTest,
 	#superclass : #MooseAbstractGroupTest,
-	#instVars : [
-		'model'
-	],
 	#category : #'Moose-Tests-Core'
 }
 
@@ -15,31 +12,23 @@ MooseModelTest >> actualClass [
 	^ MooseModel
 ]
 
-{ #category : #running }
-MooseModelTest >> setUp [
-	super setUp.
-	model := MooseModel new.
-]
-
 { #category : #tests }
 MooseModelTest >> testAdd [
 	| entity |
 	entity := MooseEntity new.
-	model add: entity.
-	self assert: model entities size equals: 1.
-	self assert: entity mooseModel == model
+	group add: entity.
+	self assert: group entities size equals: 1.
+	self assert: entity mooseModel identicalTo: group
 ]
 
 { #category : #tests }
 MooseModelTest >> testAddAnnouncement [
 	| entity announcedEntity |
 	entity := MooseEntity new.
-	announcedEntity := nil.
-	model announcer 
-		when: MooseEntityAdded do: [:a | announcedEntity := a entity ].
+	group announcer when: MooseEntityAdded do: [ :a | announcedEntity := a entity ].
 
-	model add: entity.
-	self assert: announcedEntity == entity.
+	group add: entity.
+	self assert: announcedEntity identicalTo: entity
 ]
 
 { #category : #tests }
@@ -48,12 +37,12 @@ MooseModelTest >> testAllBookmarks [
 	entity1 := MooseEntity new.
 	entity2 := MooseEntity new.
 	entity3 := MooseEntity new.
-	model add: entity1.
-	model add: entity2.
-	model add: entity3.
+	group add: entity1.
+	group add: entity2.
+	group add: entity3.
 	entity1 bookmarkAs: 'one'.
 	entity2 bookmarkAs: 'two'.
-	self assert: model allBookmarks size equals: 2
+	self assert: group allBookmarks size equals: 2
 ]
 
 { #category : #tests }
@@ -73,21 +62,18 @@ MooseModelTest >> testAsMSEString [
 MooseModelTest >> testBookmarkAsRaisesAnnouncement [
 	| entity1 announcedEntity |
 	entity1 := MooseEntity new.
-	model add: entity1.
-	announcedEntity := nil.
-	model announcer 
-		when: MooseEntityAdded do: [:a | announcedEntity := a entity ].
-	
+	group add: entity1.
+	group announcer when: MooseEntityAdded do: [ :a | announcedEntity := a entity ].
+
 	entity1 bookmarkAs: 'one'.
-	self assert: announcedEntity notNil.
+	self assert: announcedEntity isNotNil
 ]
 
 { #category : #tests }
 MooseModelTest >> testCacheInvalidationAfterAdd [
-
-	self assert: model allClasses isEmpty.
-	model add: FAMIXClass new.
-	self assert: model allClasses size equals: 1
+	self assertEmpty: group allClasses.
+	group add: FAMIXClass new.
+	self assert: group allClasses size equals: 1
 ]
 
 { #category : #tests }
@@ -95,118 +81,94 @@ MooseModelTest >> testCacheInvalidationAfterMultipleAddRemove [
 	| classA classB |
 	classA := FAMIXClass new name: 'ClassA'.
 	classB := FAMIXClass new name: 'ClassB'.
-	model add: classA.
-	self assert: model allClasses size equals: 1.
-	model add: classB.
-	self assert: model allClasses size equals: 2.
-	model remove: classA.
-	self assert: model allClasses size equals: 1.
-	model add: classA.
-	self assert: model allClasses size equals: 2.
-	model remove: classA.
-	self assert: model allClasses size equals: 1.
-	model remove: classB.
-	self assert: model allClasses isEmpty
+	group add: classA.
+	self assert: group allClasses size equals: 1.
+	group add: classB.
+	self assert: group allClasses size equals: 2.
+	group remove: classA.
+	self assert: group allClasses size equals: 1.
+	group add: classA.
+	self assert: group allClasses size equals: 2.
+	group remove: classA.
+	self assert: group allClasses size equals: 1.
+	group remove: classB.
+	self assertEmpty: group allClasses
 ]
 
 { #category : #tests }
 MooseModelTest >> testCacheInvalidationAfterRemove [
 	| class |
 	class := FAMIXClass new name: 'AClass'.
-	model add: class.
-	self assert: model allClasses size equals: 1.
-	model remove: class.
-	self assert: model allClasses isEmpty
+	group add: class.
+	self assert: group allClasses size equals: 1.
+	group remove: class.
+	self assertEmpty: group allClasses
 ]
 
 { #category : #tests }
 MooseModelTest >> testCollect [
-	| t group el1 el2 el3 |
-	t := OrderedCollection new.
-	group := MooseModel new.
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
+	group add: MooseEntity new.
+	group add: MooseEntity new.
+	group add: MooseEntity new.
 	self assert: (group collect: #name) asArray equals: #(#noname #noname #noname)
 ]
 
 { #category : #tests }
 MooseModelTest >> testDifference [
-	| t model1 model2 el1 el2 el3 el4 |
-	t := OrderedCollection new.
-	model1 := MooseModel new.
-	model1 add: (el1 := MooseEntity new).
-	model1 add: (el2 := MooseEntity new).
-	model1 add: (el3 := MooseEntity new).
-	model2 := MooseModel new.
-	model2 add: (el4 := MooseEntity new).
-	self assert: (model1 difference: model2) entities asSet equals: model1 entities asSet.
-	self assert: (model1 difference: MooseModel new) entities asSet equals: model1 entities asSet.
-	self assert: (model1 difference: model1) entities isEmpty.
-	model2 add: el1.
-	self assert: (model1 difference: model2) entities size equals: 2.
-	self
-		assert:
-			((model1 difference: model2) entities
-				includesAll:
-					{el2.
-					el3}).
-	model1 add: el1.
-	self assert: (model1 difference: model2) entities size equals: 2.
-	self
-		assert:
-			((model1 difference: model2) entities
-				includesAll:
-					{el2.
-					el3})
-]
-
-{ #category : #tests }
-MooseModelTest >> testDoSeparatedBy [
-	| t group el1 el2 el3 |
-	t := OrderedCollection new.
+	| group2 el1 el2 el3 |
 	group := MooseModel new.
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
+	group2 := MooseModel new.
+	group2 add: MooseEntity new.
+	self assert: (group difference: group2) entities asSet equals: group entities asSet.
+	self assert: (group difference: MooseModel new) entities asSet equals: group entities asSet.
+	self assert: (group difference: group) entities isEmpty.
+	group2 add: el1.
+	self assert: (group difference: group2) entities size equals: 2.
+	self assert: ((group difference: group2) entities includesAll: {el2 . el3}).
+	group add: el1.
+	self assert: (group difference: group2) entities size equals: 2.
+	self assert: ((group difference: group2) entities includesAll: {el2 . el3})
+]
+
+{ #category : #tests }
+MooseModelTest >> testDoSeparatedBy [
+	| t el1 el2 el3 |
+	t := OrderedCollection new.
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
 	group do: [ :x | t add: x ] separatedBy: [ t add: 10 ].
-	self
-		assert: t asArray
-		equals:
-			{el1.
-			10.
-			el2.
-			10.
-			el3}
+	self assert: t asArray equals: {el1 . 10 . el2 . 10 . el3}
 ]
 
 { #category : #tests }
 MooseModelTest >> testEnsureClassesAndNamespaces [
 	| aMethod |
+	group add: (aMethod := FAMIXMethod new).
+	self assert: aMethod parentType isNil.
+	self should: [ aMethod parentScope isNil ] raise: Error.
 
-	model add: (aMethod := FAMIXMethod new).
-	self assert: (aMethod parentType isNil).
-	self should: [(aMethod parentScope isNil)] raise: Error.
 
+	group ensureClassesAndNamespaces.
+	self deny: aMethod parentType isNil.
+	self deny: aMethod parentScope isNil.
 
-	model ensureClassesAndNamespaces.
-	self deny: (aMethod parentType isNil).
-	self deny: (aMethod parentScope isNil).
-
-	self assert: (aMethod parentType == model unknownFAMIXClass).
-	self assert: (aMethod parentScope == model unknownFAMIXNamespace).
-
+	self assert: aMethod parentType == group unknownFAMIXClass.
+	self assert: aMethod parentScope == group unknownFAMIXNamespace
 ]
 
 { #category : #tests }
 MooseModelTest >> testExport [
 	| stream |
 	stream := WriteStream on: String new.
-	model exportTo: stream.
+	group exportTo: stream.
 	self assert: stream contents equals: '()'.
-	model add: (FAMIXClass new name: 'Foo').
+	group add: (FAMIXClass new name: 'Foo').
 	stream := WriteStream on: String new.
-	model exportTo: stream.
+	group exportTo: stream.
 	self
 		assert: stream contents
 		equals:
@@ -220,97 +182,75 @@ MooseModelTest >> testExportMetamodelTo [
 
 	| stream |
 	stream := WriteStream on: String new.
-	self shouldnt: [model exportMetamodelTo: stream]  raise: Error.
+	self shouldnt: [group exportMetamodelTo: stream]  raise: Error.
 	self deny: stream isEmpty
 ]
 
 { #category : #tests }
 MooseModelTest >> testIntersect [
-	| model1 model2 el1 el2 el3 el4 |
-	model1 := MooseModel new.
-	model1 add: (el1 := MooseEntity new).
-	model1 add: (el2 := MooseEntity new).
-	model1 add: (el3 := MooseEntity new).
-	model2 := MooseModel new.
-	model2 add: (el4 := MooseEntity new).
-	model2 add: el1.
-	self assert: (model1 intersection: MooseModel new) entities isEmpty.
-	self assert: (model1 intersection: model2) entities asArray equals: {el1}.
-	self assert: (MooseModel new intersection: MooseModel new) entities isEmpty
+	| group2 el1 |
+	group add: (el1 := MooseEntity new).
+	group add: MooseEntity new.
+	group add: MooseEntity new.
+	group2 := MooseModel new.
+	group2 add: MooseEntity new.
+	group2 add: el1.
+	self assert: (group intersection: MooseModel new) entities isEmpty.
+	self assert: (group intersection: group2) entities asArray equals: {el1}.
+	self assertEmpty: (MooseModel new intersection: MooseModel new) entities
 ]
 
 { #category : #tests }
 MooseModelTest >> testPrintOn [
-	| model |
-	model := MooseModel new.
-	self assert: model printString equals: 'a MooseModel #noname(0)'.
-	model := MooseModel new.
-	model name: 'hello'.
-	self assert: model printString equals: 'a MooseModel #hello(0)'.
-	model := MooseModel new.
-	model name: 'hello2'.
-	model add: MooseEntity new.
-	self assert: model printString equals: 'a MooseModel #hello2(1)'.
+	self assert: group printString equals: 'a MooseModel #noname(0)'.
+	group name: 'hello'.
+	self assert: group printString equals: 'a MooseModel #hello(0)'.
+	group name: 'hello2'.
+	group add: MooseEntity new.
+	self assert: group printString equals: 'a MooseModel #hello2(1)'.
 	self assert: MooseModel meta printString equals: 'a FMMetaRepository'
 ]
 
 { #category : #tests }
 MooseModelTest >> testReferenceModel [
-	
-	| model parentModel |
-"	self assert: MooseModel root mooseModel isNil."
-	model := MooseModel new.
+	| parentModel |
 	parentModel := MooseModel new.
-	parentModel add: model.
-	self assert: model localMooseModel == model.
-	self assert: model mooseModel == parentModel
+	parentModel add: group.
+	self assert: group localMooseModel identicalTo: group.
+	self assert: group mooseModel identicalTo: parentModel
 ]
 
 { #category : #tests }
 MooseModelTest >> testReject [
-	| t group el1 el2 el3 v |
-	t := OrderedCollection new.
-	group := MooseModel new.
+	| el1 el2 el3 v |
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
 	v := group reject: [ :el | el == el1 ].
 	self assert: v size equals: 2.
-	self
-		assert:
-			(v
-				includesAll:
-					{el2.
-					el3})
+	self assert: (v includesAll: {el2 . el3})
 ]
 
 { #category : #tests }
 MooseModelTest >> testRemoveAll [
-
-	| group el1 el2 el3 |
-	group := MooseModel new.
+	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
 
 	group removeAll: {el1 . el2 . el3}.
-	self assert: group isEmpty
+	self assertEmpty: group
 ]
 
 { #category : #tests }
 MooseModelTest >> testRemoveAll2 [
-	| group el1 el2 el3 |
-	group := MooseModel new.
+	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: el1.
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
-	group
-		removeAll:
-			{el1.
-			el2.
-			el3}.
-	self deny: group isEmpty.
+	group removeAll: {el1 . el2 . el3}.
+	self denyEmpty: group.
 	self assert: group entities asArray equals: {el1}
 ]
 
@@ -318,42 +258,36 @@ MooseModelTest >> testRemoveAll2 [
 MooseModelTest >> testRemoveAnnouncement [
 	| entity announcedEntity |
 	entity := MooseEntity new.
-	announcedEntity := nil.
-	model announcer when: MooseEntityRemoved do: [:a | 
-		announcedEntity := a entity ].
-	model add: entity.
+	group announcer when: MooseEntityRemoved do: [ :a | announcedEntity := a entity ].
+	group add: entity.
 	self assert: announcedEntity isNil.
-	model remove: entity.
-	self assert: announcedEntity == entity.
+	group remove: entity.
+	self assert: announcedEntity identicalTo: entity
 ]
 
 { #category : #tests }
 MooseModelTest >> testRemoveFromModel [
-	
-	| model parentModel |
-	model := MooseModel new.
+	| parentModel |
 	parentModel := MooseModel new.
-	parentModel add: model.
-	self assert: model mooseModel == parentModel.
-	self assert: model removeFromModel == model.
-	self assert: parentModel entities isEmpty.
-
+	parentModel add: group.
+	self assert: group mooseModel identicalTo: parentModel.
+	self assert: group removeFromModel identicalTo: group.
+	self assertEmpty: parentModel entities
 ]
 
 { #category : #tests }
 MooseModelTest >> testRemoveModelNamedFromRoot [
 	"self debug: #testRemoveModelNamedFromRoot"
 
-	| model1 model2 parentModel res |
-	model1 := MooseModel new.
-	model1 name: 'zork'.
-	model2 := MooseModel new.
-	model2 name: 'baz'.
+	| group2 parentModel res |
+	group name: 'zork'.
+	group2 := MooseModel new.
+	group2 name: 'baz'.
 	parentModel := MooseModel new.
-	parentModel add: model1.
-	parentModel add: model2.
-	self assert: model1 mooseModel == parentModel.
-	self assert: model2 mooseModel == parentModel.
+	parentModel add: group.
+	parentModel add: group2.
+	self assert: group mooseModel identicalTo: parentModel.
+	self assert: group2 mooseModel identicalTo: parentModel.
 	self assert: parentModel size equals: 2.
 	res := parentModel removeModelNamed: 'zork'.
 	self assert: res name equals: #zork.
@@ -365,124 +299,86 @@ MooseModelTest >> testRemoveModelNamedFromRoot [
 { #category : #tests }
 MooseModelTest >> testRenamedAnnouncement [
 	| oldName |
-	model announcer when: MooseEntityRenamed do: [ :a | oldName := a oldName ].
-	model name: #somename.
+	group announcer when: MooseEntityRenamed do: [ :a | oldName := a oldName ].
+	group name: #somename.
 	self assert: oldName equals: #noname.
-	model name: #anothername.
+	group name: #anothername.
 	self assert: oldName equals: #somename
 ]
 
 { #category : #tests }
 MooseModelTest >> testRootFolder [
-
-	model := MooseModel new.
-	self assert: model rootFolder equals: (Smalltalk imageDirectory asFileReference / 'src' / (model name) ).
-	
+	self assert: group rootFolder equals: Smalltalk imageDirectory asFileReference / 'src' / group name
 ]
 
 { #category : #tests }
 MooseModelTest >> testRootModel [
-	
-	self assert: MooseModel new mooseID  > 0
+	self assert: MooseModel new mooseID > 0
 ]
 
 { #category : #tests }
 MooseModelTest >> testRootUniqueness [
-	self assert: MooseModel root == MooseModel root
+	self assert: MooseModel root identicalTo: MooseModel root
 ]
 
 { #category : #tests }
 MooseModelTest >> testSelect [
-	| t group el1 el2 el3 v |
-	t := OrderedCollection new.
-	group := MooseModel new.
+	| el1 v |
 	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
+	group add: MooseEntity new.
+	group add: MooseEntity new.
 	v := group select: [ :el | el == el1 ].
 	self assert: v size equals: 1.
-	self assert: v first == el1
+	self assert: v first identicalTo: el1
 ]
 
 { #category : #tests }
 MooseModelTest >> testUnion [
-	| model1 model2 model3 el1 el2 el3 el4 |
-	model1 := MooseModel new.
-	model1 add: (el1 := MooseEntity new).
-	model1 add: (el2 := MooseEntity new).
-	model1 add: (el3 := MooseEntity new).
-	model2 := MooseModel new.
-	model2 add: (el4 := MooseEntity new).
-	model3 := model1 union: model2.
-	self
-		assert:
-			(model3 entities
-				includesAll:
-					{el1.
-					el2.
-					el3.
-					el4}).
+	| group2 model3 el1 el2 el3 el4 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
+	group2 := MooseModel new.
+	group2 add: (el4 := MooseEntity new).
+	model3 := group union: group2.
+	self assert: (model3 entities includesAll: {el1 . el2 . el3 . el4}).
 	self assert: model3 entities size equals: 4.
-	self
-		assert:
-			((model2 union: model1) entities
-				includesAll:
-					{el1.
-					el2.
-					el3.
-					el4}).
-	self assert: (model2 union: model1) ~= (model1 union: model2)
+	self assert: ((group2 union: group) entities includesAll: {el1 . el2 . el3 . el4}).
+	self assert: (group2 union: group) ~= (group union: group2)
 ]
 
 { #category : #tests }
 MooseModelTest >> testUnion2 [
-	| model1 group2 group3 el1 el2 el3 el4 |
-	model1 := MooseModel new.
-	model1 add: (el1 := MooseEntity new).
-	model1 add: (el2 := MooseEntity new).
-	model1 add: (el3 := MooseEntity new).
+	| group2 group3 el1 el2 el3 el4 |
+	group add: (el1 := MooseEntity new).
+	group add: (el2 := MooseEntity new).
+	group add: (el3 := MooseEntity new).
 	group2 := MooseGroup new.
 	group2 add: (el4 := MooseEntity new).
-	group3 := model1 union: group2.
-	self
-		assert:
-			(group3 entities
-				includesAll:
-					{el1.
-					el2.
-					el3.
-					el4}).
+	group3 := group union: group2.
+	self assert: (group3 entities includesAll: {el1 . el2 . el3 . el4}).
 	self assert: group3 entities size equals: 4.
-	self
-		assert:
-			((group2 union: model1) entities
-				includesAll:
-					{el1.
-					el2.
-					el3.
-					el4}).
-	self assert: (group2 union: model1) ~= (model1 union: group2)
+	self assert: ((group2 union: group) entities includesAll: {el1 . el2 . el3 . el4}).
+	self assert: (group2 union: group) ~= (group union: group2)
 ]
 
 { #category : #tests }
 MooseModelTest >> testUnknownFAMIXClass [
-	self assert: (model unknownFAMIXClass isKindOf: FAMIXClass).
-	self assert: (model unknownFAMIXClass == model unknownFAMIXClass).
-	self assert: (model unknownFAMIXClass isStub)
+	self assert: (group unknownFAMIXClass isKindOf: FAMIXClass).
+	self assert: group unknownFAMIXClass identicalTo: group unknownFAMIXClass.
+	self assert: group unknownFAMIXClass isStub
 ]
 
 { #category : #tests }
 MooseModelTest >> testUnknownFAMIXNamespace [
-	self assert: (model unknownFAMIXNamespace isKindOf: FAMIXNamespace).
-	self assert: (model unknownFAMIXNamespace == model unknownFAMIXNamespace).
-	self assert: (model unknownFAMIXNamespace isStub)
+	self assert: (group unknownFAMIXNamespace isKindOf: FAMIXNamespace).
+	self assert: group unknownFAMIXNamespace identicalTo: group unknownFAMIXNamespace.
+	self assert: group unknownFAMIXNamespace isStub
 ]
 
 { #category : #tests }
 MooseModelTest >> testUnknownProperty [
-	| model |
-	model := MooseModel new.
-	self assert: (model propertyNamed: #UNKNOWN) isNil.
-	model propertyNamed: 'UNKNOWN' put: 10.
-	self assert: (model propertyNamed: #UNKNOWN) equals: 10
+	self assert: (group propertyNamed: #UNKNOWN) isNil.
+	group propertyNamed: 'UNKNOWN' put: 10.
+	self assert: (group propertyNamed: #UNKNOWN) equals: 10
 ]

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -308,17 +308,6 @@ MooseModelTest >> testRootUniqueness [
 ]
 
 { #category : #tests }
-MooseModelTest >> testSelect [
-	| el1 v |
-	group add: (el1 := MooseEntity new).
-	group add: MooseEntity new.
-	group add: MooseEntity new.
-	v := group select: [ :el | el == el1 ].
-	self assert: v size equals: 1.
-	self assert: v first identicalTo: el1
-]
-
-{ #category : #tests }
 MooseModelTest >> testUnion [
 	| group2 model3 el1 el2 el3 el4 |
 	group add: (el1 := MooseEntity new).

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -338,6 +338,14 @@ MooseModelTest >> testUnion2 [
 ]
 
 { #category : #tests }
+MooseModelTest >> testUnionWithRealCollection [
+	self
+		should: [ group addAll: #(1 2 3).
+			group union: #(2 3 4) ]
+		raise: Error
+]
+
+{ #category : #tests }
 MooseModelTest >> testUnknownFAMIXClass [
 	self assert: (group unknownFAMIXClass isKindOf: FAMIXClass).
 	self assert: group unknownFAMIXClass identicalTo: group unknownFAMIXClass.

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -113,29 +113,8 @@ MooseModelTest >> testDifferenceWithRealCollection [
 ]
 
 { #category : #tests }
-MooseModelTest >> testExport [
-	| stream |
-	stream := WriteStream on: String new.
-	group exportTo: stream.
-	self assert: stream contents equals: '()'.
-	group add: (FAMIXClass new name: 'Foo').
-	stream := WriteStream on: String new.
-	group exportTo: stream.
-	self
-		assert: stream contents
-		equals:
-			'(
-	(FAMIX.Class (id: 1)
-		(name ''Foo'')))'
-]
-
-{ #category : #tests }
 MooseModelTest >> testExportMetamodelTo [
-
-	| stream |
-	stream := WriteStream on: String new.
-	self shouldnt: [group exportMetamodelTo: stream]  raise: Error.
-	self deny: stream isEmpty
+	self denyEmpty: (String streamContents: [ :s | group exportMetamodelTo: s ])
 ]
 
 { #category : #tests }
@@ -156,50 +135,15 @@ MooseModelTest >> testPrintOn [
 	group name: 'hello2'.
 	group add: MooseEntity new.
 	self assert: group printString equals: 'a MooseModel #hello2(1)'.
-	self assert: MooseModel meta printString equals: 'a FMMetaRepository'
+	self assert: self actualClass meta printString equals: 'a FMMetaRepository'
 ]
 
 { #category : #tests }
 MooseModelTest >> testReferenceModel [
 	| parentModel |
-	parentModel := MooseModel new.
-	parentModel add: group.
+	parentModel := self actualClass with: group.
 	self assert: group localMooseModel identicalTo: group.
 	self assert: group mooseModel identicalTo: parentModel
-]
-
-{ #category : #tests }
-MooseModelTest >> testReject [
-	| el1 el2 el3 v |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	v := group reject: [ :el | el == el1 ].
-	self assert: v size equals: 2.
-	self assert: (v includesAll: {el2 . el3})
-]
-
-{ #category : #tests }
-MooseModelTest >> testRemoveAll [
-	| el1 el2 el3 |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-
-	group removeAll: {el1 . el2 . el3}.
-	self assertEmpty: group
-]
-
-{ #category : #tests }
-MooseModelTest >> testRemoveAll2 [
-	| el1 el2 el3 |
-	group add: (el1 := MooseEntity new).
-	group add: el1.
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group removeAll: {el1 . el2 . el3}.
-	self denyEmpty: group.
-	self assert: group entities asArray equals: {el1}
 ]
 
 { #category : #tests }
@@ -216,11 +160,10 @@ MooseModelTest >> testRemoveAnnouncement [
 { #category : #tests }
 MooseModelTest >> testRemoveFromModel [
 	| parentModel |
-	parentModel := MooseModel new.
-	parentModel add: group.
+	parentModel := self actualClass with: group.
 	self assert: group mooseModel identicalTo: parentModel.
 	self assert: group removeFromModel identicalTo: group.
-	self assertEmpty: parentModel entities
+	self assertEmpty: parentModel
 ]
 
 { #category : #tests }
@@ -229,11 +172,9 @@ MooseModelTest >> testRemoveModelNamedFromRoot [
 
 	| group2 parentModel res |
 	group name: 'zork'.
-	group2 := MooseModel new.
+	group2 := self actualClass new.
 	group2 name: 'baz'.
-	parentModel := MooseModel new.
-	parentModel add: group.
-	parentModel add: group2.
+	parentModel := self actualClass withAll: {group . group2}.
 	self assert: group mooseModel identicalTo: parentModel.
 	self assert: group2 mooseModel identicalTo: parentModel.
 	self assert: parentModel size equals: 2.
@@ -261,42 +202,12 @@ MooseModelTest >> testRootFolder [
 
 { #category : #tests }
 MooseModelTest >> testRootModel [
-	self assert: MooseModel new mooseID > 0
+	self assert: self actualClass new mooseID > 0
 ]
 
 { #category : #tests }
 MooseModelTest >> testRootUniqueness [
-	self assert: MooseModel root identicalTo: MooseModel root
-]
-
-{ #category : #tests }
-MooseModelTest >> testUnion [
-	| group2 model3 el1 el2 el3 el4 |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group2 := MooseModel new.
-	group2 add: (el4 := MooseEntity new).
-	model3 := group union: group2.
-	self assert: (model3 entities includesAll: {el1 . el2 . el3 . el4}).
-	self assert: model3 entities size equals: 4.
-	self assert: ((group2 union: group) entities includesAll: {el1 . el2 . el3 . el4}).
-	self assert: (group2 union: group) ~= (group union: group2)
-]
-
-{ #category : #tests }
-MooseModelTest >> testUnion2 [
-	| group2 group3 el1 el2 el3 el4 |
-	group add: (el1 := MooseEntity new).
-	group add: (el2 := MooseEntity new).
-	group add: (el3 := MooseEntity new).
-	group2 := MooseGroup new.
-	group2 add: (el4 := MooseEntity new).
-	group3 := group union: group2.
-	self assert: (group3 entities includesAll: {el1 . el2 . el3 . el4}).
-	self assert: group3 entities size equals: 4.
-	self assert: ((group2 union: group) entities includesAll: {el1 . el2 . el3 . el4}).
-	self assert: (group2 union: group) ~= (group union: group2)
+	self assert: self actualClass root identicalTo: MooseModel root
 ]
 
 { #category : #tests }
@@ -305,18 +216,4 @@ MooseModelTest >> testUnionWithRealCollection [
 		should: [ group addAll: #(1 2 3).
 			group union: #(2 3 4) ]
 		raise: Error
-]
-
-{ #category : #tests }
-MooseModelTest >> testUnknownFAMIXNamespace [
-	self assert: (group unknownFAMIXNamespace isKindOf: FAMIXNamespace).
-	self assert: group unknownFAMIXNamespace identicalTo: group unknownFAMIXNamespace.
-	self assert: group unknownFAMIXNamespace isStub
-]
-
-{ #category : #tests }
-MooseModelTest >> testUnknownProperty [
-	self assert: (group propertyNamed: #UNKNOWN) isNil.
-	group propertyNamed: 'UNKNOWN' put: 10.
-	self assert: (group propertyNamed: #UNKNOWN) equals: 10
 ]


### PR DESCRIPTION
Introduce hierarchy for test of MooseAbstractGroup, MooseGroup and MooseModel