### PR TITLE
Do-not-use-MooseModel-in-compatibility-tests

### DIFF
--- a/src/Famix-Compatibility-Tests-C/FAMIXCImporting2Test.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCImporting2Test.class.st
@@ -12,7 +12,7 @@ FAMIXCImporting2Test >> setUp [
 	super setUp.
 	self skip: 'Test skipped until C metamodel definition'.
 
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(

--- a/src/Famix-Compatibility-Tests-C/FAMIXCSourceLanguageTest.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCSourceLanguageTest.class.st
@@ -8,7 +8,7 @@ Class {
 FAMIXCSourceLanguageTest >> testIsC [
 	| model |
 	self skip: 'Test skipped until C metamodel definition'.
-	model := MooseModel new.
+	model := FAMIXModel new.
 	
 	model importFromMSEStream: '(
 		(FAMIX.CSourceLanguage)

--- a/src/Famix-Compatibility-Tests-C/FAMIXCompilationUnitTest.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCompilationUnitTest.class.st
@@ -8,7 +8,7 @@ Class {
 FAMIXCompilationUnitTest >> testImporting [
 	| model |
 	self skip: 'Test skipped until C metamodel definition'.
-	model := MooseModel new.
+	model := FAMIXModel new.
 	
 	model importFromMSEStream: '(
 		(FAMIX.CompilationUnit (id: 2) (module (ref: 3)))

--- a/src/Famix-Compatibility-Tests-Core/FAMIXAbstractFileTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXAbstractFileTest.class.st
@@ -17,7 +17,7 @@ FAMIXAbstractFileTest >> testFullNameDoesNotRaiseError [
 	self
 		shouldnt: [ self actualClass new
 				mooseModel:
-					(MooseModel new
+					(FAMIXModel new
 						rootFolder: FileSystem memory root;
 						yourself);
 					name: 'test';

--- a/src/Famix-Compatibility-Tests-Core/FAMIXAnnotationInstanceAttributeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXAnnotationInstanceAttributeTest.class.st
@@ -12,7 +12,7 @@ FAMIXAnnotationInstanceAttributeTest >> actualClass [
 { #category : #tests }
 FAMIXAnnotationInstanceAttributeTest >> testComplex [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(

--- a/src/Famix-Compatibility-Tests-Core/FAMIXMetricTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXMetricTest.class.st
@@ -25,7 +25,11 @@ self skip.
 
 { #category : #testing }
 FAMIXMetricTest >> testAllPackageMetrics [
-	self assertNoErrorForAllMetricsOf: (FAMIXPackage new name: 'package'; mooseModel: MooseModel new)
+	self
+		assertNoErrorForAllMetricsOf:
+			(FAMIXPackage new
+				name: 'package';
+				mooseModel: FAMIXModel new)
 ]
 
 { #category : #testing }

--- a/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
@@ -24,13 +24,15 @@ FAMIXModelQueriesTest >> setUp [
 	class1 := FAMIXClass new.
 	stubClass1 := FAMIXClass new isStub: true.
 	interface1 := FAMIXClass new isInterface: true.
-	stubInterface1 := FAMIXClass new isStub: true; isInterface: true.
+	stubInterface1 := FAMIXClass new
+		isStub: true;
+		isInterface: true.
 	stubPrimitiveType := FAMIXPrimitiveType new isStub: true.
 	class1 container: namespace1.
 	stubClass1 container: stubNamespace.
 	interface1 container: namespace2.
 	stubInterface1 container: stubNamespace.
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model add: class1.
 	model add: stubClass1.
 	model add: interface1.

--- a/src/Famix-Compatibility-Tests-Core/FAMIXMultipleSourceAnchorTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXMultipleSourceAnchorTest.class.st
@@ -10,8 +10,8 @@ Class {
 { #category : #running }
 FAMIXMultipleSourceAnchorTest >> setUp [
 	super setUp.
-	multipleFileAnchor := FAMIXMultipleFileAnchor new mooseModel: MooseModel new.
-	(1 to: 2) do: [:each | multipleFileAnchor addFileAnchorWithPath: 'aFileName']
+	multipleFileAnchor := FAMIXMultipleFileAnchor new mooseModel: FAMIXModel new.
+	(1 to: 2) do: [ :each | multipleFileAnchor addFileAnchorWithPath: 'aFileName' ]
 ]
 
 { #category : #tests }
@@ -28,8 +28,10 @@ FAMIXMultipleSourceAnchorTest >> testAdditionOfFiles [
 { #category : #tests }
 FAMIXMultipleSourceAnchorTest >> testMultipleSourceAnchorEntity [
 	| class |
-	class := FAMIXClass new mooseModel: MooseModel new; defineMultiSourceAnchorWithPath: 'aClassName'.
-	self assert: class sourceAnchor allFiles size equals: 1.
+	class := FAMIXClass new
+		mooseModel: FAMIXModel new;
+		defineMultiSourceAnchorWithPath: 'aClassName'.
+	self assert: class sourceAnchor allFiles size equals: 1
 ]
 
 { #category : #tests }
@@ -50,6 +52,6 @@ FAMIXMultipleSourceAnchorTest >> testWritingAndReadingInMSE [
 	| tempFile importedModel |
 	tempFile := (FileSystem memory / 'files-test.mse') ensureCreateFile.
 	multipleFileAnchor mooseModel exportToMSEStream: tempFile writeStream.
-	importedModel := MooseModel new importFromMSEStream: tempFile readStream.
+	importedModel := FAMIXModel new importFromMSEStream: tempFile readStream.
 	self deny: multipleFileAnchor allFiles isEmpty
 ]

--- a/src/Famix-Compatibility-Tests-Core/FAMIXSourceAnchorTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXSourceAnchorTest.class.st
@@ -12,7 +12,7 @@ FAMIXSourceAnchorTest class >> isAbstract [
 { #category : #tests }
 FAMIXSourceAnchorTest >> testImportFileAnchors [
 	| model aMethod |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(		

--- a/src/Famix-Compatibility-Tests-Core/FAMIXSourceLanguageTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXSourceLanguageTest.class.st
@@ -12,7 +12,7 @@ FAMIXSourceLanguageTest >> actualClass [
 { #category : #tests }
 FAMIXSourceLanguageTest >> testDefaultSourceLanguage [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(
@@ -22,15 +22,13 @@ FAMIXSourceLanguageTest >> testDefaultSourceLanguage [
 	)' readStream.
 	self assert: (model allClasses entityNamed: 'ClassWithoutSourceA') declaredSourceLanguage isNil.
 	self assert: (model allClasses entityNamed: 'ClassWithoutSourceB') declaredSourceLanguage isNil.
-	self
-		assert: (model allClasses entityNamed: 'ClassWithoutSourceA') sourceLanguage
-		equals: (model allClasses entityNamed: 'ClassWithoutSourceB') sourceLanguage.
+	self assert: (model allClasses entityNamed: 'ClassWithoutSourceA') sourceLanguage equals: (model allClasses entityNamed: 'ClassWithoutSourceB') sourceLanguage.
 	self assert: model sourceLanguage name equals: 'SomeLanguage'
 ]
 
 { #category : #tests }
 FAMIXSourceLanguageTest >> testDefaultUnknownLanguage [
-	self assert: MooseModel new sourceLanguage isNil
+	self assert: FAMIXModel new sourceLanguage isNil
 ]
 
 { #category : #tests }
@@ -46,7 +44,7 @@ FAMIXSourceLanguageTest >> testName [
 { #category : #tests }
 FAMIXSourceLanguageTest >> testSourcedEntities [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(

--- a/src/Famix-Compatibility-Tests-Core/FAMIXTypeAliasTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXTypeAliasTest.class.st
@@ -56,7 +56,7 @@ FAMIXTypeAliasTest >> testAliasSuperclasses [
 	| type supertype alias model |
 	self skip.
 	self flag: 'Manage alias after FamixNG refactoring'.
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model sourceLanguage: FAMIXCSourceLanguage new.
 	supertype := FAMIXType new
 		name: 'SuperType';

--- a/src/Famix-Compatibility-Tests-Java/FAMIXJavaSourceLanguageTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FAMIXJavaSourceLanguageTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 FAMIXJavaSourceLanguageTest >> testIsJava [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	
 	model importFromMSEStream: '(
 		(FAMIX.JavaSourceLanguage)

--- a/src/Famix-Compatibility-Tests-Java/FamixJavaTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixJavaTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 FamixJavaTest >> testImportAnnotations [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(
@@ -41,7 +41,7 @@ FamixJavaTest >> testImportAnnotations [
 { #category : #tests }
 FamixJavaTest >> testImportExceptions [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(
@@ -73,7 +73,7 @@ FamixJavaTest >> testImportExceptions [
 { #category : #tests }
 FamixJavaTest >> testInferNamespaces [
 	| model |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model add: (FAMIXNamespace new name: 'org.project.package1').
 	model add: (FAMIXNamespace new name: 'org.project.package2').
 	self assert: model allNamespaces size equals: 2.

--- a/src/Famix-Compatibility-Tests-Java/FamixParameterizableClassTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixParameterizableClassTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 FamixParameterizableClassTest >> testParameterTypes [
 	| model aParameterizableClass |
-	model := MooseModel new.
+	model := FAMIXModel new.
 	model
 		importFromMSEStream:
 			'(

--- a/src/Famix-Compatibility-Tests-Java/FamixParameterizedTypeTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/FamixParameterizedTypeTest.class.st
@@ -11,7 +11,7 @@ Class {
 FamixParameterizedTypeTest >> setUp [
 
 	super setUp.
-	model := MooseModel new.
+	model := FAMIXModel new.
 	
 	model importFromMSEStream: '(
 		(FAMIX.Namespace (id: 1) (name ''NamespaceA''))

--- a/src/Famix-Groups-Tests/FAMIXInvocationGroupTest.class.st
+++ b/src/Famix-Groups-Tests/FAMIXInvocationGroupTest.class.st
@@ -36,7 +36,7 @@ FAMIXInvocationGroupTest >> setUp [
 	invocation from: fromMethod.
 	invocation addCandidate: toMethod.
 	
-	model := MooseModel new addAll: { fromMethod. fromClass. fromNamespace. fromNamespaceNamespace. invocation. toMethod. toClass.  toNamespace. toNamespaceNamespace }; yourself
+	model := FAMIXModel new addAll: { fromMethod. fromClass. fromNamespace. fromNamespaceNamespace. invocation. toMethod. toClass.  toNamespace. toNamespaceNamespace }; yourself
 ]
 
 { #category : #test }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
@@ -171,7 +171,7 @@ FAMIXStepwiseImporterTest >> testImportLANPackage [
 	"self debug: #testImportLANPackage"
 
 	| model class package |
-	model := MooseModel new.
+	model := FamixStModel new.
 	self newPharoImporterTask
 		importerClass: SmalltalkImporter;
 		doNotRunCandidateOperator;
@@ -231,7 +231,7 @@ FAMIXStepwiseImporterTest >> testImportNamespace [
 	"self debug: #testImportNamespace"
 
 	| model nap |
-	model := MooseModel new.
+	model := FamixStModel new.
 	self newPharoImporterTask
 		importerClass: SmalltalkImporter;
 		doNotRunCandidateOperator;


### PR DESCRIPTION
Use FAMIXModel instead of MooseModel in compatibility tests.