### PR TITLE
1819-Non-container-relations-are-not-persisted-in-MSE

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -50,14 +50,6 @@ FAMIXSourceAnchor >> containerFiles [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
-FAMIXSourceAnchor >> element [
-
-	<MSEComment: 'Enable the accessibility to the famix entity that this class is a source pointer for'>
-	<container>
-	^ element
-]
-
 { #category : #testing }
 FAMIXSourceAnchor >> isFile [
 	^ false

--- a/src/Moose-Tests-Core/FamixTest.class.st
+++ b/src/Moose-Tests-Core/FamixTest.class.st
@@ -58,7 +58,7 @@ FamixTest >> testMSEImport [
 	importer run.
 	self assert: importer repository elements size equals: 2.
 	model := FamixTest3MooseModel new.
-	importer repository elements do: [ :each | model add: each ].
+	model addAll: importer repository elements.
 	self assert: model allClasses size equals: 1.
 	self assert: model allMethods size equals: 1
 ]
@@ -74,7 +74,7 @@ FamixTest >> testRobustMSEImport [
 
 	self assert: importer repository elements size equals: 4.
 	model := FamixTest3MooseModel new.
-	importer repository elements do: [ :each | model add: each ].
+	model addAll: importer repository elements.
 	self assert: model allClasses size equals: 2.
 	self assert: model allMethods size equals: 1.
 	self assert: model allReferences size equals: 1
@@ -83,34 +83,27 @@ FamixTest >> testRobustMSEImport [
 { #category : #tests }
 FamixTest >> testSlot [
 	| fClass fMethod |
-	fClass := FAMIXClass new.
-	fMethod := FAMIXMethod new.
+	fClass := FamixTest3Class new.
+	fMethod := FamixTest3Method new.
 	fMethod parentType: fClass.
 	self assert: (fClass methods at: 1) equals: fMethod
 ]
 
 { #category : #tests }
 FamixTest >> testSourcesAnchorsAreNotDuplicatedAfterExport [
-	| model package tempFile importedModel ws |
-	model := MooseModel new name: 'Perdu'.
-	package := FAMIXPackage new
-		name: 'Package';
-		mooseModel: model;
-		yourself.
-	FAMIXClass new
+	| model tempFile importedModel |
+	model := FamixTest3MooseModel new name: 'Perdu'.
+	FamixTest3Class new
 		name: 'Class';
-		container: package;
 		sourceAnchor:
-			(FAMIXSourceTextAnchor new
+			(FamixTest3SourceTextAnchor new
 				source: 'some text';
 				mooseModel: model;
 				yourself);
 		mooseModel: model.
 	tempFile := (FileSystem memory / 'export-test.mse') ensureCreateFile.
-	ws := tempFile writeStream.
-	model exportToMSEStream: ws.
-	ws close; flush.
-	importedModel := MooseModel new importFromMSEStream: tempFile readStream.
+	tempFile writeStreamDo: [ :s | model exportToMSEStream: s ].
+	importedModel := FamixTest3MooseModel new importFromMSEStream: tempFile readStream.
 	self assert: importedModel size equals: model size.
 	self assert: importedModel allClasses anyOne sourceAnchor notNil
 ]


### PR DESCRIPTION
Migrate tests to new MM now that issue #1819 is fixed (in #1839) + remove container pragma from source anchor. 

Fixes #1819