### PR TITLE
1837-Associations-are-wrongly-exported-to-MSE

### DIFF
--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -198,7 +198,6 @@ FMRelationSlot >> moosePropertyFor: anOwningClassName multivalued: aBoolean [
 		mooseProperty setImplementingSelector: self name. "should be a link to slot"
 
 		mooseProperty isMultivalued: aBoolean.
-		mooseProperty isDerived: true.
 		
 		mooseProperty privOpposite: self inverseSlot mooseProperty ].
 	

--- a/src/Fame-Core/Object.extension.st
+++ b/src/Fame-Core/Object.extension.st
@@ -16,14 +16,14 @@ Object >> isFM3Property [
 ]
 
 { #category : #'*Fame-Core' }
-Object >> metamodel [
-
-	^ self class metamodel
+Object class >> metamodel [ 
+	^ nil
 ]
 
 { #category : #'*Fame-Core' }
-Object class >> metamodel [ 
-	^ nil
+Object >> metamodel [
+
+	^ self class metamodel
 ]
 
 { #category : #'*Fame-Core' }

--- a/src/Fame-ImportExport/FMRepositoryVisitor.class.st
+++ b/src/Fame-ImportExport/FMRepositoryVisitor.class.st
@@ -154,11 +154,9 @@ FMRepositoryVisitor >> run [
 
 { #category : #exporting }
 FMRepositoryVisitor >> shouldIgnoreProperty: property [
+	(repository metamodel includes: property) ifFalse: [ ^ true ].
 
-	(((repository metamodel includes: property) and: [property isContainer]))
-		ifTrue: [ ^ false ].
-		
-	^ (repository metamodel includes: property) not or: [ property isDerived ]
+	^ property isDerived
 ]
 
 { #category : #exporting }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideTrait.trait.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideTrait.trait.st
@@ -156,6 +156,7 @@ FmxMBRelationSideTrait >> manyToMany: aRelationSide [
 	ownSide := self asRelationSideNamed: aRelationSide pluralPropertyName.
 	oppositeSide := aRelationSide asRelationSideNamed: self pluralPropertyName.
 	ownSide many.
+	ownSide derived.
 	oppositeSide many.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
 	self builder configuration navigationForNonContainers
@@ -179,6 +180,7 @@ FmxMBRelationSideTrait >> manyToOne: aRelationSide [
 	ownSide := self asRelationSideNamed: aRelationSide singularPropertyName.
 	oppositeSide := aRelationSide asRelationSideNamed: self pluralPropertyName.
 	oppositeSide many.
+	oppositeSide derived.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
 	self builder configuration navigationForNonContainers
 		ifTrue: [ aRelation withNavigation ].
@@ -214,6 +216,7 @@ FmxMBRelationSideTrait >> oneToMany: aRelationSide [
 	ownSide := self asRelationSideNamed: aRelationSide pluralPropertyName.
 	oppositeSide := aRelationSide asRelationSideNamed: self singularPropertyName.
 	ownSide many.
+	ownSide derived.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
 	self builder configuration navigationForNonContainers
 		ifTrue: [ aRelation withNavigation ].
@@ -235,7 +238,7 @@ FmxMBRelationSideTrait >> oneToOne: aRelationSide [
 	
 	ownSide := self asRelationSideNamed: aRelationSide propertyName.
 	oppositeSide := aRelationSide asRelationSideNamed: self propertyName.
-	 	
+	oppositeSide derived.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
 	self builder configuration navigationForNonContainers
 		ifTrue: [ aRelation withNavigation ].

--- a/src/Famix-Test3-Tests/FamixTest3Test.class.st
+++ b/src/Famix-Test3-Tests/FamixTest3Test.class.st
@@ -1,108 +1,138 @@
 Class {
 	#name : #FamixTest3Test,
 	#superclass : #TestCase,
-	#instVars : [
-		'model',
-		'c1',
-		'c2',
-		'm1',
-		'm2',
-		'pt1',
-		'pt2',
-		'ref1',
-		'ref2',
-		'inv1'
-	],
+	#traits : 'FamixTWithMSEExportTestCase',
+	#classTraits : 'FamixTWithMSEExportTestCase classTrait',
 	#category : #'Famix-Test3-Tests'
 }
+
+{ #category : #accessing }
+FamixTest3Test >> c1 [
+	^ model entityNamed: #Class1
+]
+
+{ #category : #accessing }
+FamixTest3Test >> c2 [
+	^ model entityNamed: #Class2
+]
 
 { #category : #running }
 FamixTest3Test >> checkAtScopeWithNonMatchingEntitiesDoWith: aBehavior [
 
 	| mooseQueryResult nonMatching |
-	mooseQueryResult := MooseOutgoingQueryResult on: c1 withAll: { ref1. inv1 }.
+	mooseQueryResult := MooseOutgoingQueryResult on: self c1 withAll: { self ref1. self inv1 }.
 
 	nonMatching := Set new.
 	self assertCollection: (
 		mooseQueryResult 
 			atScope: aBehavior 
 			withNonMatchingEntitiesDo: [ :entities :matchingAtTheScope | 
-				nonMatching addAll: entities asCollection ]) hasSameElements: { c1. }.
-	self assertCollection: nonMatching hasSameElements: { pt1 }.
+				nonMatching addAll: entities asCollection ]) hasSameElements: { self c1. }.
+	self assertCollection: nonMatching hasSameElements: { self pt1 }.
 
+]
+
+{ #category : #accessing }
+FamixTest3Test >> inv1 [
+	^ (model allUsing: FamixTInvocation) anyOne
+]
+
+{ #category : #accessing }
+FamixTest3Test >> m1 [
+	^ model entityNamed: #m1
+]
+
+{ #category : #accessing }
+FamixTest3Test >> m2 [
+	^ model entityNamed: #m2
+]
+
+{ #category : #accessing }
+FamixTest3Test >> pt1 [
+	^ model entityNamed: #int
+]
+
+{ #category : #accessing }
+FamixTest3Test >> pt2 [
+	^ model entityNamed: #float
+]
+
+{ #category : #accessing }
+FamixTest3Test >> ref1 [
+	^ (model allUsing: FamixTReference) detect: [ :ref | ref source = self m1 and: [ ref target = self pt1 ] ]
 ]
 
 { #category : #running }
 FamixTest3Test >> setUp [
-
+	| c1 c2 m1 m2 pt1 pt2 ref1 ref2 inv1 |
 	super setUp.
 
 	model := FamixTest3MooseModel new.
 
 	c1 := FamixTest3Class named: 'Class1'.
 	c2 := FamixTest3Class named: 'Class2'.
-	
-	m1 := FamixTest3Method named: 'm1'. 
-	m2 := FamixTest3Method named: 'm2'. 
 
-	pt1 := FamixTest3PrimitiveType named: 'int'. 
-	pt2 := FamixTest3PrimitiveType named: 'float'. 
-	
+	m1 := FamixTest3Method named: 'm1'.
+	m2 := FamixTest3Method named: 'm2'.
+
+	pt1 := FamixTest3PrimitiveType named: 'int'.
+	pt2 := FamixTest3PrimitiveType named: 'float'.
+
 	ref1 := FamixTest3Reference new.
 	ref2 := FamixTest3Reference new.
 	inv1 := FamixTest3Invocation new.
-	
-	model addAll: { c1. c2. m1. m2. pt1. pt2 }.
-	
+
 	c1 addMethod: m1.
 	c2 addMethod: m2.
-	
-	ref1 
-		source: m1; 
+
+	ref1
+		source: m1;
 		target: pt1.
-	ref2 
-		source: m1; 
+	ref2
+		source: m1;
 		target: c1.
 	inv1
 		from: m1;
 		to: {m1}.
+
+	model addAll: {c1 . c2 . m1 . m2 . pt1 . pt2. ref1. ref2. inv1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testAllClients [
-	self assertCollection: pt1 allClients hasSameElements: {m1}
+	self assertCollection: self pt1 allClients hasSameElements: {self m1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testAllClientsAtScope [
-	self assertCollection: (pt1 allClientsAtScope: FamixTClass) hasSameElements: {c1}.
-	self assertCollection: (pt1 allClientsAtScope: FamixTest3Class) hasSameElements: {c1}
+	self assertCollection: (self pt1 allClientsAtScope: FamixTClass) hasSameElements: {self c1}.
+	self assertCollection: (self pt1 allClientsAtScope: FamixTest3Class) hasSameElements: {self c1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testAllProviders [
-	self assertCollection: m1 allProviders hasSameElements: {c1 . pt1}
+	self assertCollection: self m1 allProviders hasSameElements: {self c1 . self pt1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testAllProvidersAtScope [
-	self assertCollection: (m1 allProvidersAtScope: FamixTClass) hasSameElements: {c1 . pt1}.
-	self assertCollection: (m1 allProvidersAtScope: FamixTest3Class) hasSameElements: {c1 . pt1}
+	self assertCollection: (self m1 allProvidersAtScope: FamixTClass) hasSameElements: {self c1 . self pt1}.
+	self assertCollection: (self m1 allProvidersAtScope: FamixTest3Class) hasSameElements: {self c1 . self pt1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testAtScope [
-	self assertCollection: (m1 atScope: FamixTClass) hasSameElements: {c1}.
-	self assertCollection: (m1 atScope: FamixTest3Class) hasSameElements: {c1}
+	self assertCollection: (self m1 atScope: FamixTClass) hasSameElements: {self c1}.
+	self assertCollection: (self m1 atScope: FamixTest3Class) hasSameElements: {self c1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testAtScopeOnQueryResult [
 	| mooseQueryResult |
-	mooseQueryResult := MooseObjectQueryResult on: c1 withAll: {m1 . m2 . pt1 . pt2}.
+	mooseQueryResult := MooseObjectQueryResult on: self c1 withAll: {self m1 . self m2 . self pt1 . self pt2}.
 
-	self assertCollection: (mooseQueryResult atScope: FamixTClass) hasSameElements: {c1 . c2}.
-	self assertCollection: (mooseQueryResult atScope: FamixTest3Class) hasSameElements: {c1 . c2}
+	self assertCollection: (mooseQueryResult atScope: FamixTClass) hasSameElements: {self c1 . self c2}.
+	self assertCollection: (mooseQueryResult atScope: FamixTest3Class) hasSameElements: {self c1 . self c2}
 ]
 
 { #category : #running }
@@ -113,10 +143,10 @@ FamixTest3Test >> testAtScopeWithNonMatchingEntitiesDo [
 
 { #category : #running }
 FamixTest3Test >> testIncomingReferences [
-	self assertCollection: pt1 incomingReferences hasSameElements: {ref1}
+	self assertCollection: self pt1 incomingReferences hasSameElements: {self ref1}
 ]
 
 { #category : #running }
 FamixTest3Test >> testQueryIncomingDependencies [
-	self assertCollection: pt1 queryIncomingDependencies hasSameElements: {ref1}
+	self assertCollection: self pt1 queryIncomingDependencies hasSameElements: {self ref1}
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -27,6 +27,7 @@ FamixTest4Person >> books [
 	"Relation named: #books type: #FamixTest4Book opposite: #person"
 
 	<generated>
+	<derived>
 	^ books
 ]
 

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -42,6 +42,7 @@ FamixTest4School >> principal [
 	"Relation named: #principal type: #FamixTest4Principal opposite: #school"
 
 	<generated>
+	<derived>
 	^ principal
 ]
 
@@ -65,6 +66,7 @@ FamixTest4School >> rooms [
 	"Relation named: #rooms type: #FamixTest4Room opposite: #school"
 
 	<generated>
+	<derived>
 	^ rooms
 ]
 
@@ -88,6 +90,7 @@ FamixTest4School >> students [
 	"Relation named: #students type: #FamixTest4Student opposite: #school"
 
 	<generated>
+	<derived>
 	^ students
 ]
 
@@ -111,6 +114,7 @@ FamixTest4School >> teachers [
 	"Relation named: #teachers type: #FamixTest4Teacher opposite: #school"
 
 	<generated>
+	<derived>
 	^ teachers
 ]
 

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -75,6 +75,7 @@ FamixTest4Student >> teachers [
 	"Relation named: #teachers type: #FamixTest4Teacher opposite: #students"
 
 	<generated>
+	<derived>
 	^ teachers
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
@@ -30,6 +30,7 @@ FamixTestComposed1CustomEntity1 >> customEntity1 [
 
 	<generated>
 	<container>
+	<derived>
 	<MSEProperty: #customEntity1 type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntity1 ifAbsent: [ nil ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed1CustomEntity2 >> c22s [
 	"Relation named: #c22s type: #FamixTestComposed1CustomEntity2 opposite: #c12"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c22s type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c12: ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
@@ -22,6 +22,7 @@ FamixTestComposed1CustomEntity3 >> customEntities3 [
 	"Relation named: #customEntities3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntity3"
 
 	<generated>
+	<derived>
 	<MSEProperty: #customEntities3 type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntities3 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity3: ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed1CustomEntity4 >> c24s [
 	"Relation named: #c24s type: #FamixTestComposed1CustomEntity4 opposite: #c14s"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c24s type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c14s ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed1CustomEntity5 >> associations [
 	"Relation named: #associations type: #FamixTestComposed1Association opposite: #c15"
 
 	<generated>
+	<derived>
 	<MSEProperty: #associations type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c15: ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed1Method >> entity [
 	"Relation named: #entity type: #FamixTestComposed1Entity opposite: #method"
 
 	<generated>
+	<derived>
 	<MSEProperty: #entity type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #entity ifAbsent: [ nil ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed2CustomEntity1 >> c1 [
 	"Relation named: #c1 type: #FamixTestComposed2CustomEntity1 opposite: #c21"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c1 type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c1 ifAbsent: [ nil ]
@@ -15,6 +16,7 @@ FamixTestComposed2CustomEntity1 >> c11 [
 	"Relation named: #c11 type: #FamixTestComposed2CustomEntity1 opposite: #c21"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c11 type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c11 ifAbsent: [ nil ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed2CustomEntity3 >> c13s [
 	"Relation named: #c13s type: #FamixTestComposed2CustomEntity3 opposite: #c23"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c13s type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c13s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
@@ -22,6 +23,7 @@ FamixTestComposed2CustomEntity3 >> c3s [
 	"Relation named: #c3s type: #FamixTestComposed2CustomEntity3 opposite: #c23"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c3s type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c3s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
@@ -5,6 +5,7 @@ FamixTestComposed2CustomEntity5 >> associations [
 	"Relation named: #associations type: #FamixTestComposed2Association opposite: #c25"
 
 	<generated>
+	<derived>
 	<MSEProperty: #associations type: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c25: ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -25,6 +25,7 @@ FamixTestComposedCustomEntity2 >> c22s [
 	"Relation named: #c22s type: #FamixTestComposedCustomEntity2 opposite: #c2"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c22s type: #Object>
 	^ self privateState attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c2: ]
 ]
@@ -41,6 +42,7 @@ FamixTestComposedCustomEntity2 >> customEntities2 [
 	"Relation named: #customEntities2 type: #FamixTestComposedCustomEntity2 opposite: #customEntity2"
 
 	<generated>
+	<derived>
 	<MSEProperty: #customEntities2 type: #Object>
 	^ self privateState attributeAt: #customEntities2 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity2: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -25,6 +25,7 @@ FamixTestComposedCustomEntity4 >> c24s [
 	"Relation named: #c24s type: #FamixTestComposedCustomEntity4 opposite: #c4s"
 
 	<generated>
+	<derived>
 	<MSEProperty: #c24s type: #Object>
 	^ self privateState attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c4s ]
 ]
@@ -41,6 +42,7 @@ FamixTestComposedCustomEntity4 >> customEntities4 [
 	"Relation named: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4"
 
 	<generated>
+	<derived>
 	<MSEProperty: #customEntities4 type: #Object>
 	^ self privateState attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]

--- a/src/Famix-Tests/FamixTWithMSEExportTestCase.trait.st
+++ b/src/Famix-Tests/FamixTWithMSEExportTestCase.trait.st
@@ -36,5 +36,6 @@ FamixTWithMSEExportTestCase >> setUpImportedModel [
 	self setUp.
 	tempFile := (FileSystem memory / 'files-test.mse') ensureCreateFile.
 	tempFile writeStreamDo: [ :s | model exportToMSEStream: s ].
-	model := tempFile readStreamDo: [ :s | model class importFromMSEStream: s ]
+	model := tempFile readStreamDo: [ :s | model class importFromMSEStream: s ].
+	model name: 'IMPORTED FROM MSE' , model name
 ]

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -61,6 +61,7 @@ FamixTAccessible >> incomingAccesses [
 
 	<generated>
 	<MSEComment: 'All Famix accesses pointing to this structural entity'>
+	<derived>
 	^ incomingAccesses
 ]
 

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -69,6 +69,7 @@ FamixTAnnotationType >> instances [
 
 	<generated>
 	<MSEComment: 'Annotations of this type'>
+	<derived>
 	^ instances
 ]
 

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -45,6 +45,7 @@ FamixTAnnotationTypeAttribute >> annotationAttributeInstances [
 
 	<generated>
 	<MSEComment: 'A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances'>
+	<derived>
 	^ annotationAttributeInstances
 ]
 

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -48,6 +48,7 @@ FamixTAssociation >> next [
 
 	<generated>
 	<MSEComment: 'Next association in an ordered collection of associations. Currently not supported by the Moose importer'>
+	<derived>
 	^ next
 ]
 

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -37,6 +37,7 @@ FamixTFile >> entities [
 
 	<generated>
 	<MSEComment: 'List of entities defined in the file'>
+	<derived>
 	^ entities
 ]
 

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -53,6 +53,7 @@ FamixTFolder >> childrenFileSystemEntities [
 
 	<generated>
 	<MSEComment: 'List of entities contained in this folder.'>
+	<derived>
 	^ childrenFileSystemEntities
 ]
 

--- a/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
@@ -26,6 +26,7 @@ FamixTGlobalVariableScope >> globalVariables [
 
 	<generated>
 	<MSEComment: 'Global variables defined in the scope, if any.'>
+	<derived>
 	^ globalVariables
 ]
 

--- a/src/Famix-Traits/FamixTInvocable.trait.st
+++ b/src/Famix-Traits/FamixTInvocable.trait.st
@@ -26,6 +26,7 @@ FamixTInvocable >> incomingInvocations [
 
 	<generated>
 	<MSEComment: 'Incoming invocations from other behaviours computed by the candidate operator.'>
+	<derived>
 	^ incomingInvocations
 ]
 

--- a/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
+++ b/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
@@ -26,6 +26,7 @@ FamixTInvocationsReceiver >> receivingInvocations [
 
 	<generated>
 	<MSEComment: 'List of invocations performed on this entity (considered as the receiver)'>
+	<derived>
 	^ receivingInvocations
 ]
 

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -31,6 +31,7 @@ FamixTModule >> moduleEntities [
 	"Relation named: #moduleEntities type: #FamixTDefinedInModule opposite: #parentModule"
 
 	<generated>
+	<derived>
 	^ moduleEntities
 ]
 

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -49,6 +49,7 @@ FamixTNamespace >> namespaceEntities [
 	"Relation named: #namespaceEntities type: #FamixTNamespaceEntity opposite: #parentNamespace"
 
 	<generated>
+	<derived>
 	^ namespaceEntities
 ]
 

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -40,6 +40,7 @@ FamixTPackage >> childEntities [
 	"Relation named: #childEntities type: #FamixTPackageable opposite: #parentPackage"
 
 	<generated>
+	<derived>
 	^ childEntities
 ]
 

--- a/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
@@ -27,6 +27,7 @@ FamixTParameterizedTypeUser >> argumentsInParameterizedTypes [
 	"Relation named: #argumentsInParameterizedTypes type: #FamixTWithParameterizedTypeUsers opposite: #arguments"
 
 	<generated>
+	<derived>
 	^ argumentsInParameterizedTypes
 ]
 

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -26,6 +26,7 @@ FamixTReferenceable >> incomingReferences [
 
 	<generated>
 	<MSEComment: 'References to this entity by other entities.'>
+	<derived>
 	^ incomingReferences
 ]
 

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -58,6 +58,7 @@ FamixTScopingEntity >> childScopes [
 
 	<generated>
 	<MSEComment: 'Child scopes embedded in this scope, if any.'>
+	<derived>
 	^ childScopes
 ]
 

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -39,6 +39,7 @@ FamixTSourceLanguage >> sourcedEntities [
 
 	<generated>
 	<MSEComment: 'References to the entities saying explicitly that are written in this language.'>
+	<derived>
 	^ sourcedEntities
 ]
 

--- a/src/Famix-Traits/FamixTSuper.trait.st
+++ b/src/Famix-Traits/FamixTSuper.trait.st
@@ -27,6 +27,7 @@ FamixTSuper >> subs [
 	"Relation named: #subs type: #FamixTSub opposite: #supers"
 
 	<generated>
+	<derived>
 	^ subs
 ]
 

--- a/src/Famix-Traits/FamixTTemplate.trait.st
+++ b/src/Famix-Traits/FamixTTemplate.trait.st
@@ -44,6 +44,7 @@ FamixTTemplate >> templateUsers [
 	"Relation named: #templateUsers type: #FamixTTemplateUser opposite: #template"
 
 	<generated>
+	<derived>
 	^ templateUsers
 ]
 

--- a/src/Famix-Traits/FamixTTrait.trait.st
+++ b/src/Famix-Traits/FamixTTrait.trait.st
@@ -31,6 +31,7 @@ FamixTTrait >> incomingTraitUsages [
 	"Relation named: #incomingTraitUsages type: #FamixTTraitUsage opposite: #trait"
 
 	<generated>
+	<derived>
 	^ incomingTraitUsages
 ]
 

--- a/src/Famix-Traits/FamixTTraitUser.trait.st
+++ b/src/Famix-Traits/FamixTTraitUser.trait.st
@@ -27,6 +27,7 @@ FamixTTraitUser >> outgoingTraitUsages [
 	"Relation named: #outgoingTraitUsages type: #FamixTTraitUsage opposite: #user"
 
 	<generated>
+	<derived>
 	^ outgoingTraitUsages
 ]
 

--- a/src/Famix-Traits/FamixTWithAccesses.trait.st
+++ b/src/Famix-Traits/FamixTWithAccesses.trait.st
@@ -21,6 +21,7 @@ FamixTWithAccesses >> accesses [
 
 	<generated>
 	<MSEComment: 'Accesses to variables made by this behaviour.'>
+	<derived>
 	^ accesses
 ]
 

--- a/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
@@ -26,6 +26,7 @@ FamixTWithAnnotationInstanceAttributes >> attributes [
 
 	<generated>
 	<MSEComment: 'This corresponds to the actual values of the attributes in an AnnotationInstance'>
+	<derived>
 	^ attributes
 ]
 

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -49,6 +49,7 @@ FamixTWithAnnotationInstances >> annotationInstances [
 
 	<generated>
 	<MSEComment: 'This property corresponds to the set of annotations associated to the entity'>
+	<derived>
 	^ annotationInstances
 ]
 

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -27,6 +27,7 @@ FamixTWithAnnotationTypes >> definedAnnotationTypes [
 
 	<generated>
 	<MSEComment: 'The container in which the AnnotationTypes may be declared'>
+	<derived>
 	^ definedAnnotationTypes
 ]
 

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -26,6 +26,7 @@ FamixTWithAttributes >> attributes [
 
 	<generated>
 	<MSEComment: 'List of attributes declared by this type.'>
+	<derived>
 	^ attributes
 ]
 

--- a/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
@@ -27,6 +27,7 @@ FamixTWithCaughtExceptions >> caughtExceptions [
 
 	<generated>
 	<MSEComment: 'The exceptions caught by the method'>
+	<derived>
 	^ caughtExceptions
 ]
 

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -28,6 +28,7 @@ FamixTWithComments >> comments [
 
 	<generated>
 	<MSEComment: 'list of comments defined in the entity'>
+	<derived>
 	^ comments
 ]
 

--- a/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
@@ -20,6 +20,7 @@ FamixTWithCompilationUnit >> compilationUnit [
 	"Relation named: #compilationUnit type: #FamixTCompilationUnit opposite: #compilationUnitOwner"
 
 	<generated>
+	<derived>
 	^ compilationUnit
 ]
 

--- a/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
@@ -26,6 +26,7 @@ FamixTWithDeclaredExceptions >> declaredExceptions [
 
 	<generated>
 	<MSEComment: 'The exceptions declared by the method'>
+	<derived>
 	^ declaredExceptions
 ]
 

--- a/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
@@ -26,6 +26,7 @@ FamixTWithDereferencedInvocations >> dereferencedInvocations [
 
 	<generated>
 	<MSEComment: 'List of invocations performed on BehaviouralEntities referenced by this entity'>
+	<derived>
 	^ dereferencedInvocations
 ]
 

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -26,6 +26,7 @@ FamixTWithEnumValues >> enumValues [
 	"Relation named: #enumValues type: #FamixTEnumValue opposite: #parentEnum"
 
 	<generated>
+	<derived>
 	^ enumValues
 ]
 

--- a/src/Famix-Traits/FamixTWithExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithExceptions.trait.st
@@ -27,6 +27,7 @@ FamixTWithExceptions >> exceptions [
 
 	<generated>
 	<MSEComment: 'Exceptions which class is myself.'>
+	<derived>
 	^ exceptions
 ]
 

--- a/src/Famix-Traits/FamixTWithFileIncludes.trait.st
+++ b/src/Famix-Traits/FamixTWithFileIncludes.trait.st
@@ -34,6 +34,7 @@ FamixTWithFileIncludes >> incomingIncludeRelations [
 
 	<generated>
 	<MSEComment: 'The include entities that have this file as a target.'>
+	<derived>
 	^ incomingIncludeRelations
 ]
 
@@ -51,6 +52,7 @@ FamixTWithFileIncludes >> outgoingIncludeRelations [
 
 	<generated>
 	<MSEComment: 'The include entities that have this file as a source.'>
+	<derived>
 	^ outgoingIncludeRelations
 ]
 

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -27,6 +27,7 @@ FamixTWithFunctions >> functions [
 
 	<generated>
 	<MSEComment: 'Functions defined in the container, if any.'>
+	<derived>
 	^ functions
 ]
 

--- a/src/Famix-Traits/FamixTWithHeader.trait.st
+++ b/src/Famix-Traits/FamixTWithHeader.trait.st
@@ -21,6 +21,7 @@ FamixTWithHeader >> header [
 
 	<generated>
 	<MSEComment: 'The header file that defines this module'>
+	<derived>
 	^ header
 ]
 

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -26,6 +26,7 @@ FamixTWithImplicitVariables >> implicitVariables [
 
 	<generated>
 	<MSEComment: 'Implicit variables used locally by this behaviour.'>
+	<derived>
 	^ implicitVariables
 ]
 

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -26,6 +26,7 @@ FamixTWithInvocations >> outgoingInvocations [
 
 	<generated>
 	<MSEComment: 'Outgoing invocations sent by this behaviour.'>
+	<derived>
 	^ outgoingInvocations
 ]
 

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -26,6 +26,7 @@ FamixTWithLocalVariables >> localVariables [
 
 	<generated>
 	<MSEComment: 'Variables locally defined by this behaviour.'>
+	<derived>
 	^ localVariables
 ]
 

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -26,6 +26,7 @@ FamixTWithMethods >> methods [
 
 	<generated>
 	<MSEComment: 'Methods declared by this type.'>
+	<derived>
 	^ methods
 ]
 

--- a/src/Famix-Traits/FamixTWithNamespaces.trait.st
+++ b/src/Famix-Traits/FamixTWithNamespaces.trait.st
@@ -26,6 +26,7 @@ FamixTWithNamespaces >> namespaces [
 	"Relation named: #namespaces type: #FamixTNamespace opposite: #namespaceOwner"
 
 	<generated>
+	<derived>
 	^ namespaces
 ]
 

--- a/src/Famix-Traits/FamixTWithPackages.trait.st
+++ b/src/Famix-Traits/FamixTWithPackages.trait.st
@@ -26,6 +26,7 @@ FamixTWithPackages >> packages [
 	"Relation named: #packages type: #FamixTPackage opposite: #packageOwner"
 
 	<generated>
+	<derived>
 	^ packages
 ]
 

--- a/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
@@ -26,6 +26,7 @@ FamixTWithParameterizedTypes >> parameterizedTypes [
 	"Relation named: #parameterizedTypes type: #FamixTParameterizedType opposite: #parameterizableClass"
 
 	<generated>
+	<derived>
 	^ parameterizedTypes
 ]
 

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -40,6 +40,7 @@ FamixTWithParameters >> parameters [
 
 	<generated>
 	<MSEComment: 'List of formal parameters declared by this behaviour.'>
+	<derived>
 	^ parameters
 ]
 

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -26,6 +26,7 @@ FamixTWithReferences >> outgoingReferences [
 
 	<generated>
 	<MSEComment: 'References from this entity to other entities.'>
+	<derived>
 	^ outgoingReferences
 ]
 

--- a/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
@@ -71,6 +71,7 @@ FamixTWithSourceAnchor >> sourceAnchor [
 
 	<generated>
 	<MSEComment: 'SourceAnchor entity linking to the original source code for this entity'>
+	<derived>
 	^ sourceAnchor
 ]
 

--- a/src/Famix-Traits/FamixTWithSubInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithSubInheritances.trait.st
@@ -26,6 +26,7 @@ FamixTWithSubInheritances >> superInheritances [
 
 	<generated>
 	<MSEComment: 'Superinheritance relationships, i.e. known superclasses of this type.'>
+	<derived>
 	^ superInheritances
 ]
 

--- a/src/Famix-Traits/FamixTWithSuperInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithSuperInheritances.trait.st
@@ -40,6 +40,7 @@ FamixTWithSuperInheritances >> subInheritances [
 
 	<generated>
 	<MSEComment: 'Subinheritance relationships, i.e. known subclasses of this type.'>
+	<derived>
 	^ subInheritances
 ]
 

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -26,6 +26,7 @@ FamixTWithTemplates >> templates [
 	"Relation named: #templates type: #FamixTTemplate opposite: #templateOwner"
 
 	<generated>
+	<derived>
 	^ templates
 ]
 

--- a/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
@@ -26,6 +26,7 @@ FamixTWithThrownExceptions >> thrownExceptions [
 
 	<generated>
 	<MSEComment: 'The exceptions thrown by the method'>
+	<derived>
 	^ thrownExceptions
 ]
 

--- a/src/Famix-Traits/FamixTWithTraits.trait.st
+++ b/src/Famix-Traits/FamixTWithTraits.trait.st
@@ -26,6 +26,7 @@ FamixTWithTraits >> traits [
 	"Relation named: #traits type: #FamixTTrait opposite: #traitOwner"
 
 	<generated>
+	<derived>
 	^ traits
 ]
 

--- a/src/Famix-Traits/FamixTWithTypeAliases.trait.st
+++ b/src/Famix-Traits/FamixTWithTypeAliases.trait.st
@@ -35,6 +35,7 @@ FamixTWithTypeAliases >> typeAliases [
 
 	<generated>
 	<MSEComment: 'Aliases'>
+	<derived>
 	^ typeAliases
 ]
 

--- a/src/Famix-Traits/FamixTWithTypedStructures.trait.st
+++ b/src/Famix-Traits/FamixTWithTypedStructures.trait.st
@@ -41,6 +41,7 @@ FamixTWithTypedStructures >> structuresWithDeclaredType [
 
 	<generated>
 	<MSEComment: 'Structural entities that have this type as declaredType'>
+	<derived>
 	^ structuresWithDeclaredType
 ]
 

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -60,6 +60,7 @@ FamixTWithTypes >> types [
 	<generated>
 	<MSEComment: 'Types contained (declared) in this entity, if any.
 #types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.'>
+	<derived>
 	^ types
 ]
 


### PR DESCRIPTION
Do not set everything to derived but only one part of the relations.

Fixes #1837