### PR TITLE
Clean-Smalltalk-tests-dependencies

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -59,15 +59,16 @@ BaselineOfFamix >> baseline: spec [
 
 				package: 'Moose-TestResources-LAN';
 				package: 'Moose-TestResources-LCOM';
+
 				package: 'Moose-Query-Test' with: [ spec requires: #('Moose-Query' 'Famix-Java-Entities') ];
 				package: 'FamixTestGenerator' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-Tests' with: [ spec requires: #('BasicTraits' 'Talents') ];
-				package: 'Moose-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'TestModels' 'Moose-SmalltalkImporter' 'ReferenceTestResources') ];
+				package: 'Moose-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'TestModels' 'ReferenceTestResources') ];
 				package: 'Famix-Groups-Tests' with: [ spec requires: #('Famix-Groups' 'Moose-Tests-Core') ];
 				package: 'Famix-Smalltalk-Utils-Tests' with: [ spec requires: #('Famix-Smalltalk-Utils') ];
-				package: 'Moose-Tests-SmalltalkImporter-LAN' with: [ spec requires: #('Moose-Tests-Core' 'Moose-TestResources-LAN' 'Moose-SmalltalkImporter') ];
-				package: 'Moose-Tests-SmalltalkImporter-Core' with: [ spec requires: #('Moose-Tests-SmalltalkImporter-LAN') ];
-				package: 'Moose-Tests-SmalltalkImporter-KGB' with: [ spec requires: #('Moose-Tests-Core' 'KGBTestResources' 'Moose-SmalltalkImporter') ];
+				package: 'Moose-Tests-SmalltalkImporter-LAN' with: [ spec requires: #('Moose-Tests-SmalltalkImporter-Core' 'Moose-TestResources-LAN') ];
+				package: 'Moose-Tests-SmalltalkImporter-Core' with: [ spec requires: #('Moose-Tests-Core' 'Moose-SmalltalkImporter') ];
+				package: 'Moose-Tests-SmalltalkImporter-KGB' with: [ spec requires: #('KGBTestResources' 'Moose-Tests-SmalltalkImporter-Core') ];
 				package: 'Famix-Compatibility-Tests-C' with: [ spec requires: #('Famix-Compatibility-Entities') ];
 				package: 'Famix-Compatibility-Tests-Java' with: [ spec requires: #('Moose-Tests-Core') ];
 				package: 'Famix-Compatibility-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'Moose-Tests-SmalltalkImporter-LAN' 'Moose-Tests-SmalltalkImporter-KGB') ];

--- a/src/Moose-Tests-SmalltalkImporter-Core/MooseModelTestResourceWithSmalltalkDependency.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MooseModelTestResourceWithSmalltalkDependency.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MooseModelTestResourceWithSmalltalkDependency,
 	#superclass : #MooseModelTestResource,
-	#category : #'Moose-Tests-Core'
+	#category : #'Moose-Tests-SmalltalkImporter-Core'
 }
 
 { #category : #testing }

--- a/src/Moose-Tests-SmalltalkImporter-Core/MoosePharoImporterTaskTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MoosePharoImporterTaskTest.class.st
@@ -21,5 +21,5 @@ MoosePharoImporterTaskTest >> testImportedModelHasSmalltalkMetamodel [
 		model: FamixStModel new;
 		addFromPackageNamed: 'Moose-Tests-SmalltalkImporter-Core';
 		basicRun.
-	self assert: model metamodel equals: FamixPharoSmalltalkGenerator metamodel
+	self assert: model metamodel equals: FamixStModel metamodel
 ]

--- a/src/Moose-Tests-SmalltalkImporter-Core/MooseScriptsTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MooseScriptsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MooseScriptsTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Tests-Core'
+	#category : #'Moose-Tests-SmalltalkImporter-Core'
 }
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-Core/MooseSmalltalkImporterSubclassesTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MooseSmalltalkImporterSubclassesTest.class.st
@@ -33,7 +33,6 @@ MooseSmalltalkImporterSubclassesTest >> setUp [
 	super setUp.
 	model := FamixStModel new.	
 	model name: 'Test'.
-	model sourceLanguage: FAMIXSmalltalkSourceLanguage new.
 	pharoImporterTask := MoosePharoImporterTask new
 		importerClass: SmalltalkImporter;
 		doNotRunCandidateOperator; 

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FamixInvocationsTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FamixInvocationsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixInvocationsTest,
 	#superclass : #LANAbstractImportTest,
-	#category : #'Moose-Tests-SmalltalkImporter-Core'
+	#category : #'Moose-Tests-SmalltalkImporter-LAN'
 }
 
 { #category : #model }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FamixModelExtractionTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FamixModelExtractionTest.class.st
@@ -25,7 +25,7 @@ Class {
 		'canOriginateNodeName',
 		'methodWithEmptyBodyNodeName'
 	],
-	#category : #'Moose-Tests-SmalltalkImporter-Core'
+	#category : #'Moose-Tests-SmalltalkImporter-LAN'
 }
 
 { #category : #auxiliary }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FamixPropertiesTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FamixPropertiesTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixPropertiesTest,
 	#superclass : #LANAbstractImportTest,
-	#category : #'Moose-Tests-SmalltalkImporter-Core'
+	#category : #'Moose-Tests-SmalltalkImporter-LAN'
 }
 
 { #category : #testing }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/MooseSqueakClassPackageImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/MooseSqueakClassPackageImporterTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MooseSqueakClassPackageImporterTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Tests-SmalltalkImporter-Core'
+	#category : #'Moose-Tests-SmalltalkImporter-LAN'
 }
 
 { #category : #'testing collecting classes' }


### PR DESCRIPTION
Do a pass of cleaning on Smalltalk tests

- Moose-Tests-Core should not depend on the Smalltalk importer
- Moose-Tests-SmalltalkImporter-Core should not depend on LAN
- Moose-Tests-SmalltalkImporter-LAN and Moose-Tests-SmalltalkImporter-KGB should depend on Moose-Tests-SmalltalkImporter-Core