### PR TITLE
tests-cleaning

### DIFF
--- a/src/Famix-Compatibility-Tests-C/FAMIXModuleTest.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXModuleTest.class.st
@@ -12,6 +12,6 @@ FAMIXModuleTest >> testFunctions [
 	self assert: module functions isEmpty.
 	function := FAMIXFunction new.
 	function parentModule: module.
-	self assert: function parentModule == module.
+	self assert: function parentModule identicalTo: module.
 	self assert: module moduleEntities size equals: 1
 ]

--- a/src/Famix-Compatibility-Tests-Core/FAMIXCommentTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXCommentTest.class.st
@@ -14,7 +14,7 @@ FAMIXCommentTest >> testAddingComment [
 	| cls |
 	cls := FAMIXClass new.
 	cls name: 'AClass'.
-	self assert: cls mooseName == #AClass.
+	self assert: cls mooseName identicalTo: #AClass.
 	self assert: cls comments isEmpty.
 	cls addComment: (FAMIXComment content: 'This is a comment').
 	self assert: (cls comments allSatisfy: [ :c | c isKindOf: FAMIXComment ]).

--- a/src/Famix-Compatibility-Tests-Core/FAMIXSourceAnchorTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXSourceAnchorTest.class.st
@@ -23,7 +23,7 @@ FAMIXSourceAnchorTest >> testImportFileAnchors [
 	)' readStream.
 	self assert: model entities size equals: 4.
 	self assert: model allClasses first sourceAnchor notNil.
-	self assert: model allClasses first sourceAnchor mooseModel == model.
+	self assert: model allClasses first sourceAnchor mooseModel identicalTo: model.
 	self assert: (model allClasses first sourceAnchor isKindOf: FAMIXSourceAnchor).
 	self assert: model allClasses first sourceAnchor fileName equals: 'afile'.
 	aMethod := model allMethods first.

--- a/src/Famix-Compatibility-Tests-Core/FAMIXTypeAliasTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXTypeAliasTest.class.st
@@ -22,9 +22,9 @@ FAMIXTypeAliasTest >> testAliasOpposite [
 	alias := self actualClass new
 		aliasedType: type;
 		yourself.
-	self assert: alias aliasedType == type.
+	self assert: alias aliasedType identicalTo: type.
 	self assert: type typeAliases size equals: 1.
-	self assert: type typeAliases first == alias
+	self assert: type typeAliases first identicalTo: alias
 ]
 
 { #category : #tests }

--- a/src/Famix-Compatibility-Tests-Core/FAMIXTypeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXTypeTest.class.st
@@ -15,7 +15,7 @@ FAMIXTypeTest >> testBehaviorsWithDeclaredType [
 	type := self actualClass new.
 	behaviour := FAMIXBehaviouralEntity new.
 	behaviour declaredType: type.
-	self assert: behaviour declaredType == type.
+	self assert: behaviour declaredType identicalTo: type.
 	self assert: type structuresWithDeclaredType size equals: 1.
 	self assert: (type structuresWithDeclaredType includes: behaviour)
 ]
@@ -26,7 +26,7 @@ FAMIXTypeTest >> testStructuresWithDeclaredType [
 	type := self actualClass new.
 	structure := FAMIXStructuralEntity new.
 	structure declaredType: type.
-	self assert: structure declaredType == type.
+	self assert: structure declaredType identicalTo: type.
 	self assert: type structuresWithDeclaredType size equals: 1.
 	self assert: (type structuresWithDeclaredType includes: structure)
 ]

--- a/src/Famix-Compatibility-Tests-Java/FamixJavaTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixJavaTest.class.st
@@ -30,12 +30,12 @@ FamixJavaTest >> testImportAnnotations [
 		do: [ :i | 
 			self assert: (i annotationType instances includes: i).
 			self assert: (i annotatedEntity annotationInstances includes: i) ].
-	self assert: (model allAnnotationTypes entityNamed: #aNamespace::AnAnnotation) instances size equals: 2.
-	self assert: (model allAnnotationTypes entityNamed: #aNamespace::AnotherAnnotation) instances size equals: 1.
+	self assert: (model allAnnotationTypes entityNamed: #'aNamespace::AnAnnotation') instances size equals: 2.
+	self assert: (model allAnnotationTypes entityNamed: #'aNamespace::AnotherAnnotation') instances size equals: 1.
 	model allAnnotationTypes
 		do: [ :each | 
 			self assert: (each container definedAnnotationTypes includes: each).
-			self assert: each container == each belongsTo ]
+			self assert: each container identicalTo: each belongsTo ]
 ]
 
 { #category : #tests }

--- a/src/Famix-Compatibility-Tests-Java/FamixParameterizedTypeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixParameterizedTypeTest.class.st
@@ -142,5 +142,5 @@ FamixParameterizedTypeTest >> testMooseName [
 
 { #category : #tests }
 FamixParameterizedTypeTest >> testParameterizableClass [
-	self assert: model allParameterizableClasses anyOne parameterizedTypes size = 2
+	self assert: model allParameterizableClasses anyOne parameterizedTypes size equals: 2
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
@@ -49,9 +49,8 @@ FmxMBImportingContextTest >> testDefineImport [
 
 { #category : #initialization }
 FmxMBImportingContextTest >> testGeneratedContextClass [
-
 	self assert: generatedContext notNil.
-	self assert: generatedContext superclass name = #FmxImportingContext.
+	self assert: generatedContext superclass name equals: #FmxImportingContext
 ]
 
 { #category : #initialization }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
@@ -234,39 +234,31 @@ FmxMBTraitTest >> testCustomPackageForUserClasses [
 
 { #category : #tests }
 FmxMBTraitTest >> testCustomPackageForUserClassesChanged [
-
-	| simpleClass generated generatedAccess  |
-	
+	| simpleClass generated generatedAccess |
 	builder configuration packageName: 'Custom'.
-	
-	simpleClass := builder newTraitNamed: #TComment.	
+
+	simpleClass := builder newTraitNamed: #TComment.
 
 	builder configuration packageName: 'Custom2'.
 
-	simpleClass := builder newTraitNamed: #TAccess.	
+	simpleClass := builder newTraitNamed: #TAccess.
 
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstTComment'.
 	generatedAccess := builder testingEnvironment ask classNamed: 'TstTAccess'.
 
-	self assert: (generated package name = #Custom).
-	self assert: (generatedAccess package name = #Custom2).
-
-
-	
+	self assert: generated package name equals: #Custom.
+	self assert: generatedAccess package name equals: #Custom2
 ]
 
 { #category : #tests }
 FmxMBTraitTest >> testDefaultPackageForUserClasses [
-
-	| simpleClass  userClass |
-	
-	simpleClass := builder newTraitNamed: #TComment.	
+	| simpleClass userClass |
+	simpleClass := builder newTraitNamed: #TComment.
 	builder generate.
 	userClass := builder testingEnvironment ask classNamed: 'TstTComment'.
 
-	self assert: (userClass package name = #Tst).
-	
+	self assert: userClass package name equals: #Tst
 ]
 
 { #category : #tests }

--- a/src/Famix-Smalltalk-Utils-Tests/FamixSmalltalkNameResolverTest.class.st
+++ b/src/Famix-Smalltalk-Utils-Tests/FamixSmalltalkNameResolverTest.class.st
@@ -38,7 +38,7 @@ FamixSmalltalkNameResolverTest >> testGroupedBy [
 { #category : #tests }
 FamixSmalltalkNameResolverTest >> testResolvingName [
 	self assert: (self actualClass smalltalkClassFromFamixClassName: #Object ifAbsent: [  ]) equals: Object.
-	self assert: (self actualClass smalltalkClassFromFamixClassName: #FooBarZorkAbsent ifAbsent: [ 10 ]) == 10
+	self assert: (self actualClass smalltalkClassFromFamixClassName: #FooBarZorkAbsent ifAbsent: [ 10 ]) identicalTo: 10
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/FAMIXLintRuleTest.class.st
+++ b/src/Moose-Tests-Core/FAMIXLintRuleTest.class.st
@@ -6,8 +6,5 @@ Class {
 
 { #category : #tests }
 FAMIXLintRuleTest >> testRules [
-	{
-		FAMIXMetaModelClassesNotDeclaredInFameRule new.
-		FAMIXMetaModelClassesShouldNotOverrideRule new }
-		do: [ :rule | RBSmalllintChecker runRule: rule ].
+	{FAMIXMetaModelClassesNotDeclaredInFameRule . FAMIXMetaModelClassesShouldNotOverrideRule} do: [ :rule | RBSmalllintChecker runRule: rule new ]
 ]

--- a/src/Moose-Tests-Core/MooseEntityTest.class.st
+++ b/src/Moose-Tests-Core/MooseEntityTest.class.st
@@ -27,56 +27,50 @@ MooseEntityTest >> testAllMooseNameOn [
 
 { #category : #tests }
 MooseEntityTest >> testAllPrintOn [
-	| t str ins |
+	| t ins |
 	MooseEntity withAllSubclasses
 		do: [ :cls | 
-			cls hasAbstractMethods ifFalse: [
-				str := WriteStream on: String new.
-				ins := cls new.
-				self shouldnt: [ t := ins printString ] raise: Error.
-				self assert: t isByteString.
-				ins printOn: str.
-				self assert: str contents equals: t ] ]
+			cls hasAbstractMethods
+				ifFalse: [ ins := cls new.
+					self shouldnt: [ t := ins printString ] raise: Error.
+					self assert: t isByteString.
+					self assert: (String streamContents: [ :s | ins printOn: s ]) equals: t ] ]
 ]
 
 { #category : #tests }
 MooseEntityTest >> testAllPrinting [
-	| str entity |
+	| entity |
 	MooseEntity withAllSubclasses
 		do: [ :cls | 
-			cls hasAbstractMethods ifFalse: [
-				str := WriteStream on: String new.
-				entity := cls new.
-				entity printOn: str.
-				self assert: str contents equals: entity printString ] ]
+			cls hasAbstractMethods
+				ifFalse: [ entity := cls new.
+					self assert: (String streamContents: [ :s | entity printOn: s ]) equals: entity printString ] ]
 ]
 
 { #category : #tests }
 MooseEntityTest >> testAllPropertySelectors [
 	| model class |
-	model := MooseModel new.
-	self assert: (FAMIXEntity allPropertySelectorsComputableIn: model) equals: IdentityDictionary new.
+	model := FamixTest1MooseModel new.
+	self assert: (FamixTest1Entity allPropertySelectorsComputableIn: model) equals: IdentityDictionary new.
 	model := FAMIXTypeGroup new.
-	class := FAMIXClass new name: 'AClass'.
+	class := FamixTest1Class named: 'AClass'.
 	model add: class.
-	self assert: (FAMIXEntity allPropertySelectorsComputableIn: model) equals: IdentityDictionary new.
+	self assert: (FamixTest1Entity allPropertySelectorsComputableIn: model) equals: IdentityDictionary new.
 	model := MooseAbstractGroup new.
-	class := FAMIXClass new name: 'AClass'.
+	class := FamixTest1Class named: 'AClass'.
 	model add: class.
-	self assert: (FAMIXEntity allPropertySelectorsComputableIn: model) equals: IdentityDictionary new
+	self assert: (FamixTest1Entity allPropertySelectorsComputableIn: model) equals: IdentityDictionary new
 ]
 
 { #category : #tests }
 MooseEntityTest >> testAnnotation [
 	| methodProperty |
-	MooseEntity allSubclassesDo: [ :cls |
-		self assert: cls annotation == cls.
-	].
+	MooseEntity allSubclassesDo: [ :cls | self assert: cls annotation identicalTo: cls ].
 
-	self assert: MooseEntity annotation == MooseEntity.
-	
+	self assert: MooseEntity annotation identicalTo: MooseEntity.
+
 	methodProperty := (MooseEntity class >> #annotation) properties.
-	self assert:  (methodProperty includesKey: #abstract)
+	self assert: (methodProperty includesKey: #abstract)
 ]
 
 { #category : #tests }
@@ -92,19 +86,19 @@ MooseEntityTest >> testBookmark [
 { #category : #tests }
 MooseEntityTest >> testEntityBackLink [
 	"self debug: #testEntityBackLink"
-	
+
 	| e r |
 	e := MooseEntity new.
 	r := e privateState entity.
-	self assert: (r == e)
+	self assert: r identicalTo: e
 ]
 
 { #category : #tests }
 MooseEntityTest >> testGroupFor [
 	| entity1 entity2 model classGroup methodGroup |
-	entity1 := FAMIXClass new.
-	entity2 := FAMIXClass new.
-	model := MooseModel new.
+	entity1 := FamixTest1Class new.
+	entity2 := FamixTest1Class new.
+	model := FamixTest1MooseModel new.
 	model addAll: {entity1 . entity2}.
 	classGroup := model groupFor: #allClasses.
 	self assert: classGroup class identicalTo: FAMIXClassGroup.
@@ -133,44 +127,40 @@ MooseEntityTest >> testIsStub [
 { #category : #tests }
 MooseEntityTest >> testLocalMooseModel [
 	| element model |
-	
 	element := MooseEntity new.
 	model := MooseModel new.
-	
+
 	"self assert: (element mooseModel isNil)."
 	model add: element.
-	self assert: (element mooseModel == model).
-	self assert: (element localMooseModel == model).
+	self assert: element mooseModel identicalTo: model.
+	self assert: element localMooseModel identicalTo: model.
 
 	model := MooseModel new.
-	self assert: (model localMooseModel == model)
+	self assert: model localMooseModel identicalTo: model
 ]
 
 { #category : #tests }
 MooseEntityTest >> testMooseModel [
 	| element model |
-	
 	element := MooseEntity new.
 	model := MooseModel new.
-	
-	model add: element.
-	self assert: (element mooseModel == model).
 
+	model add: element.
+	self assert: element mooseModel identicalTo: model
 ]
 
 { #category : #tests }
 MooseEntityTest >> testMooseModelAccessor [
 	| entity model |
 	entity := MooseEntity new.
-"	self assert: (MooseModel ownerOf: entity) isNil. 
+	"	self assert: (MooseModel ownerOf: entity) isNil. 
 	self assert: (entity mooseModel isNil).
 "
 	model := MooseModel new.
-	self assert: (model isEmpty).
+	self assert: model isEmpty.
 	entity mooseModel: model.
-	self assert: (entity mooseModel == model).
-	self deny: (model isEmpty)
-	
+	self assert: entity mooseModel identicalTo: model.
+	self deny: model isEmpty
 ]
 
 { #category : #tests }
@@ -213,22 +203,19 @@ MooseEntityTest >> testPrivateSetMooseModel [
 	entity := MooseEntity new.
 	model := MooseModel new.
 	entity privateSetMooseModel: model.
-	self assert: (entity mooseModel == model).
-
+	self assert: entity mooseModel identicalTo: model
 ]
 
 { #category : #tests }
 MooseEntityTest >> testPrivateStateMutator [
-
 	| entity state mooseState |
 	entity := MooseEntity new.
 	state := entity privateState.
 	self assert: state notNil.
-	
+
 	mooseState := MooseMemoryEfficientState new.
 	entity privateState: mooseState.
-	self assert: (entity privateState == mooseState).
-
+	self assert: entity privateState identicalTo: mooseState
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseMSEImporterTest.class.st
+++ b/src/Moose-Tests-Core/MooseMSEImporterTest.class.st
@@ -102,9 +102,9 @@ MooseMSEImporterTest >> testSimple [
 	self assert: mooseModel entities notEmpty.
 	self assert: (mooseModel allClasses collect: #name) asSortedCollection asArray equals: {'ClassA' . 'ClassB'}.
 	self assert: (mooseModel allPackages collect: #name) asArray equals: {'aPackage' . 'aPackage'}.
-	classA := mooseModel entityNamed: #aNamespace::ClassA.
+	classA := mooseModel entityNamed: #'aNamespace::ClassA'.
 	self assert: classA notNil.
-	self assert: classA container == (mooseModel entityNamed: #aNamespace).
+	self assert: classA container identicalTo: (mooseModel entityNamed: #aNamespace).
 	self assert: classA methods size equals: 1.	"====="
 	self shouldnt: [ self readMSEStream: mooseSample modelVersion2 readStream ] raise: Error.
 	self shouldnt: [ self readMSEStream: mooseSample modelVersion3 readStream ] raise: Error.

--- a/src/Moose-Tests-DistributionMap/DistributionMapExampleTest.class.st
+++ b/src/Moose-Tests-DistributionMap/DistributionMapExampleTest.class.st
@@ -11,15 +11,15 @@ DistributionMapExampleTest class >> lastStoredRun [
 
 { #category : #tests }
 DistributionMapExampleTest >> testSample [
-	
 	| viewRenderer |
-	viewRenderer := (DistributionMapExample new properties: DistributionMapExample sampleProperties;
-				propertiesMap: DistributionMapExample sampleMap;
-				propertyBlock: DistributionMapExample sampleBlock;
-				elements: DistributionMapExample sampleOrderedElements;
-				render: Collection withAllSubclasses).
-				
-	self assert: (viewRenderer class == RTMondrian).
+	viewRenderer := DistributionMapExample new
+		properties: DistributionMapExample sampleProperties;
+		propertiesMap: DistributionMapExample sampleMap;
+		propertyBlock: DistributionMapExample sampleBlock;
+		elements: DistributionMapExample sampleOrderedElements;
+		render: Collection withAllSubclasses.
+
+	self assert: viewRenderer class identicalTo: RTMondrian.
 	"self shouldnt: [ viewRenderer getRenderedForm ] raise: Error."
-	self shouldnt: [ viewRenderer open delete ] raise: Error.
+	self shouldnt: [ viewRenderer open delete ] raise: Error
 ]

--- a/src/Moose-Tests-Finder/MooseFinderTest.class.st
+++ b/src/Moose-Tests-Finder/MooseFinderTest.class.st
@@ -87,13 +87,10 @@ MooseFinderTest >> testAsMooseFinderItemNamed [
 	entity2 := FAMIXType new.
 	entity2 name: 'hello2'.
 	model := MooseModel new.
-	model
-		addAll:
-			{entity1.
-			entity2}.
-	self assert: (model asMooseFinderItemNamed: 'bouba' in: model) == model.
+	model addAll: {entity1 . entity2}.
+	self assert: (model asMooseFinderItemNamed: 'bouba' in: model) identicalTo: model.
 	model2 := entity1 asMooseFinderItemNamed: 'bouba' in: model.
-	self assert: model2 class == FAMIXTypeGroup.
+	self assert: model2 class identicalTo: FAMIXTypeGroup.
 	self assert: model2 name equals: 'Bouba: hello'.
 	self assert: model2 entities asArray equals: {entity1}
 ]

--- a/src/Moose-Tests-Finder/MooseModelFinderExtensionsTest.class.st
+++ b/src/Moose-Tests-Finder/MooseModelFinderExtensionsTest.class.st
@@ -60,13 +60,11 @@ MooseModelFinderExtensionsTest >> testMooseInterestingEntity [
 	model := MooseModel new.
 	state := model privateState.
 	storage := model entityStorage.
-	
+
 	model mooseInterestingEntity.
 
-	self assert: model privateState == state.
-	self assert: model entityStorage == storage.
-
-
+	self assert: model privateState identicalTo: state.
+	self assert: model entityStorage identicalTo: storage
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixModelExtractionTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixModelExtractionTest.class.st
@@ -313,7 +313,7 @@ FamixModelExtractionTest >> testNumberOfFormalParameters [
 { #category : #tests }
 FamixModelExtractionTest >> testReferenceModel [
 	self assert: self model mooseModel isNil.
-	self assert: self model localMooseModel == self model.
+	self assert: self model localMooseModel identicalTo: self model
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixPropertiesTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixPropertiesTest.class.st
@@ -280,13 +280,9 @@ FamixPropertiesTest >> testMethodsSimpleProperties [
 
 { #category : #testing }
 FamixPropertiesTest >> testNoDuplicatesOfClassVariables [
-	self
-		assert: ((self model entityNamed: #Smalltalk::Object) attributes contains: [ :each | each name = #DependentsFields ]).
-	self
-		assert:
-			(self model entityNamed: #Smalltalk::Object) attributes first
-				== (self model entityNamed: #Smalltalk::Object) attributes last.
-	self assert: (self model entityNamed: #Smalltalk::Object) attributes size equals: 1
+	self assert: ((self model entityNamed: #'Smalltalk::Object') attributes contains: [ :each | each name = #DependentsFields ]).
+	self assert: (self model entityNamed: #'Smalltalk::Object') attributes first identicalTo: (self model entityNamed: #'Smalltalk::Object') attributes last.
+	self assert: (self model entityNamed: #'Smalltalk::Object') attributes size equals: 1
 ]
 
 { #category : #testing }

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
@@ -684,8 +684,9 @@ FamixReferenceModelImporterTest >> testMethodReification [
 { #category : #'reference model reification' }
 FamixReferenceModelImporterTest >> testNameResolverNamespaceName [
 	"self debug: #testNameResolverNamespaceName"
-	self assert: ((FamixSmalltalkNameResolver uniqueNameForNamespaceNamed: #ReferenceModel scope: #'SCG::Moose') == #'SCG::Moose::ReferenceModel').
-	self assert: ((FamixSmalltalkNameResolver uniqueNameForNamespaceNamed: #Moose scope: #SCG) ==  #'SCG::Moose')
+
+	self assert: (FamixSmalltalkNameResolver uniqueNameForNamespaceNamed: #ReferenceModel scope: #'SCG::Moose') identicalTo: #'SCG::Moose::ReferenceModel'.
+	self assert: (FamixSmalltalkNameResolver uniqueNameForNamespaceNamed: #Moose scope: #SCG) identicalTo: #'SCG::Moose'
 ]
 
 { #category : #'reference model reification' }

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
@@ -93,13 +93,14 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testConflictingInstan
 ]
 
 { #category : #tests }
-FamixReferenceModelMergingClassAndMetaclassImporterTest >> testInstanceAndClassSideWhenMergingClassAndMetaclass [	
+FamixReferenceModelMergingClassAndMetaclassImporterTest >> testInstanceAndClassSideWhenMergingClassAndMetaclass [
 	"self debug: #testInstanceAndClassSideWhenMergingClassAndMetaclass"
+
 	| node |
 	node := self model entityNamed: #'Smalltalk::TheRoot'.
-	self assert: (self model entityNamed: #'Smalltalk::TheRoot_class' ifAbsent: [nil]) isNil.
-	self  assert: node instanceSide == node.
-	self  assert: node classSide == nil.
+	self assert: (self model entityNamed: #'Smalltalk::TheRoot_class' ifAbsent: [ nil ]) isNil.
+	self assert: node instanceSide identicalTo: node.
+	self assert: node classSide identicalTo: nil
 ]
 
 { #category : #'new to put in VW' }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
@@ -171,21 +171,25 @@ FAMIXStepwiseImporterTest >> testImportClassAndMethodAndMergeItsMetaclass [
 { #category : #tests }
 FAMIXStepwiseImporterTest >> testImportLANPackage [
 	"self debug: #testImportLANPackage"
-	
+
 	| model class package |
-	model := MooseModel new.	
+	model := MooseModel new.
 	self newPharoImporterTask
 		importerClass: SmalltalkImporter;
-		doNotRunCandidateOperator; 
-		importingContext: (MooseImportingContext new importClass; importPackage; yourself);
+		doNotRunCandidateOperator;
+		importingContext:
+			(MooseImportingContext new
+				importClass;
+				importPackage;
+				yourself);
 		model: model;
 		addFromPackageNamed: #'Moose-TestResources-LAN';
 		run;
 		yourself.
-	self deny: (model allPackages isEmpty).
+	self deny: model allPackages isEmpty.
 	package := model entityNamed: #'Moose-TestResources-LAN'.
-	class := model entityNamed: #'Smalltalk::LANNode'. 
-	self assert: class parentPackage == package
+	class := model entityNamed: #'Smalltalk::LANNode'.
+	self assert: class parentPackage identicalTo: package
 ]
 
 { #category : #tests }
@@ -216,8 +220,8 @@ FAMIXStepwiseImporterTest >> testImportMethodBody [
 	self assert: famixClassNode methods size equals: LANNode methodDict size + LANNode class methodDict size.	"Browser Node>>nextNode to see the code that has been imported"
 	nextNodeMethod := famixClassNode methods detect: [ :fm | fm name == #nextNode ].
 	self assert: nextNodeMethod parameters isEmpty.
-	self assert: nextNodeMethod signature == #'nextNode()'.
-	self assert: nextNodeMethod mooseName == #'Smalltalk::LANNode.nextNode()'.
+	self assert: nextNodeMethod signature identicalTo: #'nextNode()'.
+	self assert: nextNodeMethod mooseName identicalTo: #'Smalltalk::LANNode.nextNode()'.
 	nameMethod := famixClassNode methods detect: [ :fm | fm name == #name: ].
 	self assert: nameMethod parameters size equals: 1.
 	xFormalParameter := nameMethod parameters at: 1.

--- a/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
@@ -105,15 +105,14 @@ LANImporterTest >> testClassNameDoesNotIncludeSpace [
 ]
 
 { #category : #tests }
-LANImporterTest >> testClassSides [ 
-	 
-	| node nodeClass | 
-	node := self model entityNamed: LANNode mooseName. 
-	nodeClass := self model entityNamed: LANNode class mooseName. 
-	self assert: node instanceSide == node. 
-	self assert: node classSide == nodeClass. 
-	self assert: nodeClass classSide == nodeClass. 
-	self assert: nodeClass instanceSide == node
+LANImporterTest >> testClassSides [
+	| node nodeClass |
+	node := self model entityNamed: LANNode mooseName.
+	nodeClass := self model entityNamed: LANNode class mooseName.
+	self assert: node instanceSide identicalTo: node.
+	self assert: node classSide identicalTo: nodeClass.
+	self assert: nodeClass classSide identicalTo: nodeClass.
+	self assert: nodeClass instanceSide identicalTo: node
 ]
 
 { #category : #tests }
@@ -325,38 +324,34 @@ LANImporterTest >> testMooseName [
 LANImporterTest >> testNameAndUniqueName [
 	| mseClass mseMethod mseAttribute mseGlobalVar mseImplicitVar mseLocalVariable mseFormalParameter transcriptName |
 	mseClass := self model entityNamed: LANNode mooseName.
-	self assert: mseClass name == #LANNode.
+	self assert: mseClass name identicalTo: #LANNode.
 	self
-		assert:
-			mseClass mooseName
-				==
-					(FamixSmalltalkNameResolver
-						uniqueNameForClassNamed: LANNode name
-						scope: (FamixSmalltalkNameResolver moosify: LANNode environment absoluteName)).
-	self assert: mseClass mooseName == LANNode mooseName.
+		assert: mseClass mooseName
+		identicalTo: (FamixSmalltalkNameResolver uniqueNameForClassNamed: LANNode name scope: (FamixSmalltalkNameResolver moosify: LANNode environment absoluteName)).
+	self assert: mseClass mooseName identicalTo: LANNode mooseName.
 	mseMethod := self model entityNamed: #'Smalltalk::LANPacket.printOn:(Object)'.
-	self assert: mseMethod name == #printOn:.
-	self assert: mseMethod mooseName == #'Smalltalk::LANPacket.printOn:(Object)'.
-	self assert: mseMethod signature == #'printOn:(Object)'.
+	self assert: mseMethod name identicalTo: #printOn:.
+	self assert: mseMethod mooseName identicalTo: #'Smalltalk::LANPacket.printOn:(Object)'.
+	self assert: mseMethod signature identicalTo: #'printOn:(Object)'.
 	mseAttribute := self model entityNamed: (LANNode mooseNameOf: 'name') asSymbol.
-	self assert: mseAttribute mooseName == (LANNode mooseNameOf: 'name').
-	self assert: mseAttribute name == #name.
+	self assert: mseAttribute mooseName identicalTo: (LANNode mooseNameOf: 'name').
+	self assert: mseAttribute name identicalTo: #name.
 	transcriptName := #Transcript.
 	mseGlobalVar := self model entityNamed: transcriptName.
-	self assert: mseGlobalVar name == transcriptName.
-	self assert: mseGlobalVar mooseName == transcriptName.	"self assert: (mseGlobalVar interfaceSignatures includes: #cr)."
+	self assert: mseGlobalVar name identicalTo: transcriptName.
+	self assert: mseGlobalVar mooseName identicalTo: transcriptName.	"self assert: (mseGlobalVar interfaceSignatures includes: #cr)."
 	mseImplicitVar := self model entityNamed: LANNode mooseName , '.accept:(Object).self'.
-	self assert: mseImplicitVar name == #self.
+	self assert: mseImplicitVar name identicalTo: #self.
 	self assert: mseImplicitVar mooseName equals: LANNode mooseName , '.accept:(Object).self'.	"self assert: (mseImplicitVar interfaceSignatures includes: #send:)."
 	mseImplicitVar := self model entityNamed: LANNode mooseName , '.printOn:(Object).super'.
-	self assert: mseImplicitVar name == #super.
-	self assert: mseImplicitVar mooseName == (LANNode mooseName , '.printOn:(Object).super') asSymbol.
+	self assert: mseImplicitVar name identicalTo: #super.
+	self assert: mseImplicitVar mooseName identicalTo: (LANNode mooseName , '.printOn:(Object).super') asSymbol.
 	mseLocalVariable := self model entityNamed: #'Smalltalk::LANInterface.originate().packet'.
-	self assert: mseLocalVariable name == #packet.
-	self assert: mseLocalVariable mooseName == #'Smalltalk::LANInterface.originate().packet'.
+	self assert: mseLocalVariable name identicalTo: #packet.
+	self assert: mseLocalVariable mooseName identicalTo: #'Smalltalk::LANInterface.originate().packet'.
 	mseFormalParameter := self model entityNamed: (LANNode mooseNameOf: 'nextNode:(Object).aNode').
-	self assert: mseFormalParameter name == #aNode.
-	self assert: mseFormalParameter mooseName == (LANNode mooseNameOf: 'nextNode:(Object).aNode')	"self assert: mseFormalParameter position = 1"
+	self assert: mseFormalParameter name identicalTo: #aNode.
+	self assert: mseFormalParameter mooseName identicalTo: (LANNode mooseNameOf: 'nextNode:(Object).aNode')	"self assert: mseFormalParameter position = 1"
 ]
 
 { #category : #tests }
@@ -414,11 +409,10 @@ LANImporterTest >> testPoolVariablesAreReified [
 ]
 
 { #category : #tests }
-LANImporterTest >> testReferenceModelInEntities [ 
+LANImporterTest >> testReferenceModelInEntities [
 	"self debug: #testReferenceModelInEntities"
-	
-	self model entities 
-		do: [:each | self assert: each mooseModel == self model]
+
+	self model entities do: [ :each | self assert: each mooseModel identicalTo: self model ]
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/MoosePropertyGroupTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/MoosePropertyGroupTest.class.st
@@ -12,20 +12,14 @@ MoosePropertyGroupTest >> model [
 
 { #category : #tests }
 MoosePropertyGroupTest >> testBasic [
-	|  allClasses propertyGroup |
-	allClasses := {
-		FAMIXClass new numberOfLinesOfCode: 10.
-		FAMIXClass new numberOfLinesOfCode: 20.
-		FAMIXClass new numberOfLinesOfCode: 30 } asMooseGroup.
-	propertyGroup := MoosePropertyGroup
-		withAll: (allClasses copyFrom: 1 to: 2)
-		from: allClasses
-		using: #numberOfLinesOfCode.
-	self assert: propertyGroup originalGroup == allClasses.
-	self assert: propertyGroup property == #numberOfLinesOfCode.
+	| allClasses propertyGroup |
+	allClasses := {(FAMIXClass new numberOfLinesOfCode: 10) . (FAMIXClass new numberOfLinesOfCode: 20) . (FAMIXClass new numberOfLinesOfCode: 30)} asMooseGroup.
+	propertyGroup := MoosePropertyGroup withAll: (allClasses copyFrom: 1 to: 2) from: allClasses using: #numberOfLinesOfCode.
+	self assert: propertyGroup originalGroup identicalTo: allClasses.
+	self assert: propertyGroup property identicalTo: #numberOfLinesOfCode.
 	self assert: propertyGroup propertyRatio equals: 0.5.
 	self assert: propertyGroup propertyTotal equals: 30.
-	self assert: propertyGroup asMooseGroup class == FAMIXClassGroup.
+	self assert: propertyGroup asMooseGroup class identicalTo: FAMIXClassGroup.
 	self assert: propertyGroup propertyTotalOriginal equals: 60.
 	self assert: (propertyGroup sizeRatio * 100) asInteger equals: 66.
 	self assert: propertyGroup sizeOriginal equals: allClasses size


### PR DESCRIPTION
Remove some dependencies to compatibility MM + clean some tests with this script:

```Smalltalk
r := RBParseTreeRewriter new.
r replace: '`@receiver assert: (`@statement1 == `@statement2)' with: '`@receiver assert: `@statement1 identicalTo: `@statement2'.
r replace: '`@receiver assert: (`@statement1 = `@statement2)' with: '`@receiver assert: `@statement1 equals: `@statement2'.

RPackageOrganizer default packages select: [ :e | (e name beginsWith: 'Moose') or: [ e name beginsWith: 'Famix' ] ] thenDo: [ :p | p definedClasses select: [ :e | e inheritsFrom: TestCase ] thenDo: [ :class | 
    
    class methods select: [ :m | m selector beginsWith: 'test' ] thenDo: [ :m |
			| n |
			n := m parseTree.
			(r executeTree: n) ifTrue: [ class compile: n formattedCode] ].
     ] ]
```