### PR TITLE
Move-all-MM-creation-to-FMPragmaProcessor

### DIFF
--- a/src/Fame-Core/FM3PropertyDescription.class.st
+++ b/src/Fame-Core/FM3PropertyDescription.class.st
@@ -259,13 +259,13 @@ FM3PropertyDescription >> opposite [
 
 { #category : #accessing }
 FM3PropertyDescription >> opposite: new [
-	
-	opposite ~~ new ifTrue: [
-		| old |
-		old := opposite.
-		opposite := new.
-		old notNil ifTrue: [ old opposite: nil ].
-		new notNil ifTrue: [ new opposite: self ]]
+	| old |
+	opposite ~~ new ifFalse: [ ^ self ].
+
+	old := opposite.
+	opposite := new.
+	old ifNotNil: [ old opposite: nil ].
+	new ifNotNil: [ new opposite: self ]
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FMRelationSlot.class.st
+++ b/src/Fame-Core/FMRelationSlot.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'targetClass',
 		'inverseName',
-		'inverseSlot',
-		'mooseProperty'
+		'inverseSlot'
 	],
 	#category : #'Fame-Core-Slots'
 }
@@ -143,24 +142,6 @@ FMRelationSlot >> linkUp [
 	self inverseSlot inverseName = self name ifFalse: [ self error: 'Invalid association: inverse names do not match' ]
 ]
 
-{ #category : #internal }
-FMRelationSlot >> mooseProperty [
-	| needsToBeSet |
-	needsToBeSet := false.
-
-	mooseProperty
-		ifNil: [ needsToBeSet := true.
-			mooseProperty := FM3PropertyDescription new ].
-
-	needsToBeSet
-		ifTrue: [ mooseProperty name: self name asString.
-			mooseProperty setImplementingSelector: self name.	"should be a link to slot"
-			mooseProperty isMultivalued: self isToMany.
-			mooseProperty privOpposite: self inverseSlot mooseProperty ].
-
-	^ mooseProperty
-]
-
 { #category : #printing }
 FMRelationSlot >> printOn: aStream [
 	aStream
@@ -193,11 +174,6 @@ FMRelationSlot >> removeAssociationFrom: ownerObject to: otherObject [
 	realInverseSlot isToOne
 		ifTrue: [ realInverseSlot writeInverse: nil to: otherObject ]
 		ifFalse: [ (realInverseSlot read: otherObject) inverseRemove: ownerObject ]
-]
-
-{ #category : #internal }
-FMRelationSlot >> resetMooseProperty [
-	mooseProperty := nil
 ]
 
 { #category : #accessing }

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -43,7 +43,8 @@ Class {
 		'mmClassDict',
 		'queue',
 		'implementingPackages',
-		'packDict'
+		'packDict',
+		'slotDict'
 	],
 	#classVars : [
 		'ShouldValidateMetaModel'
@@ -160,6 +161,7 @@ FMPragmaProcessor >> initialize [
 	oppositeDict := IdentityDictionary new.
 	mmClassDict := IdentityDictionary new.
 	metaDict := Dictionary new.
+	slotDict := IdentityDictionary new.
 
 	"Must use the cannonical primitives here!"
 	"Please do not at these primitives to elements!"
@@ -205,7 +207,7 @@ FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 			self extractPackageFrom: pragma method for: fm3Class.
 			classDict at: aClass put: fm3Class.
 			(self methodsToProcessFrom: aClass) do: [ :each | self processCompiledMethod: each ].
-			aClass slots do: [ :each | self processSlot: each in: aClass ].
+			aClass slots select: #isFMRelationSlot thenDo: [ :each | self processSlot: each in: aClass ].
 
 			elements add: fm3Class ]
 ]
@@ -256,9 +258,18 @@ FMPragmaProcessor >> processInfosFrom: aMethod for: prop [
 { #category : #private }
 FMPragmaProcessor >> processSlot: aSlot in: aClass [
 	| prop |
-	aSlot isFMRelationSlot ifFalse: [ ^ self ].
+	"It is possible the property was created when we set the opposite."
+	prop := slotDict at: aSlot ifAbsentPut: [ FM3PropertyDescription new ].
 
-	prop := aSlot mooseProperty.
+	slotDict at: aSlot put: prop.
+	prop name: aSlot name asString.
+	prop setImplementingSelector: aSlot name.
+	prop isMultivalued: aSlot isToMany.
+
+	self flag: #todo. "I don't know why the commented line does not work instead of the ugly line after. It'll try to find some time to check later."
+	"oppositeDict at: prop put: aSlot inverseName."
+	prop privOpposite: (slotDict at: aSlot inverseSlot ifAbsentPut: [ FM3PropertyDescription new ]).
+
 
 	typeDict at: prop put: aSlot targetClass.
 	mmClassDict at: prop put: aClass.

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -283,8 +283,6 @@ MooseModel class >> resetMetamodel [
 	"Collect all classes containing properties useful to the MM."
 	classes := self packagesToProcessToCreateMetamodel flatCollectAsSet: [ :p | p definedClasses asSet select: #isMetamodelEntity ].
 
-	"We need to reset the moose properties of each slot before building the tower."
-	(classes flatCollect: [ :class | class slots select: #isFMRelationSlot ]) do: #resetMooseProperty.
 	tower := self metaBuilder: classes.
 	metamodel := tower metamodel.
 


### PR DESCRIPTION
A part of the Fame properties were hold in the FMRelationSlot. Now it's all in the FMPragmaProcessor.

It's not the right place for the properties to be hold. Now everything is in the pragma processor.  So there is no need to reset the slots anymore.