### PR TITLE
Remove-some-accesses-to-metamodel-via-generators

### DIFF
--- a/src/Famix-Compatibility-Tests-Java/VerveineJModelTest.class.st
+++ b/src/Famix-Compatibility-Tests-Java/VerveineJModelTest.class.st
@@ -10,8 +10,7 @@ Class {
 { #category : #running }
 VerveineJModelTest >> setUp [
 	super setUp.
-	model := MooseModel new.
-	model metamodel: FamixCompatibilityGenerator metamodel.
+	model := FAMIXModel new.
 	model importFromMSEStream: VerveineJTestResource new mse readStream
 	
 ]

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedComposedMetamodels.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedComposedMetamodels.class.st
@@ -7,16 +7,15 @@ Class {
 { #category : #tests }
 FamixTestComposedComposedMetamodels >> testModifyMetamodelRecursiveSubmetamodels [
 	| customEntity1 |
-	customEntity1 := ((FamixTestComposed3Generator metamodel at: 'Famix-TestComposedMetamodel-Entities') at: 'CustomEntity1').
+	customEntity1 := ((FamixTestComposed3Model metamodel at: 'Famix-TestComposedMetamodel-Entities') at: 'CustomEntity1').
 	self assert: (customEntity1 at: 'c21') opposite isNotNil.
-	self assert: (customEntity1 at: 'customEntity1') opposite isNotNil.
-
+	self assert: (customEntity1 at: 'customEntity1') opposite isNotNil
 ]
 
 { #category : #tests }
 FamixTestComposedComposedMetamodels >> testModifyMetamodelSubmetamodels [
 	| customEntity1 |
-	customEntity1 := ((FamixTestComposedComposedGenerator metamodel at: 'Famix-TestComposedMetamodel-Entities') at: 'CustomEntity1').
+	customEntity1 := ((FamixTestComposedComposedModel metamodel at: 'Famix-TestComposedMetamodel-Entities') at: 'CustomEntity1').
 	self assert: (customEntity1 at: 'c21') opposite isNotNil.
 	self assert: (customEntity1 at: 'customEntity1') opposite isNotNil.
 

--- a/src/Moose-RoassalPaintings/MooseFameView.class.st
+++ b/src/Moose-RoassalPaintings/MooseFameView.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #opening }
 MooseFameView >> open [
-	^ self openOn: MooseModel meta
+	^ self openOn: FAMIXModel metamodel
 ]
 
 { #category : #opening }


### PR DESCRIPTION
The generators should not be used anymore to access metamodels.

Here I remove some of the users.