### PR TITLE
1892-Composed-MM-properties-should-be-created-by-the-pragma-processor-and-not-the-generator

### DIFF
--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -43,7 +43,8 @@ Class {
 		'oppositeDict',
 		'packPropDict',
 		'mmClassDict',
-		'queue'
+		'queue',
+		'implementingPackages'
 	],
 	#classVars : [
 		'ShouldValidateMetaModel'
@@ -176,6 +177,13 @@ FMPragmaProcessor >> initialize [
 		put: FM3MetaDescription object
 ]
 
+{ #category : #private }
+FMPragmaProcessor >> methodsToProcessFrom: aClass [
+	"We need to process the methods from the class and the extensions methods comming from the packages containing the entites. We should reject extension methods comming from other packages."
+
+	^ aClass methods select: [ :method | method isExtension not or: [ implementingPackages includes: method package ] ]
+]
+
 { #category : #accessing }
 FMPragmaProcessor >> packages [
 	^ elements select: [ :e | e isFM3Package ]
@@ -206,19 +214,17 @@ FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 	superclassDict at: meta put: superclassName.
 	meta setImplementingClass: aClass.
 	pragma
-		ifNotEmpty: [ (Pragma inMethod: pragma first method named: #abstract)
-				ifNotNil: [ meta isAbstract: true ].
+		ifNotEmpty: [ (Pragma inMethod: pragma first method named: #abstract) ifNotNil: [ meta isAbstract: true ].
 			(Pragma inMethod: pragma first method named: #package:)
 				ifNotNil: [ :p | 
 					| packageName |
 					packageName := p argumentAt: 1.
-					(self allowPackageNamed: packageName)
-						ifFalse: [ ^ self ].
+					(self allowPackageNamed: packageName) ifFalse: [ ^ self ].
 					packMetaDict at: meta put: packageName asString ] ].
 	elements add: meta.
 	classDict at: aClass put: meta.
-	aClass methods do: [ :each | self processCompiledMethod: each ].
-	aClass slots do: [ :each | self processSlot: each in: aClass].
+	(self methodsToProcessFrom: aClass) do: [ :each | self processCompiledMethod: each ].
+	aClass slots do: [ :each | self processSlot: each in: aClass ].
 	self assert: meta isFM3Class.
 	^ meta
 ]
@@ -356,6 +362,7 @@ FMPragmaProcessor >> resolveObjectReferences [
 
 { #category : #running }
 FMPragmaProcessor >> run [
+	implementingPackages := (queue collectAsSet: #package).
 	queue do: [ :cls | self processClass: cls ].
 	self resolveObjectReferences.
 	self class shouldValidateMetaModel

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -80,37 +80,6 @@ FamixMetamodelGenerator class >> composedMetaModels [
 	^ self allSubclasses select: [ :mm | mm isAbstract not and: [ mm isComposed ] ]
 ]
 
-{ #category : #accessing }
-FamixMetamodelGenerator class >> fixRemoteMetamodelRelationsIn: aMetamodel [
-
-	"Description of relations that are created between composed meta-models are not 
-	correct because they are created only from the information that the describing 
-	method provide. It needs to be fixed using the information that the builder 
-	provides."
-
-	| remoteRelations aBuilder |
-	
-	aBuilder := self builderWithDefinitions.
-	remoteRelations := aBuilder relations select: [ :aRelation | aRelation sides anySatisfy: #isRemote ].
-	
-	remoteRelations do: [ :aRelation |
-		| class1 class2 property1 property2 |
-		
-		class1 := Smalltalk globals at: aRelation side relatedEntity fullName.
-		class2 := Smalltalk globals at: aRelation oppositeSide relatedEntity fullName.
-			
-		property1 := (aMetamodel descriptionOf: class1) attributeNamed: aRelation side name.
-		property2 := (aMetamodel descriptionOf: class2) attributeNamed: aRelation oppositeSide name.
-		property1 opposite: property2.
-		property2 opposite: property1.
-		property1 type setImplementingClass: class2.	
-		property2 type setImplementingClass: class1.
-	]
-	
-
-
-]
-
 { #category : #generation }
 FamixMetamodelGenerator class >> generate [
 
@@ -190,11 +159,6 @@ FamixMetamodelGenerator class >> metamodelsToGenerate [
 ]
 
 { #category : #accessing }
-FamixMetamodelGenerator class >> modifyMetamodel: aMetamodel [
-	self submetamodels ifNotEmpty: [ self fixRemoteMetamodelRelationsIn: aMetamodel ]
-]
-
-{ #category : #accessing }
 FamixMetamodelGenerator class >> newRepository [
 
 	| tower |
@@ -244,9 +208,6 @@ FamixMetamodelGenerator class >> resetMetamodel [
 	elements := self submetamodels flatCollect: [ :each | each metamodel elements ].
 
 	elements do: [ :each | metamodel elementNamed: each fullName ifAbsent: [ metamodel add: each ] ].
-
-	self allSubmetamodels do: [ :submetamodel | submetamodel modifyMetamodel: metamodel ].
-	self modifyMetamodel: metamodel.
 
 	metamodel additionalProperties at: #wantsAllEntitiesNavigation put: self wantsAllEntitiesNavigation.
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBNonremoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBNonremoteRelationSideGenerationStrategy.class.st
@@ -7,8 +7,8 @@ Class {
 { #category : #printing }
 FmxMBNonRemoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
 
-	aStream tab; nextPutAll: ('<MSEProperty: #{1} type: #Object>' format: {aRelationSide name}).
-	aStream cr.
+	 aStream tab; nextPutAll: ('<MSEProperty: #{1} type: #{2} opposite: #{3}>' format: {aRelationSide name. aRelationSide oppositeType. aRelationSide oppositeName}).
+    aStream cr.
 	
 	aRelationSide remoteBuilderDo: [ :aRemoteBuilder |
 		aStream tab; nextPutAll: ('<package: #''{1}''>' format: {aRemoteBuilder generator packageName}).

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed1CustomEntity1 >> c21 [
 	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11"
 
 	<generated>
-	<MSEProperty: #c21 type: #Object>
+	<MSEProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c21 ifAbsent: [ nil ]
 ]
@@ -31,7 +31,7 @@ FamixTestComposed1CustomEntity1 >> customEntity1 [
 	<generated>
 	<container>
 	<derived>
-	<MSEProperty: #customEntity1 type: #Object>
+	<MSEProperty: #customEntity1 type: #FamixTestComposedCustomEntity1 opposite: #customEntity1>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntity1 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1CustomEntity2 >> c22s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c22s type: #Object>
+	<MSEProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c12: ]
 ]
@@ -23,7 +23,7 @@ FamixTestComposed1CustomEntity2 >> customEntity2 [
 	"Relation named: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2"
 
 	<generated>
-	<MSEProperty: #customEntity2 type: #Object>
+	<MSEProperty: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntity2 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed1CustomEntity3 >> c23 [
 	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s"
 
 	<generated>
-	<MSEProperty: #c23 type: #Object>
+	<MSEProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c23 ifAbsent: [ nil ]
 ]
@@ -23,7 +23,7 @@ FamixTestComposed1CustomEntity3 >> customEntities3 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #customEntities3 type: #Object>
+	<MSEProperty: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntities3 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity3: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1CustomEntity4 >> c24s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c24s type: #Object>
+	<MSEProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c14s ]
 ]
@@ -23,7 +23,7 @@ FamixTestComposed1CustomEntity4 >> customEntities4 [
 	"Relation named: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4"
 
 	<generated>
-	<MSEProperty: #customEntities4 type: #Object>
+	<MSEProperty: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1CustomEntity5 >> associations [
 
 	<generated>
 	<derived>
-	<MSEProperty: #associations type: #Object>
+	<MSEProperty: #associations type: #FamixTestComposedAssociation opposite: #c15>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c15: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1Method >> entity [
 
 	<generated>
 	<derived>
-	<MSEProperty: #entity type: #Object>
+	<MSEProperty: #entity type: #FamixTestComposedEntity opposite: #method>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #entity ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed2CustomEntity1 >> c1 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c1 type: #Object>
+	<MSEProperty: #c1 type: #FamixTestComposedCustomEntity1 opposite: #c21>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c1 ifAbsent: [ nil ]
 ]
@@ -17,7 +17,7 @@ FamixTestComposed2CustomEntity1 >> c11 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c11 type: #Object>
+	<MSEProperty: #c11 type: #FamixTestComposed1CustomEntity1 opposite: #c21>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c11 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed2CustomEntity2 >> c12 [
 	"Relation named: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s"
 
 	<generated>
-	<MSEProperty: #c12 type: #Object>
+	<MSEProperty: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c12 ifAbsent: [ nil ]
 ]
@@ -22,7 +22,7 @@ FamixTestComposed2CustomEntity2 >> c2 [
 	"Relation named: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s"
 
 	<generated>
-	<MSEProperty: #c2 type: #Object>
+	<MSEProperty: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c2 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed2CustomEntity3 >> c13s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c13s type: #Object>
+	<MSEProperty: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c13s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
 ]
@@ -24,7 +24,7 @@ FamixTestComposed2CustomEntity3 >> c3s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c3s type: #Object>
+	<MSEProperty: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c3s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed2CustomEntity4 >> c14s [
 	"Relation named: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s"
 
 	<generated>
-	<MSEProperty: #c14s type: #Object>
+	<MSEProperty: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c14s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c24s ]
 ]
@@ -22,7 +22,7 @@ FamixTestComposed2CustomEntity4 >> c4s [
 	"Relation named: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s"
 
 	<generated>
-	<MSEProperty: #c4s type: #Object>
+	<MSEProperty: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c4s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c24s ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed2CustomEntity5 >> associations [
 
 	<generated>
 	<derived>
-	<MSEProperty: #associations type: #Object>
+	<MSEProperty: #associations type: #FamixTestComposedAssociation opposite: #c25>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c25: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -21,7 +21,7 @@ FamixTestComposedAssociation >> c15 [
 
 	<generated>
 	<target>
-	<MSEProperty: #c15 type: #Object>
+	<MSEProperty: #c15 type: #FamixTestComposed1CustomEntity5 opposite: #associations>
 	^ self privateState attributeAt: #c15 ifAbsent: [ nil ]
 ]
 
@@ -38,7 +38,7 @@ FamixTestComposedAssociation >> c25 [
 
 	<generated>
 	<source>
-	<MSEProperty: #c25 type: #Object>
+	<MSEProperty: #c25 type: #FamixTestComposed2CustomEntity5 opposite: #associations>
 	^ self privateState attributeAt: #c25 ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -25,7 +25,7 @@ FamixTestComposedCustomEntity1 >> c21 [
 	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1"
 
 	<generated>
-	<MSEProperty: #c21 type: #Object>
+	<MSEProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1>
 	^ self privateState attributeAt: #c21 ifAbsent: [ nil ]
 ]
 
@@ -48,7 +48,7 @@ FamixTestComposedCustomEntity1 >> customEntity1 [
 	"Relation named: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1"
 
 	<generated>
-	<MSEProperty: #customEntity1 type: #Object>
+	<MSEProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>
 	^ self privateState attributeAt: #customEntity1 ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -26,7 +26,7 @@ FamixTestComposedCustomEntity2 >> c22s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c22s type: #Object>
+	<MSEProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2>
 	^ self privateState attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c2: ]
 ]
 
@@ -43,7 +43,7 @@ FamixTestComposedCustomEntity2 >> customEntities2 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #customEntities2 type: #Object>
+	<MSEProperty: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2>
 	^ self privateState attributeAt: #customEntities2 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity2: ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -25,7 +25,7 @@ FamixTestComposedCustomEntity3 >> c23 [
 	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s"
 
 	<generated>
-	<MSEProperty: #c23 type: #Object>
+	<MSEProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s>
 	^ self privateState attributeAt: #c23 ifAbsent: [ nil ]
 ]
 
@@ -41,7 +41,7 @@ FamixTestComposedCustomEntity3 >> customEntity3 [
 	"Relation named: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3"
 
 	<generated>
-	<MSEProperty: #customEntity3 type: #Object>
+	<MSEProperty: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3>
 	^ self privateState attributeAt: #customEntity3 ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -26,7 +26,7 @@ FamixTestComposedCustomEntity4 >> c24s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c24s type: #Object>
+	<MSEProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s>
 	^ self privateState attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c4s ]
 ]
 
@@ -43,7 +43,7 @@ FamixTestComposedCustomEntity4 >> customEntities4 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #customEntities4 type: #Object>
+	<MSEProperty: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4>
 	^ self privateState attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -25,7 +25,7 @@ FamixTestComposedEntity >> method [
 	"Relation named: #method type: #FamixTestComposed1Method opposite: #entity"
 
 	<generated>
-	<MSEProperty: #method type: #Object>
+	<MSEProperty: #method type: #FamixTestComposed1Method opposite: #entity>
 	^ self privateState attributeAt: #method ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
@@ -58,14 +58,14 @@ FamixTestComposedMetamodels >> setUp [
 
 { #category : #running }
 FamixTestComposedMetamodels >> testGenerationOfComposedMetamodel [
-
 	| aGenerator env |
-	
 	aGenerator := FamixTestComposedGenerator new beForTesting generate.
 	env := aGenerator builder environment ringEnvironment.
-	
-	self assert: ((((env ask behaviorNamed: #FamixTestComposedCustomEntity1) methodNamed: #customEntity1) sourceCode includesSubstring: 
-'MSEProperty: #customEntity1 type: #Object'))
+
+	self
+		assert:
+			(((env ask behaviorNamed: #FamixTestComposedCustomEntity1) methodNamed: #customEntity1) sourceCode
+				includesSubstring: '<MSEProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>')
 ]
 
 { #category : #running }

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsBuilding.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsBuilding.class.st
@@ -64,14 +64,14 @@ FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneNonRemote [
 	generatedMethod := ((env ringEnvironment ask classNamed: #Tst1Method) methodNamed: #binding).
 
 	self assert: (generatedMethod sourceCode includesSubstring: '<generated>').
-	self assert: (generatedMethod sourceCode includesSubstring: '<MSEProperty: #binding type: #Object>').
+	self assert: (generatedMethod sourceCode includesSubstring: '<MSEProperty: #binding type: #TstComposedBinding opposite: #method>').
 	self assert: (generatedMethod sourceCode includesSubstring: 'privateState attributeAt: #binding').
 	self assert: generatedMethod package name equals: #TstComposed.
 
 	source := ((env ringEnvironment ask classNamed: #TstComposedBinding) methodNamed: #method) sourceCode.
 
 	self assert:  (source includesSubstring: '<generated>').
-	self assert:  (source includesSubstring: '<MSEProperty: #method type: #Object>').
+	self assert:  (source includesSubstring: '<MSEProperty: #method type: #Tst1Method opposite: #binding>').
 	self assert:  (source includesSubstring: 'privateState attributeAt: #method').
 	self assert: generatedMethod package name equals: #TstComposed.
 ]
@@ -90,14 +90,14 @@ FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneRemote [
 	generatedMethod := ((env ringEnvironment ask classNamed: #Tst1Method) methodNamed: #methodNode).
 
 	self assert: (generatedMethod sourceCode includesSubstring: '<generated>').
-	self assert: (generatedMethod sourceCode includesSubstring: '<MSEProperty: #methodNode type: #Object>').
+	self assert: (generatedMethod sourceCode includesSubstring: '<MSEProperty: #methodNode type: #Tst2MethodNode opposite: #method>').
 	self assert: (generatedMethod sourceCode includesSubstring: 'privateState attributeAt: #methodNode').
 	self assert: generatedMethod package name equals: #TstComposed.
 
 	source := ((env ringEnvironment ask classNamed: #Tst2MethodNode) methodNamed: #method) sourceCode.
 
 	self assert:  (source includesSubstring: '<generated>').
-	self assert:  (source includesSubstring: '<MSEProperty: #method type: #Object>').
+	self assert:  (source includesSubstring: '<MSEProperty: #method type: #Tst1Method opposite: #methodNode>').
 	self assert:  (source includesSubstring: 'privateState attributeAt: #method').
 	self assert: generatedMethod package name equals: #TstComposed.
 


### PR DESCRIPTION
Composed meta models should be managed by the pragma processor to create the MM and not by the generator.

We should not have to need a generator to build a MM. We should be able to remove the generator from the image also.

Fixes #1892