### PR TITLE
Cut-dependency-between-Moose-SmalltalkImporter-and-generators

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -44,7 +44,7 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-BasicInfrastructure' with: [ spec requires: #('Famix-MetamodelGeneration') ];
 				package: 'Famix-Smalltalk-Utils' with: [ spec requires: #('Moose-Core') ];
 				package: 'Moose-GenericImporter' with: [ spec requires: #('Famix-Compatibility-Entities') ];
-				package: 'Moose-SmalltalkImporter' with: [ spec requires: #('Moose-GenericImporter' 'RoelTyper' 'Famix-BasicInfrastructure') ];
+				package: 'Moose-SmalltalkImporter' with: [ spec requires: #('Moose-GenericImporter' 'RoelTyper') ];
 
 				package: 'Famix-Compatibility-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-Compatibility-Entities' with: [ spec requires: #('BasicTraits' 'Famix-Smalltalk-Utils') ];

--- a/src/Moose-GenericImporter/AllMooseMetamodelImportingContext.class.st
+++ b/src/Moose-GenericImporter/AllMooseMetamodelImportingContext.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #AllMooseMetamodelImportingContext,
 	#superclass : #MooseAbstractImportingContext,
-	#category : #'Moose-GenericImporter'
+	#category : #'Moose-GenericImporter-Contexts'
 }
 
 { #category : #'instance creation' }

--- a/src/Moose-GenericImporter/FAMIXStandardImportingContext.class.st
+++ b/src/Moose-GenericImporter/FAMIXStandardImportingContext.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FAMIXStandardImportingContext,
 	#superclass : #MooseAbstractImportingContext,
-	#category : #'Moose-GenericImporter'
+	#category : #'Moose-GenericImporter-Contexts'
 }
 
 { #category : #'instance creation' }

--- a/src/Moose-GenericImporter/FamixBasicInfrastructureMetamodelFactory.class.st
+++ b/src/Moose-GenericImporter/FamixBasicInfrastructureMetamodelFactory.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixBasicInfrastructureMetamodelFactory,
 	#superclass : #FMMetamodelFactory,
-	#category : #'Famix-BasicInfrastructure'
+	#category : #'Moose-GenericImporter-Factories'
 }
 
 { #category : #testing }

--- a/src/Moose-GenericImporter/FamixFileBasedLanguageMetamodelFactory.class.st
+++ b/src/Moose-GenericImporter/FamixFileBasedLanguageMetamodelFactory.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixFileBasedLanguageMetamodelFactory,
 	#superclass : #FamixBasicInfrastructureMetamodelFactory,
-	#category : #'Famix-BasicInfrastructure'
+	#category : #'Moose-GenericImporter-Factories'
 }
 
 { #category : #testing }
@@ -9,43 +9,43 @@ FamixFileBasedLanguageMetamodelFactory class >> isAbstract [
 	^ self = FamixFileBasedLanguageMetamodelFactory
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> abstractFile [
 
 	^ self entityNamed: #AbstractFile
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> abstractFileAnchor [
 
 	^ self entityNamed: #AbstractFileAnchor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> file [
 
 	^ self entityNamed: #File
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> fileAnchor [
 
 	^ self entityNamed: #FileAnchor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> folder [
 
 	^ self entityNamed: #Folder
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> indexedFileAnchor [
 
 	^ self entityNamed: #IndexedFileAnchor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FamixFileBasedLanguageMetamodelFactory >> multipleFileAnchor [
 
 	^ self entityNamed: #MultipleFileAnchor

--- a/src/Moose-GenericImporter/MooseAbstractImporter.class.st
+++ b/src/Moose-GenericImporter/MooseAbstractImporter.class.st
@@ -10,7 +10,7 @@ Class {
 		'loggingStream',
 		'targetModel'
 	],
-	#category : #'Moose-GenericImporter'
+	#category : #'Moose-GenericImporter-Importers'
 }
 
 { #category : #public }

--- a/src/Moose-GenericImporter/MooseAbstractImportingContext.class.st
+++ b/src/Moose-GenericImporter/MooseAbstractImportingContext.class.st
@@ -20,7 +20,7 @@ Class {
 	#classInstVars : [
 		'entityDependencies'
 	],
-	#category : #'Moose-GenericImporter'
+	#category : #'Moose-GenericImporter-Contexts'
 }
 
 { #category : #'instance creation' }

--- a/src/Moose-GenericImporter/MooseFileStructureImporter.class.st
+++ b/src/Moose-GenericImporter/MooseFileStructureImporter.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'mooseModel'
 	],
-	#category : #'Moose-GenericImporter'
+	#category : #'Moose-GenericImporter-Importers'
 }
 
 { #category : #accessing }

--- a/src/Moose-GenericImporter/MooseImportingContext.class.st
+++ b/src/Moose-GenericImporter/MooseImportingContext.class.st
@@ -33,7 +33,7 @@ Class {
 	#classInstVars : [
 		'entityDependencies'
 	],
-	#category : #'Moose-GenericImporter'
+	#category : #'Moose-GenericImporter-Contexts'
 }
 
 { #category : #'importing-filters' }


### PR DESCRIPTION
The Moose-SmalltalkImporter should not depend on Famix-BasicInfrastructure.