### PR TITLE
1873-Metamodel-storage-should-move-from-the-Generator-to-the-Model

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -17,7 +17,7 @@ FAMIXEntity class >> annotation [
 FAMIXEntity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixCompatibilityGenerator) metamodel
+	^ FAMIXModel metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-Compatibility-Entities/FAMIXModel.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXModel.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-Compatibility-Entities'
 }
 
+{ #category : #accessing }
+FAMIXModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FAMIXModel class >> annotation [
 	<MSEClass: #FAMIXModel super: #MooseModel>
 	<package: #FAMIX>
 	<generated>
-]
-
-{ #category : #initialization }
-FAMIXModel >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixCompatibilityGenerator) metamodel
 ]

--- a/src/Famix-Deprecated/FamixMetamodelGenerator.extension.st
+++ b/src/Famix-Deprecated/FamixMetamodelGenerator.extension.st
@@ -21,3 +21,9 @@ FamixMetamodelGenerator >> builderWithStandardTraits [
 		generator: self;
 		yourself.
 ]
+
+{ #category : #'*Famix-Deprecated' }
+FamixMetamodelGenerator class >> newRepository [
+	self deprecated: 'Ask the MooseModel directly.' transformWith: '`@receiver newRepository' -> (self prefix , 'Model newRepository').
+	^ self environment at: (self prefix , 'Model') asSymbol ifPresent: [ :m | m newRepository ]
+]

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -34,7 +34,7 @@ FamixJavaEntity class >> annotation [
 FamixJavaEntity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixJavaGenerator) metamodel
+	^ FamixJavaModel metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-Java-Entities/FamixJavaModel.class.st
+++ b/src/Famix-Java-Entities/FamixJavaModel.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-Java-Entities'
 }
 
+{ #category : #accessing }
+FamixJavaModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixJavaModel class >> annotation [
 	<MSEClass: #FamixJavaModel super: #MooseModel>
 	<package: #'Famix-Java-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixJavaModel >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixJavaGenerator) metamodel
 ]

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -245,21 +245,28 @@ FamixMetamodelBuilder >> generateMooseModel [
 				in: configuration packageName
 				overwrite: false.
 
-			model
-				compile:
-					('initialize
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #{1}) metamodel' format: {self generator class name})
-				classified: 'initialization'.
-
 			model classSide
 				compile:
 					('annotation
 	<MSEClass: #{1} super: #MooseModel>
 	<package: {2}>
 	<generated>' format: {mooseModelName . self safeAnnotationPackageName})
-				classified: 'meta' ]
+				classified: 'meta'.
+			self allSubBuilders
+				ifNotEmpty: [ :subBuilders | 
+					model classSide
+						compile:
+							('allSubmetamodelsPackagesNames
+	<generated>
+	^ #({1})'
+								format:
+									{(String
+										streamContents: [ :stream | 
+											| packages |
+											packages := (subBuilders collect: [ :builder | builder configuration packageName ]) asOrderedCollection.
+											packages sort: #yourself descending.
+											packages do: [ :package | stream print: package ] separatedBy: [ stream space ] ])})
+						classified: 'accessing' ] ]
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -35,9 +35,6 @@ Class {
 		'cleaningStrategy',
 		'subBuildersMapByPrefix'
 	],
-	#classInstVars : [
-		'metamodel'
-	],
 	#category : #'Famix-MetamodelBuilder-Core-Basic'
 }
 
@@ -48,28 +45,6 @@ FamixMetamodelGenerator class >> addSubmetamodelsToGenerateFrom: aCollection to:
 		thenDo: [ :mm | 
 			mm submetamodels do: [ :smm | (metamodels includes: smm) ifFalse: [ metamodels add: smm before: mm ] ].
 			self addSubmetamodelsToGenerateFrom: mm submetamodels to: metamodels ]
