### PR TITLE
move to Pharo 8 validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ smalltalk:
 matrix:
   fast_finish: true
   allow_failures:
-    - smalltalk: Pharo64-8.0
+    - smalltalk: Pharo64-7.0
 
 after_success:
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh


### PR DESCRIPTION
Allow failures for Pharo7 but the version will be released on Pharo 8, so let's target this version