### PR TITLE
1831-Reintroduce-MooseAbstractGroupentityNamedwithType

### DIFF
--- a/src/Famix-Deprecated/MooseAbstractGroup.extension.st
+++ b/src/Famix-Deprecated/MooseAbstractGroup.extension.st
@@ -7,3 +7,23 @@ MooseAbstractGroup >> entityNamed: aMooseName ifAbsentPut: aValue [
 			'This method has a bad behavior because it will not add the entity under the name passed as parameter. This methods will be removed in the next version of Moose. If you want to keep the behavior, please inline the content.'.
 	^ self entityNamed: aMooseName ifAbsent: [ self add: aValue ]
 ]
+
+{ #category : #'*Famix-Deprecated' }
+MooseAbstractGroup >> entityNamed: aSymbol withType: aFamixType [
+	self
+		deprecated: 'Use #allWithType: association to #entityNamed: instead.'
+		transformWith: '`@receiver entityNamed: `@statements1 withType: `@statements2' -> '(`@receiver allWithType: `@statements2) entityNamed: `@statements1'.
+
+	^ (self allWithType: aFamixType) entityNamed: aSymbol
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseAbstractGroup >> entityNamed: aSymbol withType: aFamixType ifAbsent: aBlock [
+	self
+		deprecated: 'Use #allWithType: association to #entityNamed:ifAbsent: instead.'
+		transformWith:
+			'`@receiver entityNamed: `@statements1 withType: `@statements2 ifAbsent: `@statements3'
+				-> '(`@receiver allWithType: `@statements2) entityNamed: `@statements1 ifAbsent: `@statements3'.
+
+	^ (self allWithType: aFamixType) entityNamed: aSymbol ifAbsent: aBlock
+]

--- a/src/Moose-Finder/MooseEntity.extension.st
+++ b/src/Moose-Finder/MooseEntity.extension.st
@@ -23,19 +23,11 @@ MooseEntity >> bookmarkEntity [
 MooseEntity >> complexPropertyPragmas [
 	| navProps definedProps |
 	self mooseDescription
-		ifNil: [ NotInitializedMooseDescriptionError
-				signal:
-					'Moose description are not initialized. Have you refreshed the meta-model? (e.g., MooseModel resetMeta)' ].
-	navProps := (Pragma
-		allNamed: #navigation:
-		from: self class
-		to: MooseEntity)
-		sorted: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ].
-	definedProps := (self mooseDescription allAttributes
-		reject: [ :a | a type isPrimitive ])
-		flatCollect: [ :prop | 
-			(prop mmClass implementingClass >> prop implementingSelector) pragmas
-				select: [ :each | each keyword beginsWith: 'MSEProperty:' ] ].
+		ifNil:
+			[ NotInitializedMooseDescriptionError signal: 'Moose description are not initialized. Have you refreshed the meta-model? (e.g., MooseModel resetMeta)' ].
+	navProps := (Pragma allNamed: #navigation: from: self class to: MooseEntity) sorted: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ].
+	definedProps := (self mooseDescription allAttributes reject: [ :a | a type isPrimitive ])
+		flatCollect: [ :prop | (prop mmClass implementingClass >> prop implementingSelector) pragmas select: [ :each | each selector beginsWith: 'MSEProperty:' ] ].
 	^ (OrderedCollection withAll: definedProps)
 		addAll: navProps;
 		yourself

--- a/src/Moose-Finder/MooseModel.extension.st
+++ b/src/Moose-Finder/MooseModel.extension.st
@@ -29,13 +29,13 @@ MooseModel >> browseCodeWithPackages [
 ]
 
 { #category : #'*Moose-Finder' }
-MooseModel >> browseMeta [
-	^ MooseMetaBrowser new openOn: self metamodel
+MooseModel class >> browseMeta [
+	^ MooseMetaBrowser new openOn: MooseModel meta
 ]
 
 { #category : #'*Moose-Finder' }
-MooseModel class >> browseMeta [
-	^ MooseMetaBrowser new openOn: MooseModel meta
+MooseModel >> browseMeta [
+	^ MooseMetaBrowser new openOn: self metamodel
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-MenuBar/MooseAbstractToolEntry.class.st
+++ b/src/Moose-MenuBar/MooseAbstractToolEntry.class.st
@@ -11,7 +11,9 @@ MooseAbstractToolEntry class >> allToolClasses [
 
 { #category : #'world menu' }
 MooseAbstractToolEntry class >> allToolPragma [
-	^ (PragmaCollector filter: [:prg | prg keyword = 'mooseTool:']) reset; collected
+	^ (PragmaCollector filter: [ :prg | prg selector = 'mooseTool:' ])
+		reset;
+		collected
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Add once again MooseAbstractGroup>>#entityNamed:withType: with a deprecation warning and rewrite rule.

Fixes #1831