### PR TITLE
1818-Importing-a-MSE-takes-wrong-metamodel-as-reference

### DIFF
--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -410,7 +410,7 @@ MooseModel >> importFromMSEStream: aStream [
 	"
 
 	| repository |
-	repository := self class importFrom: aStream.
+	repository := self class importFrom: aStream withMetamodel: self metamodel.
 	self silentlyAddAll: repository elements.
 	self entityStorage forRuntime.
 	self name: (aStream localName removeSuffix: '.mse').


### PR DESCRIPTION
Make #importFromMSE: use metamodel

Fixes #1818