### PR TITLE
browseMeta-should-use-the-metamodel-of-the-model-and-not-compatibility-metamodel

### DIFF
--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -60,7 +60,7 @@ MooseModel class >> exportMetamodel: aMetamodel to: aStream [
 { #category : #'import-export' }
 MooseModel class >> exportMetamodelTo: aStream [
 	self deprecated: 'Use exportMetamodelTo: in instance side'.
-	self exportMetamodel: self meta to: aStream
+	self exportMetamodel: self metamodel to: aStream
 ]
 
 { #category : #accessing }

--- a/src/Moose-Finder/MooseModel.extension.st
+++ b/src/Moose-Finder/MooseModel.extension.st
@@ -35,7 +35,7 @@ MooseModel >> browseMeta [
 
 { #category : #'*Moose-Finder' }
 MooseModel class >> browseMeta [
-	^ MooseMetaBrowser new openOn: MooseModel meta
+	^ MooseMetaBrowser new openOn: self metamodel
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -135,7 +135,7 @@ MooseModelTest >> testPrintOn [
 	group name: 'hello2'.
 	group add: MooseEntity new.
 	self assert: group printString equals: 'a MooseModel #hello2(1)'.
-	self assert: self actualClass meta printString equals: 'a FMMetaRepository'
+	self assert: self actualClass metamodel printString equals: 'a FMMetaRepository'
 ]
 
 { #category : #tests }


### PR DESCRIPTION
MooseModel>>#browseMeta should open on the metamodel of the model instead of the compatibility metamodel