### PR TITLE
1828-Generator-bug-when-the-definition-string-changed-but-not-its-name

### DIFF
--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -250,7 +250,7 @@ FMPragmaProcessor >> processCompiledMethod: aMethod [
 	typeDict at: prop put: (pragma argumentAt: 2).
 	mmClassDict at: prop put: method methodClass.
 	prop setImplementingSelector: method selector.
-	pragma keyword = #MSEProperty:type:opposite: ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
+	pragma selector = #MSEProperty:type:opposite: ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
 	(Pragma inMethod: method named: #container) ifNotNil: [ prop isContainer: true ].
 	(Pragma inMethod: method named: #derived) ifNotNil: [ prop isDerived: true ].
 	(Pragma inMethod: method named: #source) ifNotNil: [ prop isSource: true ].
@@ -258,7 +258,8 @@ FMPragmaProcessor >> processCompiledMethod: aMethod [
 	(Pragma inMethod: method named: #multivalued)
 		ifNotNil: [ self
 				assert: prop isContainer not
-				description: 'It is not possible to have <multivalue> and <container> on the same method. container represents a aggregation UML link that is incompatible with the multivalue kind of the link'.
+				description:
+					'It is not possible to have <multivalue> and <container> on the same method. container represents a aggregation UML link that is incompatible with the multivalue kind of the link'.
 			prop isMultivalued: true ].
 	(Pragma inMethod: method named: #key:) ifNotNil: [ :p | prop key: (p argumentAt: 1) ].
 	elements add: prop

--- a/src/Fame-SmalltalkBinding/Pragma.extension.st
+++ b/src/Fame-SmalltalkBinding/Pragma.extension.st
@@ -2,14 +2,11 @@ Extension { #name : #Pragma }
 
 { #category : #'*Fame-SmalltalkBinding' }
 Pragma class >> inMethod: compiledMethod named: keyword [
-
 	| all keywords selection |
 	all := compiledMethod pragmas.
-	keyword isArray
-		ifTrue:[ keywords := keyword ]
-		ifFalse: [ keywords := Array with: keyword ].
-	selection := all select: [ :each | keywords includes: each keyword ].
+	keyword isArray ifTrue: [ keywords := keyword ] ifFalse: [ keywords := Array with: keyword ].
+	selection := all select: [ :each | keywords includes: each selector ].
 	selection size > 1 ifTrue: [ Error signal ].
-	selection size = 0 ifTrue: [ ^nil ].
-	^selection first
+	selection size = 0 ifTrue: [ ^ nil ].
+	^ selection first
 ]

--- a/src/Famix-MetamodelBuilder-Core/Class.extension.st
+++ b/src/Famix-MetamodelBuilder-Core/Class.extension.st
@@ -31,11 +31,13 @@ Class >> needToAdaptTo: aRGClass [
 	generatedTraitNames := self generatedTraitNames.
 
 	"We need to manage the cases where it will be things like `FamixJavaTStructuralEntity - {#mooseNameOn:}`"
-	generatedTraitDefinitions := self traitComposition rootMembers select: [ :member | generatedTraitNames includes: member name ] thenCollect: #traitCompositionExpression.
+	generatedTraitDefinitions := self traitComposition rootMembers
+		select: [ :member | generatedTraitNames includes: member name ]
+		thenCollect: #traitCompositionExpression.
 
 	(generatedTraitDefinitions equalsTo: aRGClass traitsDefinitions) ifFalse: [ ^ true ].
 
-	(self generatedSlotNames equalsTo: (aRGClass slots collect: #name)) ifFalse: [ ^ true ].
+	((self generatedSlots collect: #definitionString) equalsTo: (aRGClass slots collect: #definitionString)) ifFalse: [ ^ true ].
 
 	^ (self superclass ifNil: [ Trait ]) name ~= aRGClass superclass name
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelCleaningStrategiesTestGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelCleaningStrategiesTestGenerator.class.st
@@ -51,7 +51,8 @@ FamixMetamodelCleaningStrategiesTestGenerator >> defineProperties [
 { #category : #definition }
 FamixMetamodelCleaningStrategiesTestGenerator >> defineRelations [
 	super defineRelations.
-	fmx <>- fmx
+	fmx <>- fmx.
+	(fmx2 property: #furry) *- (fmx property: #fursonas) 
 ]
 
 { #category : #definition }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -41,7 +41,8 @@ FmxMBGeneratorCleaningStrategyTest >> generateClasses [
 			class addToComposition: FamixTestExternalTraits.
 			class addInstVarNamed: 'bananaTree'.
 			class addClassVarNamed: 'Fuhrmanator'.
-			class class addInstVarNamed: 'grandFrais' ]
+			class class addInstVarNamed: 'grandFrais'.
+			(class slotNamed: #fursonas) inClass: #FmxTestCleaningStrategyFmxTestEntity	"Here we change the type of the slot to ensure it is regenerated correctly" ]
 		ifAbsent: [ self fail ].
 	Object
 		subclass: #FmxCleanerTestAddedClass
@@ -64,12 +65,13 @@ FmxMBGeneratorCleaningStrategyTest >> generateClasses [
 	<package: #'',  self packageName , ''>
 	<generated>
 	^self'.
-	
+
 	"We add a Trait with Famix pragma to ensure it is deleted after the generation."
-	generatedTraitToRemove := Trait named: #FmxCleanerTestTAddedClassFromFamix
-	 uses: { }
-	 slots: {  }
-	 package:  self packageName.
+	generatedTraitToRemove := Trait
+		named: #FmxCleanerTestTAddedClassFromFamix
+		uses: {}
+		slots: {}
+		package: self packageName.
 	generatedTraitToRemove class
 		compile:
 			'annotation
@@ -78,7 +80,7 @@ FmxMBGeneratorCleaningStrategyTest >> generateClasses [
 	<package: #'',  self packageName , ''>
 	<generated>
 	^self'.
-	
+
 	"We change the superclass of this class to ensure regeneration will update it. Check non regression for: https://github.com/moosetechnology/Moose/issues/1668"
 	self class environment
 		at: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass
@@ -124,7 +126,9 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningCleaning [
 			self assert: (class traitComposition allTraits anySatisfy: [ :trait | trait name = #FamixTestExternalTraits ]).
 			self assert: (class hasInstVarNamed: #bananaTree).
 			self assert: (class hasClassVarNamed: #Fuhrmanator).
-			self assert: (class class hasInstVarNamed: #grandFrais) ]
+			self assert: (class class hasInstVarNamed: #grandFrais).
+			self assert: (class hasInstVarNamed: #fursonas).
+			self assert: (class slotNamed: #fursonas) definitionString equals: '#fursonas => FMMany type: #FmxTestCleaningStrategyFmxTestEntity opposite: #furry' ]
 		ifAbsent: [ self fail ].
 
 	"Before the generation, the superclass should not be updated."
@@ -158,7 +162,9 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningGeneration [
 			self assert: (class traitComposition allTraits anySatisfy: [ :trait | trait name = #FamixTestExternalTraits ]).
 			self assert: (class hasInstVarNamed: #bananaTree).
 			self assert: (class hasClassVarNamed: #Fuhrmanator).
-			self assert: (class class hasInstVarNamed: #grandFrais) ]
+			self assert: (class class hasInstVarNamed: #grandFrais).
+			self assert: (class hasInstVarNamed: #fursonas).
+			self assert: (class slotNamed: #fursonas) definitionString equals: '#fursonas => FMMany type: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass opposite: #furry' ]
 		ifAbsent: [ self fail ].
 
 	"After the generation, the superclass should be updated to be the one described in the generator."
@@ -203,7 +209,9 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningGeneration [
 			self deny: (class localMethods anySatisfy: [ :method | method selector = #generatedBanana ]).
 			self deny: (class hasInstVarNamed: #bananaTree).
 			self deny: (class hasClassVarNamed: #Fuhrmanator).
-			self deny: (class class hasInstVarNamed: #grandFrais) ]
+			self deny: (class class hasInstVarNamed: #grandFrais).
+			self assert: (class hasInstVarNamed: #fursonas).
+			self assert: (class slotNamed: #fursonas) definitionString equals: '#fursonas => FMMany type: #FmxTestCleaningStrategyFmxTestEntityWithDifferentSuperclass opposite: #furry' ]
 		ifAbsent: [ self fail ].
 
 	"After the generation, the superclass should be updated."


### PR DESCRIPTION
When the definition string of a slot change but not the name, the generator bugged. 

This is now fixed with a test. 

Fixes #1828