### PR TITLE
SImplify-generation-of-metamodels

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaTStructuralEntity.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTStructuralEntity.trait.st
@@ -8,7 +8,7 @@ Trait {
 { #category : #meta }
 FamixJavaTStructuralEntity classSide >> annotation [
 
-	<MSEClass: #TStructuralEntity super: #Trait>
+	<MSEClass: #TStructuralEntity super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -64,8 +64,7 @@ FamixMetamodelGenerator class >> basicFamixTraits [
 
 { #category : #accessing }
 FamixMetamodelGenerator class >> basicMetamodelClasses [
-	^ ({Trait . Class . ClassDescription . Behavior . MooseEntity . FmxImportingContext . MooseAbstractGroup . MooseModel . FamixTSourceLanguage.
-	FamixTWithSourceLanguage} , MooseGroup withAllSubclasses) asOrderedCollection
+	^ ({MooseEntity . MooseAbstractGroup . MooseModel . FamixTSourceLanguage . FamixTWithSourceLanguage} , MooseGroup withAllSubclasses) asOrderedCollection
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -109,6 +109,11 @@ FmxMBBehavior >> defaultSuperclass [
 	^ self builder environment basicSuperclass
 ]
 
+{ #category : #generating }
+FmxMBBehavior >> defaultSuperclassName [
+	^ self defaultSuperclass name
+]
+
 { #category : #'settings - default' }
 FmxMBBehavior >> defaultTag [
 
@@ -162,8 +167,8 @@ FmxMBBehavior >> generateAnnotationIn: aRealClass as: aName superclass: aSupercl
 	aSuperclassName := aSuperclass
 		ifNotNil: [ aSuperclass name ]
 		ifNil: [ self classGeneralization = self defaultSuperclass
-				ifTrue: [ self defaultSuperclass name ]
-				ifFalse: [ self classGeneralization ifNil: [ self defaultSuperclass name ] ifNotNil: [ self classGeneralization realClass name ] ] ].
+				ifTrue: [ self defaultSuperclassName ]
+				ifFalse: [ self classGeneralization ifNil: [ self defaultSuperclassName ] ifNotNil: [ self classGeneralization realClass name ] ] ].
 
 	aRealClass classSide
 		compile:

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
@@ -69,6 +69,13 @@ FmxMBTrait >> defaultSuperclass [
 	^ self builder environment basicTrait
 ]
 
+{ #category : #accessing }
+FmxMBTrait >> defaultSuperclassName [
+	"In case of Traits we want the annotation to point Object as superclass."
+
+	^ 'Object'
+]
+
 { #category : #'settings-default' }
 FmxMBTrait >> defaultTag [
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
@@ -314,15 +314,15 @@ FmxMBTraitTest >> testRelatedTraitName [
 { #category : #tests }
 FmxMBTraitTest >> testSimpleClassAnnotation [
 
-	| simpleClass generated method |
+	| generated method |
 		
-	simpleClass := builder newTraitNamed: #TComment.	
+	builder newTraitNamed: #TComment.	
 	builder generate.
 
 	generated := builder testingEnvironment ask classNamed: 'TstTComment'.
 
 	method := generated classSide methodNamed: #annotation.
-	self assert: (method sourceCode includesSubstring: '<MSEClass: #TComment super: #Trait>').
+	self assert: (method sourceCode includesSubstring: '<MSEClass: #TComment super: #Object>').
 	self assert: (method sourceCode includesSubstring: '<package: #Tst>').
 
 

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -25,7 +25,7 @@ Trait {
 { #category : #meta }
 FamixTAccess classSide >> annotation [
 
-	<MSEClass: #TAccess super: #Trait>
+	<MSEClass: #TAccess super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTAccessible classSide >> annotation [
 
-	<MSEClass: #TAccessible super: #Trait>
+	<MSEClass: #TAccessible super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -24,7 +24,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationInstance classSide >> annotation [
 
-	<MSEClass: #TAnnotationInstance super: #Trait>
+	<MSEClass: #TAnnotationInstance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -23,7 +23,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationInstanceAttribute classSide >> annotation [
 
-	<MSEClass: #TAnnotationInstanceAttribute super: #Trait>
+	<MSEClass: #TAnnotationInstanceAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -17,7 +17,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationType classSide >> annotation [
 
-	<MSEClass: #TAnnotationType super: #Trait>
+	<MSEClass: #TAnnotationType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -27,7 +27,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationTypeAttribute classSide >> annotation [
 
-	<MSEClass: #TAnnotationTypeAttribute super: #Trait>
+	<MSEClass: #TAnnotationTypeAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -29,7 +29,7 @@ Trait {
 { #category : #meta }
 FamixTAssociation classSide >> annotation [
 
-	<MSEClass: #TAssociation super: #Trait>
+	<MSEClass: #TAssociation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTAttribute classSide >> annotation [
 
-	<MSEClass: #TAttribute super: #Trait>
+	<MSEClass: #TAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTCaughtException.trait.st
+++ b/src/Famix-Traits/FamixTCaughtException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTCaughtException classSide >> annotation [
 
-	<MSEClass: #TCaughtException super: #Trait>
+	<MSEClass: #TCaughtException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTClass classSide >> annotation [
 
-	<MSEClass: #TClass super: #Trait>
+	<MSEClass: #TClass super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
+++ b/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTClassHierarchyNavigation classSide >> annotation [
 
-	<MSEClass: #TClassHierarchyNavigation super: #Trait>
+	<MSEClass: #TClassHierarchyNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTClassWithInvocationsGlue.trait.st
+++ b/src/Famix-Traits/FamixTClassWithInvocationsGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTClassWithInvocationsGlue classSide >> annotation [
 
-	<MSEClass: #TClassWithInvocationsGlue super: #Trait>
+	<MSEClass: #TClassWithInvocationsGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
+++ b/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
@@ -8,7 +8,7 @@ Trait {
 { #category : #meta }
 FamixTCohesionCouplingMetrics classSide >> annotation [
 
-	<MSEClass: #TCohesionCouplingMetrics super: #Trait>
+	<MSEClass: #TCohesionCouplingMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTComment.trait.st
+++ b/src/Famix-Traits/FamixTComment.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 FamixTComment classSide >> annotation [
 
-	<MSEClass: #TComment super: #Trait>
+	<MSEClass: #TComment super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTCompilationUnit.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTCompilationUnit classSide >> annotation [
 
-	<MSEClass: #TCompilationUnit super: #Trait>
+	<MSEClass: #TCompilationUnit super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTContainingWithInvocationsGlue.trait.st
+++ b/src/Famix-Traits/FamixTContainingWithInvocationsGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTContainingWithInvocationsGlue classSide >> annotation [
 
-	<MSEClass: #TContainingWithInvocationsGlue super: #Trait>
+	<MSEClass: #TContainingWithInvocationsGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTContainingWithStatementsGlue.trait.st
+++ b/src/Famix-Traits/FamixTContainingWithStatementsGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTContainingWithStatementsGlue classSide >> annotation [
 
-	<MSEClass: #TContainingWithStatementsGlue super: #Trait>
+	<MSEClass: #TContainingWithStatementsGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTDeclaredException.trait.st
+++ b/src/Famix-Traits/FamixTDeclaredException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTDeclaredException classSide >> annotation [
 
-	<MSEClass: #TDeclaredException super: #Trait>
+	<MSEClass: #TDeclaredException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTDefinedInModule.trait.st
+++ b/src/Famix-Traits/FamixTDefinedInModule.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTDefinedInModule classSide >> annotation [
 
-	<MSEClass: #TDefinedInModule super: #Trait>
+	<MSEClass: #TDefinedInModule super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
+++ b/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
@@ -16,7 +16,7 @@ Trait {
 { #category : #meta }
 FamixTDereferencedInvocation classSide >> annotation [
 
-	<MSEClass: #TDereferencedInvocation super: #Trait>
+	<MSEClass: #TDereferencedInvocation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -22,7 +22,7 @@ Trait {
 { #category : #meta }
 FamixTEnumValue classSide >> annotation [
 
-	<MSEClass: #TEnumValue super: #Trait>
+	<MSEClass: #TEnumValue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTException.trait.st
+++ b/src/Famix-Traits/FamixTException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTException classSide >> annotation [
 
-	<MSEClass: #TException super: #Trait>
+	<MSEClass: #TException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTFile classSide >> annotation [
 
-	<MSEClass: #TFile super: #Trait>
+	<MSEClass: #TFile super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTFileAnchor classSide >> annotation [
 
-	<MSEClass: #TFileAnchor super: #Trait>
+	<MSEClass: #TFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFileInclude.trait.st
+++ b/src/Famix-Traits/FamixTFileInclude.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTFileInclude classSide >> annotation [
 
-	<MSEClass: #TFileInclude super: #Trait>
+	<MSEClass: #TFileInclude super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTFileNavigation classSide >> annotation [
 
-	<MSEClass: #TFileNavigation super: #Trait>
+	<MSEClass: #TFileNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTFileSystemEntity classSide >> annotation [
 
-	<MSEClass: #TFileSystemEntity super: #Trait>
+	<MSEClass: #TFileSystemEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTFolder classSide >> annotation [
 
-	<MSEClass: #TFolder super: #Trait>
+	<MSEClass: #TFolder super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTFunction classSide >> annotation [
 
-	<MSEClass: #TFunction super: #Trait>
+	<MSEClass: #TFunction super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTGlobalVariable classSide >> annotation [
 
-	<MSEClass: #TGlobalVariable super: #Trait>
+	<MSEClass: #TGlobalVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTGlobalVariableScope classSide >> annotation [
 
-	<MSEClass: #TGlobalVariableScope super: #Trait>
+	<MSEClass: #TGlobalVariableScope super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTHeader.trait.st
+++ b/src/Famix-Traits/FamixTHeader.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTHeader classSide >> annotation [
 
-	<MSEClass: #THeader super: #Trait>
+	<MSEClass: #THeader super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTImplicitVariable classSide >> annotation [
 
-	<MSEClass: #TImplicitVariable super: #Trait>
+	<MSEClass: #TImplicitVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTIndexedFileNavigation classSide >> annotation [
 
-	<MSEClass: #TIndexedFileNavigation super: #Trait>
+	<MSEClass: #TIndexedFileNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTInheritanceGlue.trait.st
+++ b/src/Famix-Traits/FamixTInheritanceGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTInheritanceGlue classSide >> annotation [
 
-	<MSEClass: #TInheritanceGlue super: #Trait>
+	<MSEClass: #TInheritanceGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTInvocable.trait.st
+++ b/src/Famix-Traits/FamixTInvocable.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTInvocable classSide >> annotation [
 
-	<MSEClass: #TInvocable super: #Trait>
+	<MSEClass: #TInvocable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -23,7 +23,7 @@ Trait {
 { #category : #meta }
 FamixTInvocation classSide >> annotation [
 
-	<MSEClass: #TInvocation super: #Trait>
+	<MSEClass: #TInvocation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
+++ b/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTInvocationsReceiver classSide >> annotation [
 
-	<MSEClass: #TInvocationsReceiver super: #Trait>
+	<MSEClass: #TInvocationsReceiver super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTLCOMMetrics.trait.st
+++ b/src/Famix-Traits/FamixTLCOMMetrics.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTLCOMMetrics classSide >> annotation [
 
-	<MSEClass: #TLCOMMetrics super: #Trait>
+	<MSEClass: #TLCOMMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTLocalVariable classSide >> annotation [
 
-	<MSEClass: #TLocalVariable super: #Trait>
+	<MSEClass: #TLocalVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -19,7 +19,7 @@ Trait {
 { #category : #meta }
 FamixTMethod classSide >> annotation [
 
-	<MSEClass: #TMethod super: #Trait>
+	<MSEClass: #TMethod super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 FamixTModule classSide >> annotation [
 
-	<MSEClass: #TModule super: #Trait>
+	<MSEClass: #TModule super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTMultipleFileAnchor classSide >> annotation [
 
-	<MSEClass: #TMultipleFileAnchor super: #Trait>
+	<MSEClass: #TMultipleFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTNamed.trait.st
+++ b/src/Famix-Traits/FamixTNamed.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTNamed classSide >> annotation [
 
-	<MSEClass: #TNamed super: #Trait>
+	<MSEClass: #TNamed super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -17,7 +17,7 @@ Trait {
 { #category : #meta }
 FamixTNamespace classSide >> annotation [
 
-	<MSEClass: #TNamespace super: #Trait>
+	<MSEClass: #TNamespace super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTNamespaceEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamespaceEntity.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTNamespaceEntity classSide >> annotation [
 
-	<MSEClass: #TNamespaceEntity super: #Trait>
+	<MSEClass: #TNamespaceEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTPackage classSide >> annotation [
 
-	<MSEClass: #TPackage super: #Trait>
+	<MSEClass: #TPackage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPackageWithClassesGlue.trait.st
+++ b/src/Famix-Traits/FamixTPackageWithClassesGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTPackageWithClassesGlue classSide >> annotation [
 
-	<MSEClass: #TPackageWithClassesGlue super: #Trait>
+	<MSEClass: #TPackageWithClassesGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTPackageable classSide >> annotation [
 
-	<MSEClass: #TPackageable super: #Trait>
+	<MSEClass: #TPackageable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTParameter classSide >> annotation [
 
-	<MSEClass: #TParameter super: #Trait>
+	<MSEClass: #TParameter super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTParameterizedType.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedType.trait.st
@@ -19,7 +19,7 @@ Trait {
 { #category : #meta }
 FamixTParameterizedType classSide >> annotation [
 
-	<MSEClass: #TParameterizedType super: #Trait>
+	<MSEClass: #TParameterizedType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTParameterizedTypeUser classSide >> annotation [
 
-	<MSEClass: #TParameterizedTypeUser super: #Trait>
+	<MSEClass: #TParameterizedTypeUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPossibleStub.trait.st
+++ b/src/Famix-Traits/FamixTPossibleStub.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTPossibleStub classSide >> annotation [
 
-	<MSEClass: #TPossibleStub super: #Trait>
+	<MSEClass: #TPossibleStub super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPreprocessorDefine.trait.st
+++ b/src/Famix-Traits/FamixTPreprocessorDefine.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTPreprocessorDefine classSide >> annotation [
 
-	<MSEClass: #TPreprocessorDefine super: #Trait>
+	<MSEClass: #TPreprocessorDefine super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPreprocessorIfdef.trait.st
+++ b/src/Famix-Traits/FamixTPreprocessorIfdef.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTPreprocessorIfdef classSide >> annotation [
 
-	<MSEClass: #TPreprocessorIfdef super: #Trait>
+	<MSEClass: #TPreprocessorIfdef super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -23,7 +23,7 @@ Trait {
 { #category : #meta }
 FamixTReference classSide >> annotation [
 
-	<MSEClass: #TReference super: #Trait>
+	<MSEClass: #TReference super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTReferenceable classSide >> annotation [
 
-	<MSEClass: #TReferenceable super: #Trait>
+	<MSEClass: #TReferenceable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTScopingEntity classSide >> annotation [
 
-	<MSEClass: #TScopingEntity super: #Trait>
+	<MSEClass: #TScopingEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTSourceAnchor classSide >> annotation [
 
-	<MSEClass: #TSourceAnchor super: #Trait>
+	<MSEClass: #TSourceAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTSourceEntity classSide >> annotation [
 
-	<MSEClass: #TSourceEntity super: #Trait>
+	<MSEClass: #TSourceEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTSourceLanguage classSide >> annotation [
 
-	<MSEClass: #TSourceLanguage super: #Trait>
+	<MSEClass: #TSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTStructuralEntity.trait.st
+++ b/src/Famix-Traits/FamixTStructuralEntity.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTStructuralEntity classSide >> annotation [
 
-	<MSEClass: #TStructuralEntity super: #Trait>
+	<MSEClass: #TStructuralEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSub.trait.st
+++ b/src/Famix-Traits/FamixTSub.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTSub classSide >> annotation [
 
-	<MSEClass: #TSub super: #Trait>
+	<MSEClass: #TSub super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSubInheritance.trait.st
+++ b/src/Famix-Traits/FamixTSubInheritance.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTSubInheritance classSide >> annotation [
 
-	<MSEClass: #TSubInheritance super: #Trait>
+	<MSEClass: #TSubInheritance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSuper.trait.st
+++ b/src/Famix-Traits/FamixTSuper.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTSuper classSide >> annotation [
 
-	<MSEClass: #TSuper super: #Trait>
+	<MSEClass: #TSuper super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTSuperInheritance.trait.st
+++ b/src/Famix-Traits/FamixTSuperInheritance.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTSuperInheritance classSide >> annotation [
 
-	<MSEClass: #TSuperInheritance super: #Trait>
+	<MSEClass: #TSuperInheritance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTemplate.trait.st
+++ b/src/Famix-Traits/FamixTTemplate.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTTemplate classSide >> annotation [
 
-	<MSEClass: #TTemplate super: #Trait>
+	<MSEClass: #TTemplate super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTemplateUser.trait.st
+++ b/src/Famix-Traits/FamixTTemplateUser.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTemplateUser classSide >> annotation [
 
-	<MSEClass: #TTemplateUser super: #Trait>
+	<MSEClass: #TTemplateUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTThrownException.trait.st
+++ b/src/Famix-Traits/FamixTThrownException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTThrownException classSide >> annotation [
 
-	<MSEClass: #TThrownException super: #Trait>
+	<MSEClass: #TThrownException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTrait.trait.st
+++ b/src/Famix-Traits/FamixTTrait.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 FamixTTrait classSide >> annotation [
 
-	<MSEClass: #TTrait super: #Trait>
+	<MSEClass: #TTrait super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTraitUsage.trait.st
+++ b/src/Famix-Traits/FamixTTraitUsage.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTTraitUsage classSide >> annotation [
 
-	<MSEClass: #TTraitUsage super: #Trait>
+	<MSEClass: #TTraitUsage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTraitUser.trait.st
+++ b/src/Famix-Traits/FamixTTraitUser.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTraitUser classSide >> annotation [
 
-	<MSEClass: #TTraitUser super: #Trait>
+	<MSEClass: #TTraitUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -18,7 +18,7 @@ Trait {
 { #category : #meta }
 FamixTType classSide >> annotation [
 
-	<MSEClass: #TType super: #Trait>
+	<MSEClass: #TType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTypeAlias.trait.st
+++ b/src/Famix-Traits/FamixTTypeAlias.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTTypeAlias classSide >> annotation [
 
-	<MSEClass: #TTypeAlias super: #Trait>
+	<MSEClass: #TTypeAlias super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTypedAnnotationInstance classSide >> annotation [
 
-	<MSEClass: #TTypedAnnotationInstance super: #Trait>
+	<MSEClass: #TTypedAnnotationInstance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTypedAnnotationInstanceAttribute classSide >> annotation [
 
-	<MSEClass: #TTypedAnnotationInstanceAttribute super: #Trait>
+	<MSEClass: #TTypedAnnotationInstanceAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTypedStructure.trait.st
+++ b/src/Famix-Traits/FamixTTypedStructure.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTypedStructure classSide >> annotation [
 
-	<MSEClass: #TTypedStructure super: #Trait>
+	<MSEClass: #TTypedStructure super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTUnknownSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTUnknownSourceLanguage.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTUnknownSourceLanguage classSide >> annotation [
 
-	<MSEClass: #TUnknownSourceLanguage super: #Trait>
+	<MSEClass: #TUnknownSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithAccesses.trait.st
+++ b/src/Famix-Traits/FamixTWithAccesses.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAccesses classSide >> annotation [
 
-	<MSEClass: #TWithAccesses super: #Trait>
+	<MSEClass: #TWithAccesses super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAnnotationInstanceAttributes classSide >> annotation [
 
-	<MSEClass: #TWithAnnotationInstanceAttributes super: #Trait>
+	<MSEClass: #TWithAnnotationInstanceAttributes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAnnotationInstances classSide >> annotation [
 
-	<MSEClass: #TWithAnnotationInstances super: #Trait>
+	<MSEClass: #TWithAnnotationInstances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAnnotationTypes classSide >> annotation [
 
-	<MSEClass: #TWithAnnotationTypes super: #Trait>
+	<MSEClass: #TWithAnnotationTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAttributes classSide >> annotation [
 
-	<MSEClass: #TWithAttributes super: #Trait>
+	<MSEClass: #TWithAttributes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithCaughtExceptions classSide >> annotation [
 
-	<MSEClass: #TWithCaughtExceptions super: #Trait>
+	<MSEClass: #TWithCaughtExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithClassScope.trait.st
+++ b/src/Famix-Traits/FamixTWithClassScope.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithClassScope classSide >> annotation [
 
-	<MSEClass: #TWithClassScope super: #Trait>
+	<MSEClass: #TWithClassScope super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithClasses.trait.st
+++ b/src/Famix-Traits/FamixTWithClasses.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithClasses classSide >> annotation [
 
-	<MSEClass: #TWithClasses super: #Trait>
+	<MSEClass: #TWithClasses super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithComments classSide >> annotation [
 
-	<MSEClass: #TWithComments super: #Trait>
+	<MSEClass: #TWithComments super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithCompilationUnit classSide >> annotation [
 
-	<MSEClass: #TWithCompilationUnit super: #Trait>
+	<MSEClass: #TWithCompilationUnit super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithDeclaredExceptions classSide >> annotation [
 
-	<MSEClass: #TWithDeclaredExceptions super: #Trait>
+	<MSEClass: #TWithDeclaredExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithDereferencedInvocations classSide >> annotation [
 
-	<MSEClass: #TWithDereferencedInvocations super: #Trait>
+	<MSEClass: #TWithDereferencedInvocations super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithEnumValues classSide >> annotation [
 
-	<MSEClass: #TWithEnumValues super: #Trait>
+	<MSEClass: #TWithEnumValues super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithExceptions classSide >> annotation [
 
-	<MSEClass: #TWithExceptions super: #Trait>
+	<MSEClass: #TWithExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithFileIncludes.trait.st
+++ b/src/Famix-Traits/FamixTWithFileIncludes.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTWithFileIncludes classSide >> annotation [
 
-	<MSEClass: #TWithFileIncludes super: #Trait>
+	<MSEClass: #TWithFileIncludes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithFiles.trait.st
+++ b/src/Famix-Traits/FamixTWithFiles.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithFiles classSide >> annotation [
 
-	<MSEClass: #TWithFiles super: #Trait>
+	<MSEClass: #TWithFiles super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithFunctions classSide >> annotation [
 
-	<MSEClass: #TWithFunctions super: #Trait>
+	<MSEClass: #TWithFunctions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithHeader.trait.st
+++ b/src/Famix-Traits/FamixTWithHeader.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithHeader classSide >> annotation [
 
-	<MSEClass: #TWithHeader super: #Trait>
+	<MSEClass: #TWithHeader super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTWithImmediateSource.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithImmediateSource classSide >> annotation [
 
-	<MSEClass: #TWithImmediateSource super: #Trait>
+	<MSEClass: #TWithImmediateSource super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithImplicitVariables classSide >> annotation [
 
-	<MSEClass: #TWithImplicitVariables super: #Trait>
+	<MSEClass: #TWithImplicitVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithInvocations classSide >> annotation [
 
-	<MSEClass: #TWithInvocations super: #Trait>
+	<MSEClass: #TWithInvocations super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithLocalVariables classSide >> annotation [
 
-	<MSEClass: #TWithLocalVariables super: #Trait>
+	<MSEClass: #TWithLocalVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithMethods classSide >> annotation [
 
-	<MSEClass: #TWithMethods super: #Trait>
+	<MSEClass: #TWithMethods super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithMethodsWithAccessesGlue.trait.st
+++ b/src/Famix-Traits/FamixTWithMethodsWithAccessesGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithMethodsWithAccessesGlue classSide >> annotation [
 
-	<MSEClass: #TWithMethodsWithAccessesGlue super: #Trait>
+	<MSEClass: #TWithMethodsWithAccessesGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithMethodsWithModifiersGlue.trait.st
+++ b/src/Famix-Traits/FamixTWithMethodsWithModifiersGlue.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithMethodsWithModifiersGlue classSide >> annotation [
 
-	<MSEClass: #TWithMethodsWithModifiersGlue super: #Trait>
+	<MSEClass: #TWithMethodsWithModifiersGlue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithModifiers.trait.st
+++ b/src/Famix-Traits/FamixTWithModifiers.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithModifiers classSide >> annotation [
 
-	<MSEClass: #TWithModifiers super: #Trait>
+	<MSEClass: #TWithModifiers super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithNamespaces.trait.st
+++ b/src/Famix-Traits/FamixTWithNamespaces.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithNamespaces classSide >> annotation [
 
-	<MSEClass: #TWithNamespaces super: #Trait>
+	<MSEClass: #TWithNamespaces super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithPackages.trait.st
+++ b/src/Famix-Traits/FamixTWithPackages.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithPackages classSide >> annotation [
 
-	<MSEClass: #TWithPackages super: #Trait>
+	<MSEClass: #TWithPackages super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithParameterizedTypeUsers classSide >> annotation [
 
-	<MSEClass: #TWithParameterizedTypeUsers super: #Trait>
+	<MSEClass: #TWithParameterizedTypeUsers super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithParameterizedTypes classSide >> annotation [
 
-	<MSEClass: #TWithParameterizedTypes super: #Trait>
+	<MSEClass: #TWithParameterizedTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithParameters classSide >> annotation [
 
-	<MSEClass: #TWithParameters super: #Trait>
+	<MSEClass: #TWithParameters super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithReferences classSide >> annotation [
 
-	<MSEClass: #TWithReferences super: #Trait>
+	<MSEClass: #TWithReferences super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithSignature.trait.st
+++ b/src/Famix-Traits/FamixTWithSignature.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSignature classSide >> annotation [
 
-	<MSEClass: #TWithSignature super: #Trait>
+	<MSEClass: #TWithSignature super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSourceAnchor classSide >> annotation [
 
-	<MSEClass: #TWithSourceAnchor super: #Trait>
+	<MSEClass: #TWithSourceAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceLanguage.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSourceLanguage classSide >> annotation [
 
-	<MSEClass: #TWithSourceLanguage super: #Trait>
+	<MSEClass: #TWithSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithStatements classSide >> annotation [
 
-	<MSEClass: #TWithStatements super: #Trait>
+	<MSEClass: #TWithStatements super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithSubInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithSubInheritances.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSubInheritances classSide >> annotation [
 
-	<MSEClass: #TWithSubInheritances super: #Trait>
+	<MSEClass: #TWithSubInheritances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithSuperInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithSuperInheritances.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSuperInheritances classSide >> annotation [
 
-	<MSEClass: #TWithSuperInheritances super: #Trait>
+	<MSEClass: #TWithSuperInheritances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTemplates classSide >> annotation [
 
-	<MSEClass: #TWithTemplates super: #Trait>
+	<MSEClass: #TWithTemplates super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithThrownExceptions classSide >> annotation [
 
-	<MSEClass: #TWithThrownExceptions super: #Trait>
+	<MSEClass: #TWithThrownExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithTraits.trait.st
+++ b/src/Famix-Traits/FamixTWithTraits.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTraits classSide >> annotation [
 
-	<MSEClass: #TWithTraits super: #Trait>
+	<MSEClass: #TWithTraits super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithTypeAliases.trait.st
+++ b/src/Famix-Traits/FamixTWithTypeAliases.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTypeAliases classSide >> annotation [
 
-	<MSEClass: #TWithTypeAliases super: #Trait>
+	<MSEClass: #TWithTypeAliases super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithTypedStructures.trait.st
+++ b/src/Famix-Traits/FamixTWithTypedStructures.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTypedStructures classSide >> annotation [
 
-	<MSEClass: #TWithTypedStructures super: #Trait>
+	<MSEClass: #TWithTypedStructures super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTypes classSide >> annotation [
 
-	<MSEClass: #TWithTypes super: #Trait>
+	<MSEClass: #TWithTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 TAssociationMetaLevelDependency classSide >> annotation [
 
-	<MSEClass: #TAssociationMetaLevelDependency super: #Trait>
+	<MSEClass: #TAssociationMetaLevelDependency super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self

--- a/src/Moose-Query/TDependencyQueries.trait.st
+++ b/src/Moose-Query/TDependencyQueries.trait.st
@@ -64,7 +64,7 @@ Trait {
 { #category : #meta }
 TDependencyQueries classSide >> annotation [
 
-	<MSEClass: #TDependencyQueries super: #Trait>
+	<MSEClass: #TDependencyQueries super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -39,7 +39,7 @@ TEntityMetaLevelDependency classSide >> allParentTypesIn: aMetamodel [
 { #category : #meta }
 TEntityMetaLevelDependency classSide >> annotation [
 
-	<MSEClass: #TEntityMetaLevelDependency super: #Trait>
+	<MSEClass: #TEntityMetaLevelDependency super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self

--- a/src/Moose-Query/TOODependencyQueries.trait.st
+++ b/src/Moose-Query/TOODependencyQueries.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 TOODependencyQueries classSide >> annotation [
 
-	<MSEClass: #TOODependencyQueries super: #Trait>
+	<MSEClass: #TOODependencyQueries super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self


### PR DESCRIPTION
Make trait declare Object as their **FAME** superclass so that we do not need to process Trait, Class, ClassDescription, Behavior during the creation of a metamodel.