### PR TITLE
Relation-oppositeType-can-be-wrong-in-composed-models

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBNonremoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBNonremoteRelationSideGenerationStrategy.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #FmxMBNonremoteRelationSideGenerationStrategy,
+	#name : #FmxMBNonRemoteRelationSideGenerationStrategy,
 	#superclass : #FmxMBRelationSideGenerationStrategy,
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
 
 { #category : #printing }
-FmxMBNonremoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+FmxMBNonRemoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
 
 	aStream tab; nextPutAll: ('<MSEProperty: #{1} type: #Object>' format: {aRelationSide name}).
 	aStream cr.
@@ -33,7 +33,7 @@ FmxMBNonremoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTr
 ]
 
 { #category : #printing }
-FmxMBNonremoteRelationSideGenerationStrategy >> generateSetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+FmxMBNonRemoteRelationSideGenerationStrategy >> generateSetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
 
 	((aRelationSide cardinality = #one) and: [aRelationSide otherSide cardinality = #one])
 		ifTrue: [ 
@@ -64,7 +64,7 @@ FmxMBNonremoteRelationSideGenerationStrategy >> generateSetterCoreIn: aClassOrTr
 ]
 
 { #category : #printing }
-FmxMBNonremoteRelationSideGenerationStrategy >> producesSlot [
+FmxMBNonRemoteRelationSideGenerationStrategy >> producesSlot [
 
 	^ false
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
@@ -181,7 +181,7 @@ FmxMBRelationSide >> isTarget [
 { #category : #converting }
 FmxMBRelationSide >> makeNonremote [
 
-	self generationStrategy: (FmxMBNonremoteRelationSideGenerationStrategy for: self)
+	self generationStrategy: (FmxMBNonRemoteRelationSideGenerationStrategy for: self)
 ]
 
 { #category : #converting }
@@ -228,7 +228,7 @@ FmxMBRelationSide >> oppositeName [
 
 { #category : #accessing }
 FmxMBRelationSide >> oppositeType [
-	^ (self builder configuration prefix , self otherSide relatedEntityName) asSymbol
+	^ (self otherSide builder configuration prefix , self otherSide relatedEntityName) asSymbol
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRemoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRemoteRelationSideGenerationStrategy.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FmxMBRemoteRelationSideGenerationStrategy,
-	#superclass : #FmxMBNonremoteRelationSideGenerationStrategy,
+	#superclass : #FmxMBNonRemoteRelationSideGenerationStrategy,
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSideTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSideTest.class.st
@@ -79,6 +79,45 @@ FmxMBRelationSideTest >> testDirections [
 ]
 
 { #category : #tests }
+FmxMBRelationSideTest >> testOppositeName [
+	| aClass aTrait relation |
+	
+	builder configuration prefix: 'Banane'.
+	aClass := builder newClassNamed: #AClass.
+	aTrait := builder newTraitNamed: #ATrait.
+	
+	relation := aClass <>- aTrait.
+	self assert: relation left oppositeName equals: 'aClass'
+]
+
+{ #category : #tests }
+FmxMBRelationSideTest >> testOppositeType [
+	| aClass aTrait relation |
+	
+	builder configuration prefix: 'Banane'.
+	aClass := builder newClassNamed: #AClass.
+	aTrait := builder newTraitNamed: #ATrait.
+	
+	relation := aClass <>- aTrait.
+	self assert: relation left oppositeType equals: 'BananeATrait'
+]
+
+{ #category : #tests }
+FmxMBRelationSideTest >> testOppositeTypeInRemoteBuilder [
+	| builder2 aClass aTrait relation |
+	builder configuration prefix: 'Banane'.
+	
+	builder2 := FamixMetamodelBuilder forTesting.
+	builder2 configuration prefix: 'Furry'.
+	
+	aClass := builder newClassNamed: #AClass.
+	aTrait := builder2 newTraitNamed: #ATrait.
+	
+	relation := aClass <>- aTrait.
+	self assert: relation left oppositeType equals: 'FurryATrait'
+]
+
+{ #category : #tests }
 FmxMBRelationSideTest >> testProperties [
 
 	"simple tests of basic relation side properties"
@@ -243,21 +282,19 @@ FmxMBRelationSideTest >> testRelations [
 
 { #category : #tests }
 FmxMBRelationSideTest >> testSetRelatedEntity [
-
 	"test setting of a type of the property"
 
-	| aClass aTrait anAlias other relationSide |
-	
+	| aClass aTrait anAlias relationSide |
 	aClass := builder newClassNamed: #AClass.
 	aTrait := builder newTraitNamed: #ATrait.
 	anAlias := (builder newClassNamed: #AnAliasParent) as: #AnAlias.
-	other := builder newClassNamed: #Other.
+	builder newClassNamed: #Other.
 
 	relationSide := FmxMBRelationSide new.
 	relationSide relatedEntity: aClass.
 	self assert: relationSide relatedClass equals: aClass.
 	self assert: relationSide trait equals: nil.
-	
+
 	relationSide := FmxMBRelationSide new.
 	relationSide relatedEntity: aTrait.
 	self assert: relationSide relatedClass equals: nil.
@@ -266,7 +303,5 @@ FmxMBRelationSideTest >> testSetRelatedEntity [
 	relationSide := FmxMBRelationSide new.
 	relationSide relatedEntity: anAlias.
 	self assert: relationSide relatedClass equals: nil.
-	self assert: relationSide trait equals: (builder ensureTraitNamed: #AnAlias).
-
-
+	self assert: relationSide trait equals: (builder ensureTraitNamed: #AnAlias)
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed1CustomEntity1 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity1 >> c21 [
-	"Relation named: #c21 type: #FamixTestComposed1CustomEntity1 opposite: #c11"
+	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11"
 
 	<generated>
 	<MSEProperty: #c21 type: #Object>
@@ -26,7 +26,7 @@ FamixTestComposed1CustomEntity1 >> c21: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity1 >> customEntity1 [
-	"Relation named: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1"
+	"Relation named: #customEntity1 type: #FamixTestComposedCustomEntity1 opposite: #customEntity1"
 
 	<generated>
 	<container>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed1CustomEntity2 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity2 >> c22s [
-	"Relation named: #c22s type: #FamixTestComposed1CustomEntity2 opposite: #c12"
+	"Relation named: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12"
 
 	<generated>
 	<derived>
@@ -20,7 +20,7 @@ FamixTestComposed1CustomEntity2 >> c22s: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity2 >> customEntity2 [
-	"Relation named: #customEntity2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntities2"
+	"Relation named: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2"
 
 	<generated>
 	<MSEProperty: #customEntity2 type: #Object>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed1CustomEntity3 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity3 >> c23 [
-	"Relation named: #c23 type: #FamixTestComposed1CustomEntity3 opposite: #c13s"
+	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s"
 
 	<generated>
 	<MSEProperty: #c23 type: #Object>
@@ -19,7 +19,7 @@ FamixTestComposed1CustomEntity3 >> c23: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity3 >> customEntities3 [
-	"Relation named: #customEntities3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntity3"
+	"Relation named: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed1CustomEntity4 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity4 >> c24s [
-	"Relation named: #c24s type: #FamixTestComposed1CustomEntity4 opposite: #c14s"
+	"Relation named: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s"
 
 	<generated>
 	<derived>
@@ -20,7 +20,7 @@ FamixTestComposed1CustomEntity4 >> c24s: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity4 >> customEntities4 [
-	"Relation named: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4"
+	"Relation named: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4"
 
 	<generated>
 	<MSEProperty: #customEntities4 type: #Object>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed1CustomEntity5 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1CustomEntity5 >> associations [
-	"Relation named: #associations type: #FamixTestComposed1Association opposite: #c15"
+	"Relation named: #associations type: #FamixTestComposedAssociation opposite: #c15"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed1Method }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed1Method >> entity [
-	"Relation named: #entity type: #FamixTestComposed1Entity opposite: #method"
+	"Relation named: #entity type: #FamixTestComposedEntity opposite: #method"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed2CustomEntity1 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity1 >> c1 [
-	"Relation named: #c1 type: #FamixTestComposed2CustomEntity1 opposite: #c21"
+	"Relation named: #c1 type: #FamixTestComposedCustomEntity1 opposite: #c21"
 
 	<generated>
 	<derived>
@@ -13,7 +13,7 @@ FamixTestComposed2CustomEntity1 >> c1 [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity1 >> c11 [
-	"Relation named: #c11 type: #FamixTestComposed2CustomEntity1 opposite: #c21"
+	"Relation named: #c11 type: #FamixTestComposed1CustomEntity1 opposite: #c21"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed2CustomEntity2 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity2 >> c12 [
-	"Relation named: #c12 type: #FamixTestComposed2CustomEntity2 opposite: #c22s"
+	"Relation named: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s"
 
 	<generated>
 	<MSEProperty: #c12 type: #Object>
@@ -19,7 +19,7 @@ FamixTestComposed2CustomEntity2 >> c12: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity2 >> c2 [
-	"Relation named: #c2 type: #FamixTestComposed2CustomEntity2 opposite: #c22s"
+	"Relation named: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s"
 
 	<generated>
 	<MSEProperty: #c2 type: #Object>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed2CustomEntity3 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity3 >> c13s [
-	"Relation named: #c13s type: #FamixTestComposed2CustomEntity3 opposite: #c23"
+	"Relation named: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23"
 
 	<generated>
 	<derived>
@@ -20,7 +20,7 @@ FamixTestComposed2CustomEntity3 >> c13s: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity3 >> c3s [
-	"Relation named: #c3s type: #FamixTestComposed2CustomEntity3 opposite: #c23"
+	"Relation named: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed2CustomEntity4 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity4 >> c14s [
-	"Relation named: #c14s type: #FamixTestComposed2CustomEntity4 opposite: #c24s"
+	"Relation named: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s"
 
 	<generated>
 	<MSEProperty: #c14s type: #Object>
@@ -19,7 +19,7 @@ FamixTestComposed2CustomEntity4 >> c14s: anObject [
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity4 >> c4s [
-	"Relation named: #c4s type: #FamixTestComposed2CustomEntity4 opposite: #c24s"
+	"Relation named: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s"
 
 	<generated>
 	<MSEProperty: #c4s type: #Object>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FamixTestComposed2CustomEntity5 }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
 FamixTestComposed2CustomEntity5 >> associations [
-	"Relation named: #associations type: #FamixTestComposed2Association opposite: #c25"
+	"Relation named: #associations type: #FamixTestComposedAssociation opposite: #c25"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -17,7 +17,7 @@ FamixTestComposedAssociation class >> annotation [
 
 { #category : #accessing }
 FamixTestComposedAssociation >> c15 [
-	"Relation named: #c15 type: #FamixTestComposedCustomEntity5 opposite: #associations"
+	"Relation named: #c15 type: #FamixTestComposed1CustomEntity5 opposite: #associations"
 
 	<generated>
 	<target>
@@ -34,7 +34,7 @@ FamixTestComposedAssociation >> c15: anObject [
 
 { #category : #accessing }
 FamixTestComposedAssociation >> c25 [
-	"Relation named: #c25 type: #FamixTestComposedCustomEntity5 opposite: #associations"
+	"Relation named: #c25 type: #FamixTestComposed2CustomEntity5 opposite: #associations"
 
 	<generated>
 	<source>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -22,7 +22,7 @@ FamixTestComposedCustomEntity1 class >> metamodel [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity1 >> c21 [
-	"Relation named: #c21 type: #FamixTestComposedCustomEntity1 opposite: #c1"
+	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1"
 
 	<generated>
 	<MSEProperty: #c21 type: #Object>
@@ -45,7 +45,7 @@ FamixTestComposedCustomEntity1 >> c21: anObject [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity1 >> customEntity1 [
-	"Relation named: #customEntity1 type: #FamixTestComposedCustomEntity1 opposite: #customEntity1"
+	"Relation named: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1"
 
 	<generated>
 	<MSEProperty: #customEntity1 type: #Object>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -22,7 +22,7 @@ FamixTestComposedCustomEntity2 class >> metamodel [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity2 >> c22s [
-	"Relation named: #c22s type: #FamixTestComposedCustomEntity2 opposite: #c2"
+	"Relation named: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2"
 
 	<generated>
 	<derived>
@@ -39,7 +39,7 @@ FamixTestComposedCustomEntity2 >> c22s: anObject [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity2 >> customEntities2 [
-	"Relation named: #customEntities2 type: #FamixTestComposedCustomEntity2 opposite: #customEntity2"
+	"Relation named: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -22,7 +22,7 @@ FamixTestComposedCustomEntity3 class >> metamodel [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity3 >> c23 [
-	"Relation named: #c23 type: #FamixTestComposedCustomEntity3 opposite: #c3s"
+	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s"
 
 	<generated>
 	<MSEProperty: #c23 type: #Object>
@@ -38,7 +38,7 @@ FamixTestComposedCustomEntity3 >> c23: anObject [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity3 >> customEntity3 [
-	"Relation named: #customEntity3 type: #FamixTestComposedCustomEntity3 opposite: #customEntities3"
+	"Relation named: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3"
 
 	<generated>
 	<MSEProperty: #customEntity3 type: #Object>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -22,7 +22,7 @@ FamixTestComposedCustomEntity4 class >> metamodel [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity4 >> c24s [
-	"Relation named: #c24s type: #FamixTestComposedCustomEntity4 opposite: #c4s"
+	"Relation named: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s"
 
 	<generated>
 	<derived>
@@ -39,7 +39,7 @@ FamixTestComposedCustomEntity4 >> c24s: anObject [
 
 { #category : #accessing }
 FamixTestComposedCustomEntity4 >> customEntities4 [
-	"Relation named: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4"
+	"Relation named: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4"
 
 	<generated>
 	<derived>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -22,7 +22,7 @@ FamixTestComposedEntity class >> metamodel [
 
 { #category : #accessing }
 FamixTestComposedEntity >> method [
-	"Relation named: #method type: #FamixTestComposedMethod opposite: #entity"
+	"Relation named: #method type: #FamixTestComposed1Method opposite: #entity"
 
 	<generated>
 	<MSEProperty: #method type: #Object>


### PR DESCRIPTION
Fix names of #oppositeType in relations.