### PR TITLE
Source-anchor-should-not-define-parent-and-children-types

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -15,18 +15,6 @@ FAMIXSourceAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #'Moose-Query-Extensions' }
-FAMIXSourceAnchor class >> childrenTypes [
-	self flag: #todo. "Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."
-	^ {}
-]
-
-{ #category : #'Moose-Query-Extensions' }
-FAMIXSourceAnchor class >> parentTypes [
-	self flag: #todo. "Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."
-	^ {}
-]
-
 { #category : #accessing }
 FAMIXSourceAnchor >> belongsTo [ 
 		

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -15,18 +15,6 @@ FamixJavaSourceAnchor class >> annotation [
 	^self
 ]
 
-{ #category : #accessing }
-FamixJavaSourceAnchor class >> childrenTypes [
-	self flag: #todo. "Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."
-	^ {}
-]
-
-{ #category : #accessing }
-FamixJavaSourceAnchor class >> parentTypes [
-	self flag: #todo. "Source Anchors should not implement TEntityMetaLevelDependency but currently a source anchor is in Moose containment tree. This is a bug but Orion depend on this hack. So we first need to clean Orion, then we can remove those aweful methods. here."
-	^ {}
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaSourceAnchor >> completeText [
 	"The complete text of a FileAnchor contains all the code of the file pointed by the source anchor. On the contrary the #sourceText return only the pant of the file concerned by the entity. For example a FAMIXFileAnchon knows the start line and end line of the source anchor into the file."


### PR DESCRIPTION
Remove #parentTypes and #childrenTypes for source anchors.