### PR TITLE
Remove-code-from-before-submetamodels

### DIFF
--- a/src/Famix-BasicInfrastructure/FamixBasicInfrastructureGenerator.class.st
+++ b/src/Famix-BasicInfrastructure/FamixBasicInfrastructureGenerator.class.st
@@ -15,19 +15,6 @@ Class {
 	#category : #'Famix-BasicInfrastructure'
 }
 
-{ #category : #accessing }
-FamixBasicInfrastructureGenerator class >> basicMetamodelClasses [
-
-	| classes |
-	
-	classes := super basicMetamodelClasses.	
-	classes addAll: self basicFamixTraits.
-	
-	^ classes
-	
-	
-]
-
 { #category : #testing }
 FamixBasicInfrastructureGenerator class >> isAbstract [
 	^ self = FamixBasicInfrastructureGenerator


### PR DESCRIPTION
There is now no need to override #basicMetamdelClasses since FamixGenerator is a subMM.