### PR TITLE
Cleaning-of-FMRelationSlot

### DIFF
--- a/src/Fame-Core/FMMany.class.st
+++ b/src/Fame-Core/FMMany.class.st
@@ -6,11 +6,7 @@ Class {
 
 { #category : #internal }
 FMMany >> add: newObject to: collectionOwner [
-
-	self checkValue: newObject.
-	self hasInverse
-		ifTrue: [ self addAssociationFrom: collectionOwner to: newObject ]
-
+	self hasInverse ifTrue: [ self addAssociationFrom: collectionOwner to: newObject ]
 ]
 
 { #category : #initialization }
@@ -18,28 +14,6 @@ FMMany >> initialize: anObject [
 
 	self write: (FMSlotMultivalueLink on: anObject slot: self) to: anObject. 
 	
-]
-
-{ #category : #initialization }
-FMMany >> lazyInitializationFor: anObject slotValue: aSlotValue [
-
-	| newLink |
-	
-	aSlotValue ifNotNil: [ ^ aSlotValue ].
-	
-	newLink := (FMSlotMultivalueLink on: anObject slot: self).
-
-	thisContext object: anObject instVarAt: index put: newLink.
-	
-	^ newLink
-
-
-]
-
-{ #category : #'meta-object-protocol' }
-FMMany >> mooseProperty [
-
-	^ self moosePropertyFor: self owningClass name multivalued: true.
 ]
 
 { #category : #internal }

--- a/src/Fame-Core/FMOne.class.st
+++ b/src/Fame-Core/FMOne.class.st
@@ -5,23 +5,15 @@ Class {
 }
 
 { #category : #testing }
-FMOne >> isToOneSlot [
-
-	^true
-]
-
-{ #category : #'meta-object-protocol' }
-FMOne >> mooseProperty [
-
-	^ self moosePropertyFor: self owningClass name multivalued: false.
+FMOne >> isToOne [
+	^ true
 ]
 
 { #category : #'meta-object-protocol' }
 FMOne >> write: newValue to: anObject [
 	| oldValue |
 	oldValue := self read: anObject.
-	
-	newValue ifNotNil: [ self checkValue: newValue ].
+
 	self hasInverse
 		ifTrue: [ oldValue ifNotNil: [ self removeAssociationFrom: anObject to: oldValue ].
 			newValue ifNotNil: [ self addAssociationFrom: anObject to: newValue ] ].
@@ -31,5 +23,5 @@ FMOne >> write: newValue to: anObject [
 
 { #category : #internal }
 FMOne >> writeInverse: newValue to: anObject [
-	^anObject instVarAt: index put: newValue
+	^ anObject instVarAt: index put: newValue
 ]

--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -5,7 +5,7 @@ Class {
 		'targetClass',
 		'inverseName',
 		'inverseSlot',
-		'moosePropertyDictionary'
+		'mooseProperty'
 	],
 	#category : #'Fame-Core-Slots'
 }
@@ -17,13 +17,8 @@ FMRelationSlot class >> named: aSymbol inverse: anInverseSymbol inClass: aTarget
 ]
 
 { #category : #comparing }
-FMRelationSlot >> = anObject [ 
-
-	^super = anObject and: [ 
-		self targetClassName = anObject targetClassName and: [ 
-			inverseName = anObject inverseName ] ]
-
-	
+FMRelationSlot >> = anObject [
+	^ super = anObject and: [ self targetClassName = anObject targetClassName and: [ inverseName = anObject inverseName ] ]
 ]
 
 { #category : #internal }
@@ -35,25 +30,10 @@ FMRelationSlot >> addAssociationFrom: ownerObject to: otherObject [
 	| realInverseSlot |
 	realInverseSlot := self realInverseSlotFor: otherObject.
 
-	realInverseSlot isToOneSlot
+	realInverseSlot isToOne
 		ifTrue: [ (realInverseSlot read: otherObject) ifNotNil: [ :oldObject | realInverseSlot removeAssociationFrom: otherObject to: oldObject ].
 			realInverseSlot writeInverse: ownerObject to: otherObject ]
 		ifFalse: [ (realInverseSlot read: otherObject) inverseAdd: ownerObject ]
-]
-
-{ #category : #accessing }
-FMRelationSlot >> argumentAt: n [
-	"only for compatibility with Fame pragmas"
-
-	self assert: n = 1.
-	^ self name asSymbol
-]
-
-{ #category : #internal }
-FMRelationSlot >> checkValue: aValue [
-
-	"(aValue isKindOf: self targetClass)
-		ifFalse: [ self error: 'Invalid value' ]."
 ]
 
 { #category : #'code generation' }
@@ -80,16 +60,14 @@ FMRelationSlot >> emitValue: aMethodBuilder [
 
 { #category : #testing }
 FMRelationSlot >> hasInverse [
-
-	^inverseName notNil
+	^ inverseName isNotNil
 ]
 
 { #category : #comparing }
 FMRelationSlot >> hasSameDefinitionAs: otherSlot [
-
-	^ (super hasSameDefinitionAs: otherSlot) 
-		and: [ self targetClassName = otherSlot targetClassName 
-		and: [ inverseName = otherSlot inverseName ] ]
+	^ (super hasSameDefinitionAs: otherSlot)
+		and: [ self targetClassName = otherSlot targetClassName
+			and: [ inverseName = otherSlot inverseName ] ]
 ]
 
 { #category : #comparing }
@@ -101,38 +79,34 @@ FMRelationSlot >> hash [
 
 { #category : #initialization }
 FMRelationSlot >> inClass: aTargetClassOrSymbol [
-
 	targetClass := aTargetClassOrSymbol
 ]
 
 { #category : #initialization }
 FMRelationSlot >> inverse: anInverseSymbol inClass: aTargetClassOrSymbol [
-
 	self inClass: aTargetClassOrSymbol.
-	inverseName := anInverseSymbol.
+	inverseName := anInverseSymbol
 ]
 
 { #category : #accessing }
 FMRelationSlot >> inverseName [
-
-	^inverseName
+	^ inverseName
 ]
 
 { #category : #accessing }
 FMRelationSlot >> inverseSlot [
-
-	^inverseSlot ifNil: [ self linkUp. inverseSlot ]
+	^ inverseSlot
+		ifNil: [ self linkUp.
+			inverseSlot ]
 ]
 
 { #category : #testing }
-FMRelationSlot >> isAccessedIn: aMethod [ 
-
+FMRelationSlot >> isAccessedIn: aMethod [
 	^ aMethod allLiterals includes: self
 ]
 
 { #category : #testing }
 FMRelationSlot >> isFMRelationSlot [
-
 	^ true
 ]
 
@@ -142,97 +116,64 @@ FMRelationSlot >> isFameSlot [
 ]
 
 { #category : #testing }
-FMRelationSlot >> isReadIn: aMethod [ 
-
+FMRelationSlot >> isReadIn: aMethod [
 	^ aMethod allLiterals includes: self
 ]
 
 { #category : #testing }
-FMRelationSlot >> isToOneSlot [
-
-	^false
+FMRelationSlot >> isToMany [
+	^ self isToOne not
 ]
 
 { #category : #testing }
-FMRelationSlot >> isWrittenIn: aMethod [ 
-
-	^ aMethod allLiterals includes: self
+FMRelationSlot >> isToOne [
+	^ false
 ]
 
-{ #category : #initialization }
-FMRelationSlot >> lazyInitializationFor: anObject slotValue: aSlotValue [
-
-	^ aSlotValue
+{ #category : #testing }
+FMRelationSlot >> isWrittenIn: aMethod [
+	^ aMethod allLiterals includes: self
 ]
 
 { #category : #initialization }
 FMRelationSlot >> linkUp [
-
 	inverseSlot := self targetClass slotNamed: inverseName.
-	(self inverseSlot isFMRelationSlot)
-		ifFalse: [ self error: 'Invalid association: ... ' ].
-		
-	self inverseSlot inverseName = self name
-		ifFalse: [ self error: 'Invalid association: inverse names do not match' ].
+	self inverseSlot isFMRelationSlot ifFalse: [ self error: 'Invalid association: ... ' ].
+
+	self inverseSlot inverseName = self name ifFalse: [ self error: 'Invalid association: inverse names do not match' ]
 ]
 
 { #category : #internal }
-FMRelationSlot >> moosePropertyDictionary [
-
-	^ moosePropertyDictionary ifNil: [ moosePropertyDictionary := Dictionary new ].
-]
-
-{ #category : #internal }
-FMRelationSlot >> moosePropertyFor: anOwningClassName multivalued: aBoolean [
-
-	| mooseProperty needsToBeSet |
-	
+FMRelationSlot >> mooseProperty [
+	| needsToBeSet |
 	needsToBeSet := false.
-	
-	mooseProperty := self moosePropertyDictionary at: anOwningClassName ifAbsentPut: [
-		needsToBeSet := true.
-		FM3PropertyDescription new ].
-	
-	needsToBeSet ifTrue: [ 
-		mooseProperty name: self name asString.
-		mooseProperty setImplementingSelector: self name. "should be a link to slot"
 
-		mooseProperty isMultivalued: aBoolean.
-		
-		mooseProperty privOpposite: self inverseSlot mooseProperty ].
-	
-	^ mooseProperty.
+	mooseProperty
+		ifNil: [ needsToBeSet := true.
+			mooseProperty := FM3PropertyDescription new ].
 
-		
+	needsToBeSet
+		ifTrue: [ mooseProperty name: self name asString.
+			mooseProperty setImplementingSelector: self name.	"should be a link to slot"
+			mooseProperty isMultivalued: self isToMany.
+			mooseProperty privOpposite: self inverseSlot mooseProperty ].
+
+	^ mooseProperty
 ]
 
 { #category : #printing }
 FMRelationSlot >> printOn: aStream [
-	aStream 
+	aStream
 		store: self name;
 		nextPutAll: ' => ';
 		nextPutAll: self class name.
 	aStream
 		nextPutAll: ' type: ';
 		store: self targetClassName.
-	self hasInverse 
-		ifTrue: [ 
-			aStream
+	self hasInverse
+		ifTrue: [ aStream
 				nextPutAll: ' opposite: ';
-				store: inverseName ].
-
-]
-
-{ #category : #internal }
-FMRelationSlot >> read: anObject [
-
-	| slotValue | 
-	
-	slotValue := thisContext object: anObject instVarAt: index.
-	^ slotValue
-	"^ self lazyInitializationFor: anObject slotValue: slotValue".
-	
-
+				store: inverseName ]
 ]
 
 { #category : #accessing }
@@ -244,21 +185,19 @@ FMRelationSlot >> realInverseSlotFor: anObject [
 FMRelationSlot >> removeAssociationFrom: ownerObject to: otherObject [
 	"A reference from <ownerObject> to <otherObject> is removed. Here we update the other 
 	side of the association. If the other side is a ToOne association set the value to nil,
-	for ToMany associations remove <ownerObject> from the collection." 
+	for ToMany associations remove <ownerObject> from the collection."
 
 	| realInverseSlot |
-	
-	realInverseSlot := (self realInverseSlotFor: otherObject).
+	realInverseSlot := self realInverseSlotFor: otherObject.
 
-	realInverseSlot isToOneSlot
+	realInverseSlot isToOne
 		ifTrue: [ realInverseSlot writeInverse: nil to: otherObject ]
 		ifFalse: [ (realInverseSlot read: otherObject) inverseRemove: ownerObject ]
 ]
 
 { #category : #internal }
 FMRelationSlot >> resetMooseProperty [
-
-	moosePropertyDictionary := nil.
+	mooseProperty := nil
 ]
 
 { #category : #accessing }
@@ -274,22 +213,11 @@ FMRelationSlot >> targetClass [
 
 { #category : #accessing }
 FMRelationSlot >> targetClassName [
-
-	^targetClass isSymbol
-		ifTrue: [ targetClass ]
-		ifFalse: [ targetClass name ]
+	^ targetClass isSymbol ifTrue: [ targetClass ] ifFalse: [ targetClass name ]
 ]
 
-{ #category : #initialization }
+{ #category : #testing }
 FMRelationSlot >> type: aTargetClassOrSymbol opposite: anInverseSymbol [
-
 	self inClass: aTargetClassOrSymbol.
-	inverseName := anInverseSymbol.
-]
-
-{ #category : #accessing }
-FMRelationSlot >> write: aValue to: anObject [
-
-	self read: anObject. "to invoke lazy initialization"
-	^ super write: aValue to: anObject
+	inverseName := anInverseSymbol
 ]


### PR DESCRIPTION
Small cleaning of the FMRelationSlot

- Remove dead code
- Use a variable instead of a dictionary to store the moose property
- Some small improvements