-]
-
-{ #category : #accessing }
-FamixMetamodelGenerator class >> allSubmetamodels [
-	^ {self submetamodels . (self submetamodels collect: #allSubmetamodels)} flattened asSet
-]
-
-{ #category : #accessing }
-FamixMetamodelGenerator class >> basicFamixTraits [
-
-	^ #'Famix-Traits' asPackage definedClasses.
-	
-]
-
-{ #category : #accessing }
-FamixMetamodelGenerator class >> basicMetamodelClasses [
-	"We add to the creation of a metamodel all the metamodel entities of packages declaring to be part of the metamodels by default. 
-	
-	If a user of Famix wishes to add entities to all metamodels, they should add a methode #shouldBeIncludedByDefaultInMetamodels to their package manifest to return true."
-
-	^ (RPackageOrganizer default packages select: [ :package | package packageManifestOrNil ifNil: [ false ] ifNotNil: #shouldBeIncludedByDefaultInMetamodels ])
-		flatCollect: [ :package | package definedClasses select: #isMetamodelEntity ]
 ]
 
 { #category : #accessing }
@@ -141,14 +116,7 @@ FamixMetamodelGenerator class >> menuCommandOn: aBuilder [
 
 { #category : #accessing }
 FamixMetamodelGenerator class >> metamodel [
-	^ metamodel ifNil: [ metamodel := self resetMetamodel ]
-]
-
-{ #category : #accessing }
-FamixMetamodelGenerator class >> metamodel: anObject [
-
-	<ignoreForCoverage>
-	metamodel := anObject
+	^ self environment at: (self prefix , 'Model') asSymbol ifPresent: [ :m | m metamodel ]
 ]
 
 { #category : #generation }
@@ -159,16 +127,6 @@ FamixMetamodelGenerator class >> metamodelsToGenerate [
 	metamodels := self individualGenerators.
 	self addSubmetamodelsToGenerateFrom: metamodels to: metamodels.
 	^ metamodels
-]
-
-{ #category : #accessing }
-FamixMetamodelGenerator class >> newRepository [
-
-	| tower |
-	
-	tower := FMCompleteTower new.
-	tower metamodel addAll: self metamodel elements.
-	^ tower model.
 ]
 
 { #category : #accessing }
@@ -193,31 +151,9 @@ FamixMetamodelGenerator class >> prefix [
 ]
 
 { #category : #accessing }
-FamixMetamodelGenerator class >> resetMetamodel [
-	| classes tower |
-	"Collect all classes containing properties useful to the MM."
-	classes := (self packageName asPackage definedClasses asSet select: #isMetamodelEntity)
-		addAll: self basicMetamodelClasses;
-		yourself.
-
-	self allSubmetamodels do: [ :submetamodel | classes addAll: (submetamodel metamodel classes collect: #implementingClass) ].
-
-	"We need to reset the moose properties of each slot before building the tower."
-	(classes flatCollect: [ :class | class slots select: #isFMRelationSlot ]) do: #resetMooseProperty.
-
-	tower := MooseModel metaBuilder: classes.
-	self metamodel: tower metamodel.
-
-	"MooseEntity has a cache for some infos. When we regenerate a MM we need to flush this cache."
-	classes do: #resetMooseEntityCache.
-
-	^ metamodel
-]
-
-{ #category : #accessing }
 FamixMetamodelGenerator class >> resetMetamodels [
 	<script>
-	self metamodelsToGenerate do: #resetMetamodel
+	MooseModel allSubclassesDo: #resetMetamodel
 ]
 
 { #category : #accessing }
@@ -315,7 +251,7 @@ FamixMetamodelGenerator >> generate [
 				withCleaningDo: [ self builder generate.
 					self subBuilders do: #generateRemotes ]
 				with: self ].
-	self class resetMetamodel
+	self class environment at: (self prefix , 'Model') asSymbol ifPresent: #resetMetamodel
 ]
 
 { #category : #generation }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -227,13 +227,15 @@ FmxMBBehavior >> generateRemoteAccessors [
 FmxMBBehavior >> generateRootMetamodelMethodIn: aClass [
 	self isRoot ifFalse: [ ^ self ].
 
-	aClass classSide
-		compile:
-			('metamodel
+	prefix
+		ifNotEmpty: [ :pref | 
+			aClass classSide
+				compile:
+					('metamodel
 
 	<generated>
-	^ (self class environment at: #{1}) metamodel' format: {self builder generator class name})
-		classified: 'meta'
+	^ {1} metamodel' format: {(pref , 'Model') asSymbol})
+				classified: 'meta' ]
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -29,41 +29,16 @@ FmxMBGeneratorTest >> testGeneratorsAreUpToDate [
 ]
 
 { #category : #tests }
-FmxMBGeneratorTest >> testMooseModelSubclassHasInitialize [
-	| mooseModel |
-	FamixTest1Generator new generate.
-	mooseModel := 'FamixTest1Model' asClass.
-	self
-		assert: (mooseModel methods anySatisfy: [ :m | m selector = 'initialize' ])
-]
-
-{ #category : #tests }
 FmxMBGeneratorTest >> testMooseModelSubclassHasMetaModel [
-	| mooseModel |
-	FamixTest1Generator new generate.
-	mooseModel := 'FamixTest1Model' asClass new.
-	self
-		assert: mooseModel metamodel
-		equals: FamixTest1Generator metamodel
-]
-
-{ #category : #tests }
-FmxMBGeneratorTest >> testNewRepository [
-
-	| repository |
-	
-	repository := FamixTest1Generator newRepository.
-	self assert: repository isEmpty.	
-	self deny: repository metamodel elements isEmpty.
+	self assert: FamixTest1Model metamodel isNotNil.
+	self deny: MooseModel metamodel equals: FamixTest1Model metamodel
 ]
 
 { #category : #tests }
 FmxMBGeneratorTest >> testResetMetamodel [
-	
 	| metamodel |
-	
-	metamodel := FamixTest1Generator resetMetamodel.
-	self assert: (metamodel elementNamed: 'Famix-Test1-Entities.Entity' ifAbsent: [nil]) notNil.
+	metamodel := FamixTest1Model resetMetamodel.
+	self assert: (metamodel elementNamed: 'Famix-Test1-Entities.Entity' ifAbsent: [ nil ]) notNil
 ]
 
 { #category : #tests }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -17,7 +17,7 @@ FamixStEntity class >> annotation [
 FamixStEntity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixPharoSmalltalkGenerator) metamodel
+	^ FamixStModel metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStModel.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStModel.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-PharoSmalltalk-Entities'
 }
 
+{ #category : #accessing }
+FamixStModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixStModel class >> annotation [
 	<MSEClass: #FamixStModel super: #MooseModel>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixStModel >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixPharoSmalltalkGenerator) metamodel
 ]

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -17,7 +17,7 @@ FamixTest1Entity class >> annotation [
 FamixTest1Entity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTest1Generator) metamodel
+	^ FamixTest1Model metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-Test1-Entities/FamixTest1Model.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Model.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-Test1-Entities'
 }
 
+{ #category : #accessing }
+FamixTest1Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixTest1Model class >> annotation [
 	<MSEClass: #FamixTest1Model super: #MooseModel>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTest1Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTest1Generator) metamodel
 ]

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -17,7 +17,7 @@ FamixTest2Entity class >> annotation [
 FamixTest2Entity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTest2Generator) metamodel
+	^ FamixTest2Model metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-Test2-Entities/FamixTest2Model.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Model.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-Test2-Entities'
 }
 
+{ #category : #accessing }
+FamixTest2Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixTest2Model class >> annotation [
 	<MSEClass: #FamixTest2Model super: #MooseModel>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTest2Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTest2Generator) metamodel
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -17,7 +17,7 @@ FamixTest3Entity class >> annotation [
 FamixTest3Entity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTest3Generator) metamodel
+	^ FamixTest3Model metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-Test3-Entities/FamixTest3Model.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Model.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-Test3-Entities'
 }
 
+{ #category : #accessing }
+FamixTest3Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixTest3Model class >> annotation [
 	<MSEClass: #FamixTest3Model super: #MooseModel>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTest3Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTest3Generator) metamodel
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -20,7 +20,7 @@ FamixTest4Entity class >> annotation [
 FamixTest4Entity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTest4Generator) metamodel
+	^ FamixTest4Model metamodel
 ]
 
 { #category : #accessing }

--- a/src/Famix-Test4-Entities/FamixTest4Model.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Model.class.st
@@ -10,10 +10,3 @@ FamixTest4Model class >> annotation [
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 ]
-
-{ #category : #initialization }
-FamixTest4Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTest4Generator) metamodel
-]

--- a/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3Model.class.st
+++ b/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3Model.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-TestComposed3Metamodel-Entities'
 }
 
+{ #category : #accessing }
+FamixTestComposed3Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedMetamodel-Entities' 'Famix-TestComposedComposedMetamodel-Entities')
+]
+
 { #category : #meta }
 FamixTestComposed3Model class >> annotation [
 	<MSEClass: #FamixTestComposed3Model super: #MooseModel>
 	<package: #'Famix-TestComposed3Metamodel-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTestComposed3Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTestComposed3Generator) metamodel
 ]

--- a/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedModel.class.st
+++ b/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedModel.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-TestComposedComposedMetamodel-Entities'
 }
 
+{ #category : #accessing }
+FamixTestComposedComposedModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedMetamodel-Entities')
+]
+
 { #category : #meta }
 FamixTestComposedComposedModel class >> annotation [
 	<MSEClass: #FamixTestComposedComposedModel super: #MooseModel>
 	<package: #'Famix-TestComposedComposedMetamodel-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTestComposedComposedModel >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTestComposedComposedGenerator) metamodel
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -17,7 +17,7 @@ FamixTestComposedCustomEntity1 class >> annotation [
 FamixTestComposedCustomEntity1 class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedGenerator) metamodel
+	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -17,7 +17,7 @@ FamixTestComposedCustomEntity2 class >> annotation [
 FamixTestComposedCustomEntity2 class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedGenerator) metamodel
+	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -17,7 +17,7 @@ FamixTestComposedCustomEntity3 class >> annotation [
 FamixTestComposedCustomEntity3 class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedGenerator) metamodel
+	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -17,7 +17,7 @@ FamixTestComposedCustomEntity4 class >> annotation [
 FamixTestComposedCustomEntity4 class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedGenerator) metamodel
+	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -17,7 +17,7 @@ FamixTestComposedEntity class >> annotation [
 FamixTestComposedEntity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedGenerator) metamodel
+	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedModel.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedModel.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-TestComposedMetamodel-Entities'
 }
 
+{ #category : #accessing }
+FamixTestComposedModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedSubmetamodel1-Entities')
+]
+
 { #category : #meta }
 FamixTestComposedModel class >> annotation [
 	<MSEClass: #FamixTestComposedModel super: #MooseModel>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTestComposedModel >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTestComposedGenerator) metamodel
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -17,7 +17,7 @@ FamixTestComposed1Entity class >> annotation [
 FamixTestComposed1Entity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedSubmetamodel1Generator) metamodel
+	^ FamixTestComposed1Model metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Model.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Model.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-TestComposedSubmetamodel1-Entities'
 }
 
+{ #category : #accessing }
+FamixTestComposed1Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixTestComposed1Model class >> annotation [
 	<MSEClass: #FamixTestComposed1Model super: #MooseModel>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTestComposed1Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTestComposedSubmetamodel1Generator) metamodel
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -17,7 +17,7 @@ FamixTestComposed2Entity class >> annotation [
 FamixTestComposed2Entity class >> metamodel [
 
 	<generated>
-	^ (self class environment at: #FamixTestComposedSubmetamodel2Generator) metamodel
+	^ FamixTestComposed2Model metamodel
 ]
 
 { #category : #testing }

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Model.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Model.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-TestComposedSubmetamodel2-Entities'
 }
 
+{ #category : #accessing }
+FamixTestComposed2Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
 { #category : #meta }
 FamixTestComposed2Model class >> annotation [
 	<MSEClass: #FamixTestComposed2Model super: #MooseModel>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixTestComposed2Model >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixTestComposedSubmetamodel2Generator) metamodel
 ]

--- a/src/Famix-Traits/FamixModel.class.st
+++ b/src/Famix-Traits/FamixModel.class.st
@@ -4,16 +4,15 @@ Class {
 	#category : #'Famix-Traits'
 }
 
+{ #category : #accessing }
+FamixModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query')
+]
+
 { #category : #meta }
 FamixModel class >> annotation [
 	<MSEClass: #FamixModel super: #MooseModel>
 	<package: #'Famix-Traits'>
 	<generated>
-]
-
-{ #category : #initialization }
-FamixModel >> initialize [
-	<generated>
-	super initialize.
-	self metamodel: (self class environment at: #FamixGenerator) metamodel
 ]

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -12,16 +12,33 @@ Class {
 		'MostRecentOwner'
 	],
 	#classInstVars : [
-		'metaTower'
+		'metamodel'
 	],
 	#category : #'Moose-Core'
 }
+
+{ #category : #accessing }
+MooseModel class >> allSubmetamodelsPackagesNames [
+	^ #()
+]
 
 { #category : #meta }
 MooseModel class >> annotation [
 	<MSEClass: #Model super: #MooseAbstractGroup>
 	<package: #Moose>
 
+]
+
+{ #category : #accessing }
+MooseModel class >> defaultPackagesToProcess [
+	"We add to the creation of a metamodel all the metamodel entities of packages declaring to be part of the metamodels by default. 
+	
+	If a user of Famix wishes to add entities to all metamodels, they should add a methode #shouldBeIncludedByDefaultInMetamodels to their package manifest to return true."
+
+	^ RPackageOrganizer default packages
+		select: [ :package | package packageManifestOrNil
+			ifNil: [ false ]
+			ifNotNil: #shouldBeIncludedByDefaultInMetamodels ]
 ]
 
 { #category : #'import-export' }
@@ -183,10 +200,10 @@ MooseModel class >> metaBuilder: aCollectionOfClasses withProcessor: aPragmaProc
 ]
 
 { #category : #meta }
-MooseModel class >> metaTower [
-
-	^metaTower ifNil: [
-		metaTower := self metaBuilder: self metamodelClasses ]
+MooseModel class >> metamodel [
+	self flag: #TODO. "The next line is a hack to not break everything in Moose. It should be removed later."
+	self = MooseModel ifTrue: [ ^ FAMIXModel metamodel ].
+	^ metamodel ifNil: [ self resetMetamodel ]
 ]
 
 { #category : #meta }
@@ -216,6 +233,14 @@ MooseModel class >> newPragmaProcessor [
 	^ MoosePragmaProcessor new
 ]
 
+{ #category : #accessing }
+MooseModel class >> newRepository [
+	| tower |
+	tower := FMCompleteTower new.
+	tower metamodel addAll: self metamodel elements.
+	^ tower model
+]
+
 { #category : #'private-instance creation' }
 MooseModel class >> newWithDefaultModels [ 
 	 
@@ -243,6 +268,35 @@ MooseModel class >> ownerOf: element [
 		ifNotNil: [ :elementID | 
 			MostRecentOwner ifNotNil: [ :model | (model includesID: elementID) ifTrue: [ ^ model ] ].
 			self allInstances detect: [ :model | model includesID: elementID ] ifFound: [ :model | MostRecentOwner := model ] ifNone: [ nil ] ]
+]
+
+{ #category : #meta }
+MooseModel class >> resetMetamodel [
+	| packages classes tower |
+	packages := Set new.
+	packages add: self package.
+	packages addAll: (self allSubmetamodelsPackagesNames collect: #asPackage).
+	packages addAll: self defaultPackagesToProcess.
+
+	"Collect all classes containing properties useful to the MM."
+	classes := packages flatCollectAsSet: [ :p | p definedClasses asSet select: #isMetamodelEntity ].
+
+	"We need to reset the moose properties of each slot before building the tower."
+	(classes flatCollect: [ :class | class slots select: #isFMRelationSlot ]) do: #resetMooseProperty.
+
+	tower := self metaBuilder: classes.
+	metamodel := tower metamodel.
+
+	"MooseEntity has a cache for some infos. When we regenerate a MM we need to flush this cache."
+	classes do: #resetMooseEntityCache.
+
+	^ metamodel
+]
+
+{ #category : #accessing }
+MooseModel class >> resetMetamodels [
+	<script>
+	self allSubclassesDo: #resetMetamodel
 ]
 
 { #category : #'root model' }
@@ -440,10 +494,10 @@ MooseModel >> includesElementsOfType: aClass [
 ]
 
 { #category : #'initialize-release' }
-MooseModel >> initialize [ 
-	 
-	super initialize. 
-	name := #noname
+MooseModel >> initialize [
+	super initialize.
+	name := #noname.
+	self metamodel: self class metamodel
 ]
 
 { #category : #actions }

--- a/src/Moose-Tests-Core/FamixTest.class.st
+++ b/src/Moose-Tests-Core/FamixTest.class.st
@@ -53,7 +53,7 @@ FamixTest >> testMSEImport [
 	| importer model |
 	"MooseModel resetMeta."
 	importer := FMImporter new.
-	importer repository: FamixTest3Generator newRepository.
+	importer repository: FamixTest3Model newRepository.
 	importer fromString: self oneClassAndOneMethod.
 	importer run.
 	self assert: importer repository elements size equals: 2.
@@ -68,7 +68,7 @@ FamixTest >> testRobustMSEImport [
 	| importer model |
 	"MooseModel resetMeta."
 	importer := FMImporter new.
-	importer repository: FamixTest3Generator newRepository.
+	importer repository: FamixTest3Model newRepository.
 	importer fromString: self classWithUnknownAttribute.
 	importer run.
 


### PR DESCRIPTION
Move generation and storage of MMs from the generator to the model.

Fixes #1873