### PR TITLE
Java-types-should-have-methods

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -15,6 +15,13 @@ FamixJavaMethod class >> annotation [
 	^self
 ]
 
+{ #category : #meta }
+FamixJavaMethod class >> requirements [
+
+	<generated>
+	^ { FamixJavaType }
+]
+
 { #category : #'Famix-Extensions-metrics-support' }
 FamixJavaMethod >> accessedAttributes [
 	

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaType,
 	#superclass : #FamixJavaContainerEntity,
-	#traits : 'FamixTClassHierarchyNavigation + FamixTParameterizedTypeUser + FamixTType + FamixTWithTypeAliases',
-	#classTraits : 'FamixTClassHierarchyNavigation classTrait + FamixTParameterizedTypeUser classTrait + FamixTType classTrait + FamixTWithTypeAliases classTrait',
+	#traits : 'FamixTClassHierarchyNavigation + FamixTParameterizedTypeUser + FamixTType + FamixTWithMethods + FamixTWithTypeAliases',
+	#classTraits : 'FamixTClassHierarchyNavigation classTrait + FamixTParameterizedTypeUser classTrait + FamixTType classTrait + FamixTWithMethods classTrait + FamixTWithTypeAliases classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -238,6 +238,7 @@ FamixJavaGenerator >> defineHierarchy [
 	type --|> #TWithTypeAliases.
 	type --|> #TParameterizedTypeUser.
 	type --|> #TClassHierarchyNavigation. 
+	type --|> #TWithMethods.
 
 	tStructuralEntity --|> #TStructuralEntity.
 	tStructuralEntity --|> #TWithDereferencedInvocations.


### PR DESCRIPTION
Java types should have methods.