### PR TITLE
Remove-concept-of-primary-container

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFile.class.st
@@ -23,22 +23,6 @@ FAMIXAbstractFile class >> requirements [
 ]
 
 { #category : #accessing }
-FAMIXAbstractFile >> belongsTo [
-
-	<generated>
-	^ self parentFolder
-
-]
-
-{ #category : #accessing }
-FAMIXAbstractFile >> belongsTo: anObject [
-
-	<generated>
-	self parentFolder: anObject
-
-]
-
-{ #category : #accessing }
 FAMIXAbstractFile >> fileReference [ 
 	^ (FileSystem disk referenceTo: (self mooseName copyReplaceAll: self class famixFolderSeparatorString with: FileSystem disk delimiter asString))
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
@@ -23,22 +23,6 @@ FAMIXAnnotationInstance class >> requirements [
 ]
 
 { #category : #accessing }
-FAMIXAnnotationInstance >> belongsTo [
-
-	<generated>
-	^ self annotatedEntity
-
-]
-
-{ #category : #accessing }
-FAMIXAnnotationInstance >> belongsTo: anObject [
-
-	<generated>
-	self annotatedEntity: anObject
-
-]
-
-{ #category : #accessing }
 FAMIXAnnotationInstance >> mooseNameOn: aStream [
 	self annotationType notNil ifTrue: [
 		self annotationType mooseNameOn: aStream ].

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
@@ -22,22 +22,6 @@ FAMIXAnnotationInstanceAttribute class >> requirements [
 	^ { FAMIXAnnotationInstance }
 ]
 
-{ #category : #accessing }
-FAMIXAnnotationInstanceAttribute >> belongsTo [
-
-	<generated>
-	^ self parentAnnotationInstance
-
-]
-
-{ #category : #accessing }
-FAMIXAnnotationInstanceAttribute >> belongsTo: anObject [
-
-	<generated>
-	self parentAnnotationInstance: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FAMIXAnnotationInstanceAttribute >> name [ 
 	^ self annotationTypeAttribute notNil 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
@@ -34,22 +34,6 @@ FAMIXAnnotationType >> annotatedEntitiesGroup [
 ]
 
 { #category : #accessing }
-FAMIXAnnotationType >> belongsTo [
-
-	<generated>
-	^ self annotationTypesContainer
-
-]
-
-{ #category : #accessing }
-FAMIXAnnotationType >> belongsTo: anObject [
-
-	<generated>
-	self annotationTypesContainer: anObject
-
-]
-
-{ #category : #accessing }
 FAMIXAnnotationType >> typeContainer [
 
 	^ self annotationTypesContainer

--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -38,22 +38,6 @@ FAMIXAttribute >> beSharedVariable [
 ]
 
 { #category : #accessing }
-FAMIXAttribute >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FAMIXAttribute >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
-{ #category : #accessing }
 FAMIXAttribute >> hasClassScope [
 	<MSEProperty: #hasClassScope type: #Boolean>
 	<MSEComment: 'True if class-side attribute'>

--- a/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
@@ -21,19 +21,3 @@ FAMIXEnumValue class >> requirements [
 	<generated>
 	^ { FAMIXEnum }
 ]
-
-{ #category : #accessing }
-FAMIXEnumValue >> belongsTo [
-
-	<generated>
-	^ self parentEnum
-
-]
-
-{ #category : #accessing }
-FAMIXEnumValue >> belongsTo: anObject [
-
-	<generated>
-	self parentEnum: anObject
-
-]

--- a/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
@@ -23,22 +23,6 @@ FAMIXFunction class >> requirements [
 ]
 
 { #category : #accessing }
-FAMIXFunction >> belongsTo [
-
-	<generated>
-	^ self functionOwner
-
-]
-
-{ #category : #accessing }
-FAMIXFunction >> belongsTo: anObject [
-
-	<generated>
-	self functionOwner: anObject
-
-]
-
-{ #category : #accessing }
 FAMIXFunction >> container [
 	^ self functionOwner
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
@@ -22,22 +22,6 @@ FAMIXGlobalVariable class >> requirements [
 	^ { FAMIXScopingEntity }
 ]
 
-{ #category : #accessing }
-FAMIXGlobalVariable >> belongsTo [
-
-	<generated>
-	^ self parentScope
-
-]
-
-{ #category : #accessing }
-FAMIXGlobalVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentScope: anObject
-
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXGlobalVariable >> isPrivate [
 	^ self isPublic not

--- a/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
@@ -22,22 +22,6 @@ FAMIXImplicitVariable class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
-{ #category : #accessing }
-FAMIXImplicitVariable >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FAMIXImplicitVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXImplicitVariable >> isSelf [
 	^ self name = #self

--- a/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
@@ -22,22 +22,6 @@ FAMIXLocalVariable class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
-{ #category : #accessing }
-FAMIXLocalVariable >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FAMIXLocalVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXLocalVariable >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -44,22 +44,6 @@ FAMIXMethod >> accessedAttributes [
 	^ (self queryOutgoingAccesses opposites withinParentUsing: FamixTClass) asSet select: #isAttribute
 ]
 
-{ #category : #accessing }
-FAMIXMethod >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FAMIXMethod >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
 { #category : #'Famix-Smalltalk' }
 FAMIXMethod >> category [
 	<MSEProperty: #category type: #String>

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -27,7 +27,7 @@ FAMIXNamedEntity class >> requirements [
 	^ { FAMIXPackage }
 ]
 
-{ #category : #accessing }
+{ #category : #deprecated }
 FAMIXNamedEntity >> belongsTo [
 	
 	^self subclassResponsibility

--- a/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
@@ -22,22 +22,6 @@ FAMIXParameter class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
-{ #category : #accessing }
-FAMIXParameter >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FAMIXParameter >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXParameter >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -56,14 +56,6 @@ FAMIXScopingEntity >> belongsTo [
 	^ self parentScope ifNil: [ self parentPackage ]
 ]
 
-{ #category : #accessing }
-FAMIXScopingEntity >> belongsTo: anObject [
-
-	<generated>
-	self parentScope: anObject
-
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FAMIXScopingEntity >> bunchCohesion [
 	"Computing cohesion (Bunch formula)"

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -62,14 +62,6 @@ FAMIXType >> belongsTo [
 	^ self container ifNil: [ self parentPackage ]
 ]
 
-{ #category : #accessing }
-FAMIXType >> belongsTo: anObject [
-
-	<generated>
-	self typeContainer: anObject
-
-]
-
 { #category : #'Famix-Smalltalk' }
 FAMIXType >> classSide [
 	^self isClassSide

--- a/src/Famix-Groups-Tests/FAMIXInvocationGroupTest.class.st
+++ b/src/Famix-Groups-Tests/FAMIXInvocationGroupTest.class.st
@@ -22,7 +22,7 @@ FAMIXInvocationGroupTest >> setUp [
 	fromMethod := FAMIXMethod new signature: 'fromMethod()'; yourself.
 	fromClass addMethod: fromMethod.
 	fromClass container: fromNamespace.
-	fromNamespace belongsTo: fromNamespaceNamespace.
+	fromNamespace parentScope: fromNamespaceNamespace.
 
 	toNamespaceNamespace := FAMIXNamespace new name: 'com'; yourself.
 	toNamespace := FAMIXNamespace new name: 'to'; yourself.
@@ -30,7 +30,7 @@ FAMIXInvocationGroupTest >> setUp [
 	toMethod := FAMIXMethod new signature: 'toMethod()'; yourself.
 	toClass addMethod: toMethod.
 	toClass container: toNamespace.
-	toNamespace belongsTo: toNamespaceNamespace.
+	toNamespace parentScope: toNamespaceNamespace.
 	
 	invocation := FAMIXInvocation new.
 	invocation from: fromMethod.

--- a/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFile.class.st
@@ -28,14 +28,6 @@ FamixJavaAbstractFile >> belongsTo [
 	^ self parentFolder
 ]
 
-{ #category : #accessing }
-FamixJavaAbstractFile >> belongsTo: anObject [
-
-	<generated>
-	self parentFolder: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAbstractFile >> fileReference [ 
 	^ (FileSystem disk referenceTo: (self mooseName copyReplaceAll: self class famixFolderSeparatorString with: FileSystem disk delimiter asString))

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -22,22 +22,6 @@ FamixJavaAnnotationInstance class >> requirements [
 	^ { FamixJavaNamedEntity }
 ]
 
-{ #category : #accessing }
-FamixJavaAnnotationInstance >> belongsTo [
-
-	<generated>
-	^ self annotatedEntity
-
-]
-
-{ #category : #accessing }
-FamixJavaAnnotationInstance >> belongsTo: anObject [
-
-	<generated>
-	self annotatedEntity: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationInstance >> mooseNameOn: aStream [
 	self annotationType notNil ifTrue: [

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -22,22 +22,6 @@ FamixJavaAnnotationInstanceAttribute class >> requirements [
 	^ { FamixJavaAnnotationInstance }
 ]
 
-{ #category : #accessing }
-FamixJavaAnnotationInstanceAttribute >> belongsTo [
-
-	<generated>
-	^ self parentAnnotationInstance
-
-]
-
-{ #category : #accessing }
-FamixJavaAnnotationInstanceAttribute >> belongsTo: anObject [
-
-	<generated>
-	self parentAnnotationInstance: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationInstanceAttribute >> name [ 
 	^ self annotationTypeAttribute notNil 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -33,22 +33,6 @@ FamixJavaAnnotationType >> annotatedEntitiesGroup [
 	^ self annotatedEntities asMooseGroup
 ]
 
-{ #category : #accessing }
-FamixJavaAnnotationType >> belongsTo [
-
-	<generated>
-	^ self annotationTypesContainer
-
-]
-
-{ #category : #accessing }
-FamixJavaAnnotationType >> belongsTo: anObject [
-
-	<generated>
-	self annotationTypesContainer: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationType >> typeContainer [
 

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -18,22 +18,6 @@ FamixJavaAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixJavaAttribute >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixJavaAttribute >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAttribute >> hasClassScope [
 	<MSEProperty: #hasClassScope type: #Boolean>

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -21,19 +21,3 @@ FamixJavaEnumValue class >> requirements [
 	<generated>
 	^ { FamixJavaEnum }
 ]
-
-{ #category : #accessing }
-FamixJavaEnumValue >> belongsTo [
-
-	<generated>
-	^ self parentEnum
-
-]
-
-{ #category : #accessing }
-FamixJavaEnumValue >> belongsTo: anObject [
-
-	<generated>
-	self parentEnum: anObject
-
-]

--- a/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
@@ -22,22 +22,6 @@ FamixJavaGlobalVariable class >> requirements [
 	^ { FamixJavaScopingEntity }
 ]
 
-{ #category : #accessing }
-FamixJavaGlobalVariable >> belongsTo [
-
-	<generated>
-	^ self parentScope
-
-]
-
-{ #category : #accessing }
-FamixJavaGlobalVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentScope: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaGlobalVariable >> isPrivate [
 	^ self isPublic not

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -15,22 +15,6 @@ FamixJavaImplicitVariable class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixJavaImplicitVariable >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FamixJavaImplicitVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaImplicitVariable >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -15,22 +15,6 @@ FamixJavaLocalVariable class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixJavaLocalVariable >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FamixJavaLocalVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaLocalVariable >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -25,22 +25,6 @@ FamixJavaMethod >> accessedAttributes [
 ]
 
 { #category : #accessing }
-FamixJavaMethod >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixJavaMethod >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
-{ #category : #accessing }
 FamixJavaMethod >> category [
 	<MSEProperty: #category type: #String>
 	<MSEComment: 'Category of the method'>

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -22,7 +22,7 @@ FamixJavaNamedEntity class >> requirements [
 	^ { FamixJavaPackage }
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #deprecated }
 FamixJavaNamedEntity >> belongsTo [
 	
 	^self subclassResponsibility

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -15,22 +15,6 @@ FamixJavaParameter class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixJavaParameter >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FamixJavaParameter >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaParameter >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
@@ -56,14 +56,6 @@ FamixJavaScopingEntity >> belongsTo [
 	^ self parentScope ifNil: [ self parentPackage ]
 ]
 
-{ #category : #accessing }
-FamixJavaScopingEntity >> belongsTo: anObject [
-
-	<generated>
-	self parentScope: anObject
-
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixJavaScopingEntity >> bunchCohesion [
 	"Computing cohesion (Bunch formula)"

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -54,14 +54,6 @@ FamixJavaType >> belongsTo [
 ]
 
 { #category : #accessing }
-FamixJavaType >> belongsTo: anObject [
-
-	<generated>
-	self typeContainer: anObject
-
-]
-
-{ #category : #accessing }
 FamixJavaType >> container [
 
 	<MSEProperty: #container type: #FamixJavaContainerEntity>

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -94,12 +94,6 @@ FmxMBBehavior >> asRelationSideNamed: aPropertyName [
 	^ self property: aPropertyName
 ]
 
-{ #category : #testing }
-FmxMBBehavior >> canProvidePrimaryContainer [
-
-	^ additionalProperties at: #providesPrimaryContainer ifAbsent: [ true ]
-]
-
 { #category : #accessing }
 FmxMBBehavior >> classGeneralization [
 	^ self subclassResponsibility
@@ -491,27 +485,9 @@ FmxMBBehavior >> traitGeneralizations [
 ]
 
 { #category : #accessing }
-FmxMBBehavior >> usedTraitsWithoutPrimaryContainers [
-
-	"all traits that were used without primary container"
-	
-	^ self additionalProperties at: #usedTraitsWithoutPrimaryContainers ifAbsentPut: [ Set new ]
-]
-
-{ #category : #accessing }
 FmxMBBehavior >> uses: aTrait [
 
 	^ self generalization: aTrait
-]
-
-{ #category : #accessing }
-FmxMBBehavior >> usesWithoutPrimaryContainer: aTrait [
-
-	| traitEntity |
-	
-	traitEntity := self generalization: aTrait.
-	self usedTraitsWithoutPrimaryContainers add: aTrait.
-	^ traitEntity
 ]
 
 { #category : #'testing selectors' }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -190,7 +190,6 @@ FmxMBClass >> generate [
 	self generateAnnotationIn: aClass as: self name superclass: nil.
 	
 	self generateTestingMethodsIn: aClass.
-	self generateContainerMethodsIn: aClass.
 	self generateRootMetamodelMethodIn: aClass. 	
 
 	self generateRequirementsFor: aClass.
@@ -200,16 +199,6 @@ FmxMBClass >> generate [
 	
 	self generateNavigationGroupsFor: aClass.
 	self generateAddToCollectionFor: aClass
-]
-
-{ #category : #generating }
-FmxMBClass >> generateContainerMethodsIn: aClass [
-	| primaryContainerProperties |
-	primaryContainerProperties := self primaryContainerProperties.
-
-	primaryContainerProperties size > 1 ifTrue: [ self error: aClass name , ' defines more than one primary container: ' , ((primaryContainerProperties collect: #name) sorted joinUsing: ', ') ].
-
-	primaryContainerProperties do: [ :aSide | aSide generateExtendedContainerMethodsIn: aClass ]
 ]
 
 { #category : #generating }
@@ -309,16 +298,6 @@ FmxMBClass >> isMetamodelClass [
 FmxMBClass >> isRoot [
 
 	^ self classGeneralization isNil
-]
-
-{ #category : #generating }
-FmxMBClass >> primaryContainerProperties [
-	| primaryContainers |
-	primaryContainers := ((self allTraits copyWithoutAll: self usedTraitsWithoutPrimaryContainers) flatCollect: #sides) select: [:side | side isContainer and: [ side providesPrimaryContainer ] ].
-
-	primaryContainers addAll: ((self properties select: #isContainer) select: #providesPrimaryContainer).
-
-	^ primaryContainers
 ]
 
 { #category : #'name conversion' }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBProperty.class.st
@@ -16,10 +16,8 @@ FmxMBProperty >> asSlot [
 
 { #category : #generating }
 FmxMBProperty >> generateAccessorsIn: aClassOrTrait [
-
 	self generateGetterIn: aClassOrTrait.
-	self generateSetterIn: aClassOrTrait.	
-	self generateExtendedContainersIn: aClassOrTrait.
+	self generateSetterIn: aClassOrTrait
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelation.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelation.class.st
@@ -145,6 +145,8 @@ FmxMBRelation >> withoutNavigation [
 
 { #category : #'as yet unclassified' }
 FmxMBRelation >> withoutPrimaryContainer [
-
-	self sides do: [ :aSide | aSide additionalProperties at: #providesPrimaryContainer put: false ]
+	self
+		deprecated:
+			'This is not needed anymore. A generic implementation of #belongsTo was added and if you want to specify the primary container you can add a specific #belongsTo method to your trait/class.'
+		transformWith: '`@receiver withoutPrimaryContainer' -> ''
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
@@ -85,36 +85,6 @@ FmxMBRelationSide >> from [
 ]
 
 { #category : #generating }
-FmxMBRelationSide >> generateExtendedContainerMethodsIn: aClassOrTrait [
-
-	| methodSource |
-	
-	methodSource := String streamContents: [ :s |
-		s nextPutAll: 'belongsTo'; cr; cr.
-		s tab; nextPutAll: '<generated>'; cr.
-		s tab; nextPutAll: '^ self '; nextPutAll: self name; cr ].
-		
-	self builder environment compile: methodSource in: aClassOrTrait classified: 'accessing'.	
-
-	methodSource := String streamContents: [ :s |
-		s nextPutAll: 'belongsTo: anObject'; cr; cr.
-		s tab; nextPutAll: '<generated>'; cr.
-		s tab; nextPutAll: 'self '; nextPutAll: self name; nextPutAll: ': anObject'; cr ].
-		
-	self builder environment compile: methodSource in: aClassOrTrait classified: 'accessing'.	
-
-
-]
-
-{ #category : #generating }
-FmxMBRelationSide >> generateExtendedContainersIn: aClassOrTrait [
-
-	(self additionalProperties at: #primaryContainer ifAbsent: [ false ])
-		ifTrue: [ 
-			self generateExtendedContainerMethodsIn: aClassOrTrait ]
-]
-
-{ #category : #generating }
 FmxMBRelationSide >> generateGetterIn: aClassOrTrait [
 
 	^ generationStrategy generateGetterIn: aClassOrTrait for: self
@@ -286,13 +256,6 @@ FmxMBRelationSide >> producesSlot [
 FmxMBRelationSide >> propertyName [
 
 	^ self relatedClass propertyName
-]
-
-{ #category : #testing }
-FmxMBRelationSide >> providesPrimaryContainer [
-
-	^ self additionalProperties at: #providesPrimaryContainer ifAbsent: [ true ]
-	
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorTest.class.st
@@ -97,22 +97,6 @@ FmxMBBehaviorTest >> testDefaultSuperclass [
 ]
 
 { #category : #tests }
-FmxMBBehaviorTest >> testMultipleContainers [
-
-	| method package class |
-	
-	package := builder newClassNamed: #Package.    
-	method := builder newClassNamed: #Method.    
-	class := builder newClassNamed: #Class.    
-
-	(package <>-* class). 
-	(class <>-* method). 
-	(package <>-* method).
-
-	self assert: method primaryContainerProperties size > 1.
-]
-
-{ #category : #tests }
 FmxMBBehaviorTest >> testPluralOf [
 
 	| behavior | 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderRelationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderRelationTest.class.st
@@ -27,7 +27,7 @@ FmxMBBuilderRelationTest >> checkArrow: aBinarySelector from: cardinality1 to: c
 	self assert: generatedTClass slots size equals: 1.
 	self assert: generatedTClass slots first name equals: #property1.
 	self assert: generatedTClass slots first expression equals: cardinality1, ' type: #TstTComment opposite: #property2'.
-	self assertCollection: (generatedTClass instanceSide selectors copyWithoutAll: { #addProperty1:. #property1Group. #property2Group. #belongsTo. #belongsTo:}) hasSameElements: #(property1 property1:).
+	self assertCollection: (generatedTClass instanceSide selectors copyWithoutAll: { #addProperty1:. #property1Group. #property2Group.}) hasSameElements: #(property1 property1:).
 	hasContainer := (generatedTClass methodNamed: #property1) sourceCode includesSubstring: '<container>'.
 	containerFrom 
 		ifTrue: [ self assert: hasContainer ]
@@ -36,7 +36,7 @@ FmxMBBuilderRelationTest >> checkArrow: aBinarySelector from: cardinality1 to: c
 	self assert: generatedTComment slots size equals: 1.
 	self assert: generatedTComment slots first name equals: #property2.
 	self assert: generatedTComment slots first expression equals: cardinality2, ' type: #TstTClass opposite: #property1'.
-	self assertCollection: (generatedTComment instanceSide selectors copyWithoutAll: { #addProperty2:. #property1Group. #property2Group. #belongsTo. #belongsTo:}) hasSameElements: #(property2 property2:).
+	self assertCollection: (generatedTComment instanceSide selectors copyWithoutAll: { #addProperty2:. #property1Group. #property2Group.}) hasSameElements: #(property2 property2:).
 	hasContainer := (generatedTComment methodNamed: #property2) sourceCode includesSubstring: '<container>'.
 	containerTo
 		ifTrue: [ self assert: hasContainer ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
@@ -379,65 +379,6 @@ FmxMBClassTest >> testMultipleClasses [
 ]
 
 { #category : #tests }
-FmxMBClassTest >> testPrimaryContainerCombined [
-
-	| tPackage tPackageable method package class env |
-
-	tPackage := builder newTraitNamed: #TPackage.
-	tPackageable := builder newTraitNamed: #TPackageable.
-	
-	tPackage <>-* tPackageable. 
-
-	package := builder newClassNamed: #Package.    
-	method := builder newClassNamed: #Method.    
-	class := builder newClassNamed: #Class.    
-
-	package --|> tPackage.
-	class --|> tPackageable.
-	(class <>-* method). 
-	method usesWithoutPrimaryContainer: tPackageable.
-	
-	self assert: package primaryContainerProperties size equals: 0.
-	self assert: class primaryContainerProperties size equals: 1.
-	self assert: method primaryContainerProperties size equals: 1.
-	
-	builder generate.
-	
-	env := builder environment ringEnvironment.
-	
-	self assert: ((env ask classNamed: #TstPackage) methodNamed: 'belongsTo') isNil.
-	self assert: (((env ask classNamed: #TstMethod) methodNamed: 'belongsTo') sourceCode includesSubstring: '^ self class').
-	self assert: (((env ask classNamed: #TstClass) methodNamed: 'belongsTo') sourceCode includesSubstring: '^ self package').
-]
-
-{ #category : #tests }
-FmxMBClassTest >> testPrimaryContainerFromTraits [
-
-	| tMethod tWithMethods method class env |
-	
-	tMethod := builder newTraitNamed: #TMethod.
-	tWithMethods := builder newTraitNamed: #TWithMethods.
-	
-	tWithMethods <>-* tMethod. 
-
-	class := builder newClassNamed: #Class.    
-	method := builder newClassNamed: #Method.    
-
-	class --|> tWithMethods.
-	tMethod <|-- method.
-	
-	self assert: method primaryContainerProperties size equals: 1.
-	
-	builder generate.
-	
-	env := builder environment ringEnvironment.
-	
-	self assert: ((env ask classNamed: #TstClass) methodNamed: 'belongsTo') isNil.
-	self assert: (((env ask classNamed: #TstMethod) methodNamed: 'belongsTo') sourceCode includesSubstring: '^ self withMethods').
-
-]
-
-{ #category : #tests }
 FmxMBClassTest >> testPrimaryContainerWithoutTraits [
 
 	| method package class env |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -23,22 +23,6 @@ FamixStAnnotationInstance class >> requirements [
 ]
 
 { #category : #accessing }
-FamixStAnnotationInstance >> belongsTo [
-
-	<generated>
-	^ self annotatedEntity
-
-]
-
-{ #category : #accessing }
-FamixStAnnotationInstance >> belongsTo: anObject [
-
-	<generated>
-	self annotatedEntity: anObject
-
-]
-
-{ #category : #accessing }
 FamixStAnnotationInstance >> name [
 	^ String
 		streamContents: [ :stream | 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -23,22 +23,6 @@ FamixStAnnotationInstanceAttribute class >> requirements [
 ]
 
 { #category : #accessing }
-FamixStAnnotationInstanceAttribute >> belongsTo [
-
-	<generated>
-	^ self parentAnnotationInstance
-
-]
-
-{ #category : #accessing }
-FamixStAnnotationInstanceAttribute >> belongsTo: anObject [
-
-	<generated>
-	self parentAnnotationInstance: anObject
-
-]
-
-{ #category : #accessing }
 FamixStAnnotationInstanceAttribute >> name [ 
 	^ self annotationTypeAttribute notNil 
 		ifTrue: [ self annotationTypeAttribute name ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -22,22 +22,6 @@ FamixStAnnotationType class >> requirements [
 	^ { FamixStContainerEntity }
 ]
 
-{ #category : #accessing }
-FamixStAnnotationType >> belongsTo [
-
-	<generated>
-	^ self annotationTypesContainer
-
-]
-
-{ #category : #accessing }
-FamixStAnnotationType >> belongsTo: anObject [
-
-	<generated>
-	self annotationTypesContainer: anObject
-
-]
-
 { #category : #compatibility }
 FamixStAnnotationType >> directSubclasses [
 	^ OrderedCollection new

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -31,22 +31,6 @@ FamixStAttribute >> beSharedVariable [
 	self propertyNamed: #sharedVariable put: true 
 ]
 
-{ #category : #accessing }
-FamixStAttribute >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixStAttribute >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
 { #category : #testing }
 FamixStAttribute >> hasClassScope [
 	<MSEProperty: #hasClassScope type: #Boolean>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -21,19 +21,3 @@ FamixStGlobalVariable class >> requirements [
 	<generated>
 	^ { FamixStScopingEntity }
 ]
-
-{ #category : #accessing }
-FamixStGlobalVariable >> belongsTo [
-
-	<generated>
-	^ self parentScope
-
-]
-
-{ #category : #accessing }
-FamixStGlobalVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentScope: anObject
-
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -15,22 +15,6 @@ FamixStImplicitVariable class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixStImplicitVariable >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FamixStImplicitVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
 { #category : #testing }
 FamixStImplicitVariable >> isSelf [
 	^ self name = #self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
@@ -16,22 +16,6 @@ FamixStLocalVariable class >> annotation [
 ]
 
 { #category : #accessing }
-FamixStLocalVariable >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FamixStLocalVariable >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
-{ #category : #accessing }
 FamixStLocalVariable >> mooseNameOn: stream [ 
 	| parent |
 	parent := self parentBehaviouralEntity.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -27,22 +27,6 @@ FamixStMethod >> accessedAttributes [
 	^ (self queryOutgoingAccesses opposites withinParentUsing: FamixTClass) asSet select: #isAttribute
 ]
 
-{ #category : #accessing }
-FamixStMethod >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixStMethod >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> category: aString [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -22,22 +22,6 @@ FamixStNamedEntity class >> requirements [
 	^ { FamixStPackage }
 ]
 
-{ #category : #accessing }
-FamixStNamedEntity >> belongsTo [
-
-	<generated>
-	^ self parentPackage
-
-]
-
-{ #category : #accessing }
-FamixStNamedEntity >> belongsTo: anObject [
-
-	<generated>
-	self parentPackage: anObject
-
-]
-
 { #category : #'Famix-Extensions' }
 FamixStNamedEntity >> stubFormattedName [
 	 ^ self isStub 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
@@ -16,22 +16,6 @@ FamixStParameter class >> annotation [
 ]
 
 { #category : #accessing }
-FamixStParameter >> belongsTo [
-
-	<generated>
-	^ self parentBehaviouralEntity
-
-]
-
-{ #category : #accessing }
-FamixStParameter >> belongsTo: anObject [
-
-	<generated>
-	self parentBehaviouralEntity: anObject
-
-]
-
-{ #category : #accessing }
 FamixStParameter >> mooseNameOn: stream [ 
 	| parent |
 	parent := self parentBehaviouralEntity.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
@@ -41,11 +41,3 @@ FamixStScopingEntity >> allClasses [
 FamixStScopingEntity >> belongsTo [
 	^ self parentScope ifNil: [ self parentPackage ]
 ]
-
-{ #category : #accessing }
-FamixStScopingEntity >> belongsTo: anObject [
-
-	<generated>
-	self parentScope: anObject
-
-]

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFile.class.st
@@ -21,19 +21,3 @@ FamixTest1AbstractFile class >> requirements [
 	<generated>
 	^ { FamixTest1Folder }
 ]
-
-{ #category : #accessing }
-FamixTest1AbstractFile >> belongsTo [
-
-	<generated>
-	^ self parentFolder
-
-]
-
-{ #category : #accessing }
-FamixTest1AbstractFile >> belongsTo: anObject [
-
-	<generated>
-	self parentFolder: anObject
-
-]

--- a/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
@@ -14,19 +14,3 @@ FamixTest1Attribute class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #accessing }
-FamixTest1Attribute >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixTest1Attribute >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]

--- a/src/Famix-Test1-Entities/FamixTest1Method.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Method.class.st
@@ -15,22 +15,6 @@ FamixTest1Method class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixTest1Method >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixTest1Method >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]
-
 { #category : #printing }
 FamixTest1Method >> mooseNameOn: stream [  
 

--- a/src/Famix-Test1-Tests/OldFamixTMethodTest.class.st
+++ b/src/Famix-Test1-Tests/OldFamixTMethodTest.class.st
@@ -45,14 +45,7 @@ OldFamixTMethodTest >> setUp [
 
 { #category : #tests }
 OldFamixTMethodTest >> testBelongsTo [
-
-	self assert: m1 belongsTo equals: c1.
-	
-	m1 belongsTo: c2.
-	self assert: m1 parentType equals: c2.
-	self assert: c1 numberOfMethods equals: 0.
-	self assert: (c2 methods includes: m1).
-
+	self assert: m1 belongsTo equals: c1
 ]
 
 { #category : #tests }

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -166,14 +166,7 @@ TEntityMetaLevelDependencyTest >> testAllWithScope [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testBelongsTo [
-
-	self assert: m1 belongsTo equals: c1.
-	
-	m1 belongsTo: c2.
-	self assert: m1 parentType equals: c2.
-	self assert: c1 numberOfMethods equals: 0.
-	self assert: (c2 methods includes: m1).
-
+	self assert: m1 belongsTo equals: c1
 ]
 
 { #category : #tests }

--- a/src/Famix-Test3-Entities/FamixTest3Method.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Method.class.st
@@ -14,19 +14,3 @@ FamixTest3Method class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #accessing }
-FamixTest3Method >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixTest3Method >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]

--- a/src/Famix-Test3-Entities/FamixTest3Type.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Type.class.st
@@ -21,19 +21,3 @@ FamixTest3Type class >> requirements [
 	<generated>
 	^ { FamixTest3PrimitiveType }
 ]
-
-{ #category : #accessing }
-FamixTest3Type >> belongsTo [
-
-	<generated>
-	^ self typeContainer
-
-]
-
-{ #category : #accessing }
-FamixTest3Type >> belongsTo: anObject [
-
-	<generated>
-	self typeContainer: anObject
-
-]

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -24,22 +24,6 @@ FamixTest4Book class >> requirements [
 ]
 
 { #category : #accessing }
-FamixTest4Book >> belongsTo [
-
-	<generated>
-	^ self person
-
-]
-
-{ #category : #accessing }
-FamixTest4Book >> belongsTo: anObject [
-
-	<generated>
-	self person: anObject
-
-]
-
-{ #category : #accessing }
 FamixTest4Book >> person [
 	"Relation named: #person type: #FamixTest4Person opposite: #books"
 

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -24,22 +24,6 @@ FamixTest4Principal class >> requirements [
 ]
 
 { #category : #accessing }
-FamixTest4Principal >> belongsTo [
-
-	<generated>
-	^ self school
-
-]
-
-{ #category : #accessing }
-FamixTest4Principal >> belongsTo: anObject [
-
-	<generated>
-	self school: anObject
-
-]
-
-{ #category : #accessing }
 FamixTest4Principal >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #principal"
 

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -24,22 +24,6 @@ FamixTest4Room class >> requirements [
 ]
 
 { #category : #accessing }
-FamixTest4Room >> belongsTo [
-
-	<generated>
-	^ self school
-
-]
-
-{ #category : #accessing }
-FamixTest4Room >> belongsTo: anObject [
-
-	<generated>
-	self school: anObject
-
-]
-
-{ #category : #accessing }
 FamixTest4Room >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #rooms"
 

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -31,22 +31,6 @@ FamixTest4Student >> addTeachers: anObject [
 ]
 
 { #category : #accessing }
-FamixTest4Student >> belongsTo [
-
-	<generated>
-	^ self school
-
-]
-
-{ #category : #accessing }
-FamixTest4Student >> belongsTo: anObject [
-
-	<generated>
-	self school: anObject
-
-]
-
-{ #category : #accessing }
 FamixTest4Student >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #students"
 

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -31,22 +31,6 @@ FamixTest4Teacher >> addStudents: anObject [
 ]
 
 { #category : #accessing }
-FamixTest4Teacher >> belongsTo [
-
-	<generated>
-	^ self school
-
-]
-
-{ #category : #accessing }
-FamixTest4Teacher >> belongsTo: anObject [
-
-	<generated>
-	self school: anObject
-
-]
-
-{ #category : #accessing }
 FamixTest4Teacher >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #teachers"
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
@@ -14,19 +14,3 @@ FamixTestComposed1Method class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #accessing }
-FamixTestComposed1Method >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixTestComposed1Method >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
@@ -14,19 +14,3 @@ FamixTestComposed2Method class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #accessing }
-FamixTestComposed2Method >> belongsTo [
-
-	<generated>
-	^ self parentType
-
-]
-
-{ #category : #accessing }
-FamixTestComposed2Method >> belongsTo: anObject [
-
-	<generated>
-	self parentType: anObject
-
-]

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -502,6 +502,22 @@ TEntityMetaLevelDependency >> atScope: aClassFAMIX until: rejectBlock [
 	^ (self atScope: aClassFAMIX in: OrderedCollection new until: rejectBlock) asSet asArray
 ]
 
+{ #category : #deprecated }
+TEntityMetaLevelDependency >> belongsTo [
+	"Return the primary container of the entity if it exist"
+
+	"/!\ Please do not use me. 
+	It does not make sense to have a 'primary' container since the models do not have a containment tree but a containment DAG. 
+	This method will be deprecated in the future when we will rewrite the users to use #parents."
+
+	^ self parents ifNotEmpty: #anyOne ifEmpty: [ nil ]
+]
+
+{ #category : #deprecated }
+TEntityMetaLevelDependency >> belongsTo: anEntity [
+	self deprecated: 'belongsTo will be removed in the future. Use the explicit setter for the property you''re trying to set instead. Such has #parentScope, #typeContainer, ...'
+]
+
 { #category : #accessing }
 TEntityMetaLevelDependency >> children [
 	| res |


### PR DESCRIPTION
Remove the concept of primary container from the generator and use MooseQuery to create #belongsTo.