### PR TITLE
File-should-have-Folder-as-container

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
@@ -15,10 +15,27 @@ FAMIXAbstractFile class >> annotation [
 	^self
 ]
 
+{ #category : #meta }
+FAMIXAbstractFile class >> requirements [
+
+	<generated>
+	^ { FAMIXFolder }
+]
+
 { #category : #accessing }
 FAMIXAbstractFile >> belongsTo [
-	<navigation: 'parent folder'>
+
+	<generated>
 	^ self parentFolder
+
+]
+
+{ #category : #accessing }
+FAMIXAbstractFile >> belongsTo: anObject [
+
+	<generated>
+	self parentFolder: anObject
+
 ]
 
 { #category : #accessing }

--- a/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
@@ -15,10 +15,25 @@ FamixJavaAbstractFile class >> annotation [
 	^self
 ]
 
+{ #category : #meta }
+FamixJavaAbstractFile class >> requirements [
+
+	<generated>
+	^ { FamixJavaFolder }
+]
+
 { #category : #'as yet unclassified' }
 FamixJavaAbstractFile >> belongsTo [
 	<navigation: 'parent folder'>
 	^ self parentFolder
+]
+
+{ #category : #accessing }
+FamixJavaAbstractFile >> belongsTo: anObject [
+
+	<generated>
+	self parentFolder: anObject
+
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1175,7 +1175,9 @@ FamixGenerator >> defineRelations [
 	((tFolder property: #childrenFileSystemEntities)
 			comment: 'List of entities contained in this folder.')
 		-*
-	((tFileSystemEntity property: #parentFolder)).
+	((tFileSystemEntity property: #parentFolder)
+		comment: 'Folder entity containing this file.';
+		container).
 
 	((tFile property: #entities)
 			comment: 'List of entities defined in the file')

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
@@ -14,3 +14,26 @@ FamixTest1AbstractFile class >> annotation [
 	<generated>
 	^self
 ]
+
+{ #category : #meta }
+FamixTest1AbstractFile class >> requirements [
+
+	<generated>
+	^ { FamixTest1Folder }
+]
+
+{ #category : #accessing }
+FamixTest1AbstractFile >> belongsTo [
+
+	<generated>
+	^ self parentFolder
+
+]
+
+{ #category : #accessing }
+FamixTest1AbstractFile >> belongsTo: anObject [
+
+	<generated>
+	self parentFolder: anObject
+
+]

--- a/src/Famix-Test2-Tests/FamixTest2Test.class.st
+++ b/src/Famix-Test2-Tests/FamixTest2Test.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #OldFamixTest2Test,
+	#name : #FamixTest2Test,
 	#superclass : #TestCase,
 	#instVars : [
 		'model',
@@ -18,7 +18,7 @@ Class {
 }
 
 { #category : #running }
-OldFamixTest2Test >> setUp [
+FamixTest2Test >> setUp [
 
 	super setUp.
 
@@ -48,7 +48,7 @@ OldFamixTest2Test >> setUp [
 ]
 
 { #category : #running }
-OldFamixTest2Test >> testInheritances [
+FamixTest2Test >> testInheritances [
 
 	self assertCollection: (c1 subInheritances collect: #subclass) hasSameElements: { c2. c3 }.
 	self assertCollection: (c2 subInheritances collect: #subclass) hasSameElements: { c4. c5 }.	

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -40,6 +40,8 @@ FamixTFileSystemEntity >> parentFolder [
 	"Relation named: #parentFolder type: #FamixTFolder opposite: #childrenFileSystemEntities"
 
 	<generated>
+	<MSEComment: 'Folder entity containing this file.'>
+	<container>
 	^ parentFolder
 ]
 
@@ -50,4 +52,11 @@ FamixTFileSystemEntity >> parentFolder: anObject [
 	self resetMooseName.
 	
 
+]
+
+{ #category : #navigation }
+FamixTFileSystemEntity >> parentFolderGroup [
+	<generated>
+	<navigation: 'ParentFolder'>
+	^ MooseGroup with: self parentFolder
 ]


### PR DESCRIPTION
FamixTFolder should be the container of FamixTFile via the #pabrentFolder property.