### PR TITLE
Fix-bug-with-non-bijective-properties-in-fame

### DIFF
--- a/src/Fame-Core/FM3Element.class.st
+++ b/src/Fame-Core/FM3Element.class.st
@@ -56,7 +56,7 @@ FM3Element >> name: aString [
 FM3Element >> owner [
 	<MSEProperty: #owner type: #FM3Element>
 	<derived>
-	^nil "All packages are top-level (but dots are allowed in their name to fake nesting)"
+	^ nil	"All packages are top-level (but dots are allowed in their name to fake nesting)"
 ]
 
 { #category : #printing }

--- a/src/Fame-Core/FM3MetaDescription.class.st
+++ b/src/Fame-Core/FM3MetaDescription.class.st
@@ -18,7 +18,8 @@ Class {
 		'package',
 		'attributes',
 		'implementingClass',
-		'subclasses'
+		'subclasses',
+		'traits'
 	],
 	#classInstVars : [
 		'object',
@@ -38,18 +39,16 @@ FM3MetaDescription class >> annotation [
 
 { #category : #constants }
 FM3MetaDescription class >> boolean [
-
-	boolean isNil ifTrue: [ 
-		boolean := self booleanClass basicNew.
-		boolean initialize.
-		boolean name: #Boolean.
-		"FM3Boolean beImmutable" ].
-	^boolean
+	^ boolean
+		ifNil: [ boolean := self booleanClass basicNew.
+			boolean initialize.
+			boolean name: #Boolean.
+			"FM3Boolean beImmutable"
+			boolean ]
 ]
 
 { #category : #'private-anonymous classes' }
 FM3MetaDescription class >> booleanClass [
-
 	| class |
 	class := Class new.
 	self setSuperclassClassOf: class.
@@ -57,16 +56,15 @@ FM3MetaDescription class >> booleanClass [
 	class methodDict: MethodDictionary new.
 	class methodDict at: #isPrimitive put: (self methodNamed: #anonymousReturnTrue).
 	class setName: 'AnonymousClass'.
-	^class
+	^ class
 ]
 
 { #category : #constants }
 FM3MetaDescription class >> constantsDo: aBlock [
-
 	aBlock value: self boolean.
 	aBlock value: self number.
 	aBlock value: self object.
-	aBlock value: self string.
+	aBlock value: self string
 ]
 
 { #category : #examples }
@@ -84,13 +82,12 @@ FM3MetaDescription class >> gtExampleWithOnePrimitiveProperty: description [
 
 { #category : #constants }
 FM3MetaDescription class >> number [
-
-	number isNil ifTrue: [ 
-		number := self numberClass basicNew.
-		number initialize.
-		number name: #Number.
-		"FM3Number beImmutable" ].
-	^number
+	^ number
+		ifNil: [ number := self numberClass basicNew.
+			number initialize.
+			number name: #Number.
+			"FM3Number beImmutable"
+			number ]
 ]
 
 { #category : #'private-anonymous classes' }
@@ -108,14 +105,13 @@ FM3MetaDescription class >> numberClass [
 
 { #category : #constants }
 FM3MetaDescription class >> object [
-
-	object isNil ifTrue: [ 
-		object := self objectClass basicNew.
-		object initialize.
-		object superclass: nil.
-		object name: #Object.
-		"FM3Object beImmutable" ].
-	^object
+	^ object
+		ifNil: [ object := self objectClass basicNew.
+			object initialize.
+			object superclass: nil.
+			object name: #Object.
+			"FM3Object beImmutable"
+			object ]
 ]
 
 { #category : #'private-anonymous classes' }
@@ -133,13 +129,8 @@ FM3MetaDescription class >> objectClass [
 
 { #category : #private }
 FM3MetaDescription class >> privateOnlyCallMeIfYourAreBDFLOrSystemAdminFromHellFlush [
-	"
-	self privateOnlyCallMeIfYourAreBDFLOrSystemAdminFromHellFlush
-	"
-	string := nil.
-	number := nil.
-	object := nil.
-	boolean := nil.
+	<script>
+	string := number := object := boolean := nil
 ]
 
 { #category : #'private-anonymous classes' }
@@ -153,13 +144,12 @@ FM3MetaDescription class >> setSuperclassClassOf: class [
 
 { #category : #constants }
 FM3MetaDescription class >> string [
-
-	string isNil ifTrue: [ 
-		string := self stringClass basicNew.
-		string initialize.
-		string name: #String.
-		"FM3String beImmutable" ].
-	^string
+	^ string
+		ifNil: [ string := self stringClass basicNew.
+			string initialize.
+			string name: #String.
+			"FM3String beImmutable"
+			string ]
 ]
 
 { #category : #'private-anonymous classes' }
@@ -173,6 +163,11 @@ FM3MetaDescription class >> stringClass [
 	class methodDict at: #isPrimitive put: (self methodNamed: #anonymousReturnTrue).
 	class setName: 'AnonymousClass'.
 	^class
+]
+
+{ #category : #adding }
+FM3MetaDescription >> addTraits: aCollection [
+	self traits addAll: aCollection
 ]
 
 { #category : #'accessing-query' }
@@ -190,10 +185,9 @@ FM3MetaDescription >> allAttributes [
 
 { #category : #enumerating }
 FM3MetaDescription >> allAttributesDo: block [
-	
 	attributes do: block.
-	self superclass notNil ifTrue: [
-		self superclass allAttributesDo: block ]
+	self superclass ifNotNil: [ :class | class allAttributesDo: block ].
+	self traits do: [ :trait | trait allAttributesDo: block ]
 ]
 
 { #category : #'accessing-query' }
@@ -203,8 +197,7 @@ FM3MetaDescription >> allAttributesNotDerived [
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> allComplexAttributes [
-
-	^ self allAttributes reject: [:attr | attr type isPrimitive ]
+	^ self allAttributes reject: [ :attr | attr type isPrimitive ]
 ]
 
 { #category : #'accessing-query' }
@@ -224,45 +217,39 @@ FM3MetaDescription >> allContainerAttributes [
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> allPrimitiveAttributes [
-
-	^ self allAttributes select: [:attr | 
-		attr type notNil and: [attr type isPrimitive ]]
+	^ self allAttributes select: [ :attr | attr type isNotNil and: [ attr type isPrimitive ] ]
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> allPrimitiveAttributesNotDerived [
-	^ self allAttributes select: [ :attr | attr type notNil and: [ attr type isPrimitive and: [ attr isDerived not ] ] ]
+	^ self allAttributes select: [ :attr | attr type isNotNil and: [ attr type isPrimitive and: [ attr isDerived not ] ] ]
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> allSubclasses [
-
 	| all |
 	all := OrderedCollection new.
-	self allSubclassesDo: [:each | all add: each ].
+	self allSubclassesDo: [ :each | all add: each ].
 	^ all
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> allSubclassesDo: aBlock [
-
-	self subclasses do: [:each | 
-		aBlock value: each.
-		each allSubclassesDo: aBlock ]
+	self subclasses
+		do: [ :each | 
+			aBlock value: each.
+			each allSubclassesDo: aBlock ]
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> allSuperclasses [
-
 	| mmclass superclasses |
-	
 	superclasses := OrderedCollection new.
 	mmclass := self.
-	
-	[mmclass hasSuperclass]
-		whileTrue: [
-			mmclass := mmclass superclass.
-			superclasses add: mmclass].
+
+	[ mmclass hasSuperclass ]
+		whileTrue: [ mmclass := mmclass superclass.
+			superclasses add: mmclass ].
 	^ superclasses
 ]
 
@@ -284,18 +271,14 @@ FM3MetaDescription >> at: aString [
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> attributeNamed: aString [
-
-	^self attributeNamed: aString ifAbsent: nil
+	^ self attributeNamed: aString ifAbsent: nil
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> attributeNamed: aString ifAbsent: aBlock [
-	"Cyril: I remove the #asString because it is longer to convert it ourself than to let the = manage it."
+	self allAttributesDo: [ :attr | attr name = aString ifTrue: [ ^ attr ] ].
 
-	self attributes do: [ :each | each name = aString ifTrue: [ ^ each ] ].
-	
-	^ self superclass ifNil: [ aBlock value ]
-		ifNotNil: [ :sc | sc attributeNamed: aString ifAbsent: aBlock ]
+	^ aBlock value
 ]
 
 { #category : #accessing }
@@ -303,46 +286,32 @@ FM3MetaDescription >> attributes [
 	<MSEProperty: #attributes type: 'FM3.Property' opposite: #class>
 	<multivalued>
 	<key: #name>
-	
-	^attributes
+	^ attributes
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> attributes: anObject [
-
 	attributes value: anObject
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> attributesNamed: aListOfSymbol [
-	
 	^ aListOfSymbol collect: [ :each | self attributeNamed: each ]
-]
-
-{ #category : #accessing }
-FM3MetaDescription >> attributesTogetherWithGenerated [
-
-	^ self attributes, super attributes
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> complexAttributes [
-
-	^ self attributes reject: [:attr | attr type isPrimitive ]
+	^ self attributes reject: [ :attr | attr type isPrimitive ]
 ]
 
 { #category : #'instance creation' }
 FM3MetaDescription >> createInstance [
-
-	^implementingClass isNil
-		ifTrue: [ FMRuntimeElement new description: self ]
-		ifFalse: [ implementingClass new ]
+	^ implementingClass ifNil: [ FMRuntimeElement new description: self ] ifNotNil: [ implementingClass new ]
 ]
 
 { #category : #private }
 FM3MetaDescription >> defaultClassName [
-
-	^ (self package name, self name) asSymbol 
+	^ (self package name , self name) asSymbol
 ]
 
 { #category : #ui }
@@ -401,96 +370,81 @@ FM3MetaDescription >> gtInspectorRelationsIn: composite [
 ]
 
 { #category : #testing }
-FM3MetaDescription >> hasImplementingClass [
-	^ implementingClass notNil
-]
-
-{ #category : #testing }
 FM3MetaDescription >> hasOwner [
 	^ self hasPackage
 ]
 
 { #category : #testing }
 FM3MetaDescription >> hasPackage [
-	^package notNil
+	^ package isNotNil
 ]
 
 { #category : #testing }
 FM3MetaDescription >> hasSuperclass [
-	^ superclass isNil not
+	^ superclass isNotNil
 ]
 
 { #category : #private }
 FM3MetaDescription >> implementingClass [
-	
-	^implementingClass
+	^ implementingClass
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> inheritsFrom: aClass [
-	self
-		allSuperclassesDo: [ :each | 
-			each = aClass
-				ifTrue: [ ^ true ] ].
+	self allSuperclassesDo: [ :each | each = aClass ifTrue: [ ^ true ] ].
 	^ false
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 FM3MetaDescription >> initialize [
-
+	super initialize.
+	self flag: #todo.	"renameFM3MetaDescriptionIntoFM3Class"
 	attributes := FMMultivalueLink on: self opposite: #mmClass:.
-	package := nil.
 	isAbstract := false.
-	superclass := FM3 object. FM3 note: 'Not sure if this is valid, maybe, superclass must be nil?'.
+	superclass := FM3 object.
+	FM3 note: 'Not sure if this is valid, maybe, superclass must be nil?'.
 	subclasses := FMMultivalueLink on: self opposite: #superclass:.
-
+	traits := Set new
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> isAbstract [
-	<MSEProperty: #abstract type: #'Boolean'>
-	^isAbstract
+	<MSEProperty: #abstract type: #Boolean>
+	^ isAbstract
 ]
 
 { #category : #accessing }
-FM3MetaDescription >> isAbstract: anObject [
-	isAbstract := anObject
-]
-
-{ #category : #testing }
-FM3MetaDescription >> isAssociation [
-	^ self allSuperclasses anySatisfy: [ :aSuperclass | aSuperclass name = #Association ]
+FM3MetaDescription >> isAbstract: aBoolean [
+	isAbstract := aBoolean
 ]
 
 { #category : #testing }
 FM3MetaDescription >> isBuiltIn [
-	^self isPrimitive or: [ self isRoot ]
+	^ self isPrimitive or: [ self isRoot ]
 ]
 
 { #category : #testing }
 FM3MetaDescription >> isFM3Class [
-	^true
+	^ true
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> isPrimitive [
-	<MSEProperty: #primitive type: #'Boolean'>
+	<MSEProperty: #primitive type: #Boolean>
 	<derived>
-
-	^false
+	^ false
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> isRoot [
-	<MSEProperty: #root type: #'Boolean'>
+	<MSEProperty: #root type: #Boolean>
 	<derived>
-
-	^false
+	^ false
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> owner [
-	^self package
+	^ self package
 ]
 
 { #category : #'accessing-query' }
@@ -502,37 +456,33 @@ FM3MetaDescription >> ownerAttribute [
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> ownerAttributes [
-
-	^self allAttributes select: #isContainer 
+	^ self allAttributes select: #isContainer
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> package [
 	<MSEProperty: #package type: #FM3PackageDescription opposite: #classes>
 	<container>
-	
-	^package
+	^ package
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> package: newPackage [
-	
-	package := FMMultivalueLink on: self
-					update: #classes
-					from: self package
-					to: newPackage
+	package := FMMultivalueLink
+		on: self
+		update: #classes
+		from: self package
+		to: newPackage
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> packageName [
-
 	^ self package name
 ]
 
 { #category : #'accessing-query' }
 FM3MetaDescription >> primitiveAttributes [
-
-	^ self attributes select: [:attr | attr type isPrimitive ]
+	^ self attributes select: [ :attr | attr type isPrimitive ]
 ]
 
 { #category : #private }
@@ -550,30 +500,29 @@ FM3MetaDescription >> subclasses [
 
 { #category : #accessing }
 FM3MetaDescription >> subclasses: anObject [
-
 	subclasses value: anObject
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> superclass [
 	<MSEProperty: #superclass type: #FM3MetaDescription opposite: #subclasses>
-	^superclass
+	^ superclass
 ]
 
 { #category : #accessing }
 FM3MetaDescription >> superclass: newClass [
-
-	superclass := FMMultivalueLink on: self
-					update: #subclasses
-					from: self superclass
-					to: newClass
+	superclass := FMMultivalueLink
+		on: self
+		update: #subclasses
+		from: self superclass
+		to: newClass
 ]
 
-{ #category : #testing }
-FM3MetaDescription >> todo [
-
-	self flag: #renameFM3MetaDescriptionIntoFM3Class.
-	self flag: #superInvocationInInitialize.
+{ #category : #accessing }
+FM3MetaDescription >> traits [
+	<MSEProperty: #traits type: #FM3MetaDescription>
+	<multivalued>
+	^ traits
 ]
 
 { #category : #accessing }
@@ -588,10 +537,4 @@ FM3MetaDescription >> withAllSuperclasses [
 	^ self allSuperclasses
 		add: self;
 		yourself
-]
-
-{ #category : #accessing }
-FM3MetaDescription >> withSuperclassesDo: aBlock [
-	aBlock value: self.
-	self allSuperclassesDo: aBlock
 ]

--- a/src/Fame-Core/FM3PropertyDescription.class.st
+++ b/src/Fame-Core/FM3PropertyDescription.class.st
@@ -260,7 +260,7 @@ FM3PropertyDescription >> opposite [
 { #category : #accessing }
 FM3PropertyDescription >> opposite: new [
 	| old |
-	opposite ~~ new ifFalse: [ ^ self ].
+	opposite == new ifTrue: [ ^ self ].
 
 	old := opposite.
 	opposite := new.

--- a/src/Fame-ImportExport/FM3MetaDescription.extension.st
+++ b/src/Fame-ImportExport/FM3MetaDescription.extension.st
@@ -2,6 +2,5 @@ Extension { #name : #FM3MetaDescription }
 
 { #category : #'*fame-importexport' }
 FM3MetaDescription >> accept: aVisitor [
-
 	aVisitor visitFM3MetaDescription: self
 ]

--- a/src/Fame-SmalltalkBinding/Behavior.extension.st
+++ b/src/Fame-SmalltalkBinding/Behavior.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Behavior }
 
-{ #category : #'*Moose-Query' }
+{ #category : #'*Fame-SmalltalkBinding' }
 Behavior >> allGeneratedTraits [
 	^ self traitComposition allTraits select: #isMetamodelEntity
 ]

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -44,7 +44,7 @@ Class {
 		'queue',
 		'implementingPackages',
 		'packDict',
-		'slotDict'
+		'traitsDict'
 	],
 	#classVars : [
 		'ShouldValidateMetaModel'
@@ -161,7 +161,7 @@ FMPragmaProcessor >> initialize [
 	oppositeDict := IdentityDictionary new.
 	mmClassDict := IdentityDictionary new.
 	metaDict := Dictionary new.
-	slotDict := IdentityDictionary new.
+	traitsDict := IdentityDictionary new.
 
 	"Must use the cannonical primitives here!"
 	"Please do not at these primitives to elements!"
@@ -175,7 +175,7 @@ FMPragmaProcessor >> initialize [
 FMPragmaProcessor >> methodsToProcessFrom: aClass [
 	"We need to process the methods from the class and the extensions methods comming from the packages containing the entites. We should reject extension methods comming from other packages."
 
-	^ aClass methods select: [ :method | method isExtension not or: [ self implementingPackages includes: method package ] ]
+	^ aClass localMethods select: [ :method | method isExtension not or: [ self implementingPackages includes: method package ] ]
 ]
 
 { #category : #accessing }
@@ -207,7 +207,9 @@ FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 			self extractPackageFrom: pragma method for: fm3Class.
 			classDict at: aClass put: fm3Class.
 			(self methodsToProcessFrom: aClass) do: [ :each | self processCompiledMethod: each ].
-			aClass slots select: #isFMRelationSlot thenDo: [ :each | self processSlot: each in: aClass ].
+			aClass localSlots select: #isFMRelationSlot thenDo: [ :each | self processSlot: each in: aClass ].
+
+			traitsDict at: fm3Class put: aClass allGeneratedTraits.
 
 			elements add: fm3Class ]
 ]
@@ -258,18 +260,9 @@ FMPragmaProcessor >> processInfosFrom: aMethod for: prop [
 { #category : #private }
 FMPragmaProcessor >> processSlot: aSlot in: aClass [
 	| prop |
-	"It is possible the property was created when we set the opposite."
-	prop := slotDict at: aSlot ifAbsentPut: [ FM3PropertyDescription new ].
-
-	slotDict at: aSlot put: prop.
-	prop name: aSlot name asString.
+	prop := FM3PropertyDescription named: aSlot name.
 	prop setImplementingSelector: aSlot name.
 	prop isMultivalued: aSlot isToMany.
-
-	self flag: #todo. "I don't know why the commented line does not work instead of the ugly line after. It'll try to find some time to check later."
-	"oppositeDict at: prop put: aSlot inverseName."
-	prop privOpposite: (slotDict at: aSlot inverseSlot ifAbsentPut: [ FM3PropertyDescription new ]).
-
 
 	typeDict at: prop put: aSlot targetClass.
 	mmClassDict at: prop put: aClass.
@@ -316,8 +309,11 @@ FMPragmaProcessor >> resolveObjectReferences [
 	"establish class-superclass associations"
 	superclassDict keysAndValuesDo: [ :meta :value | meta superclass: (self ensureClass: value) ].
 
-	"establish property-type-oppoiste relations"
+	"establish property-type-opposite relations"
 	typeDict keysAndValuesDo: [ :prop :value | prop type: (self ensureClass: value) ].
+
+	"establish class-traits relations"
+	traitsDict keysAndValuesDo: [ :class :traits | class addTraits: (traits collect: [ :t | classDict at: t ]) ].
 
 	" Fill in oppositelinks"
 	oppositeDict keysAndValuesDo: [ :prop :oppName | prop opposite: (prop type attributeNamed: oppName) ]

--- a/src/Fame-Tests-Core/FMMetaRepositoryFilterTest.class.st
+++ b/src/Fame-Tests-Core/FMMetaRepositoryFilterTest.class.st
@@ -319,6 +319,7 @@ FMMetaRepositoryFilterTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Class.primitive').
 	self assert: (names includes: 'FM3.Class.root').
 	self assert: (names includes: 'FM3.Class.superclass').
+	self assert: (names includes: 'FM3.Class.traits').
 	self assert: (names includes: 'FM3.Class.package').
 	self assert: (names includes: 'FM3.Class.allAttributes').
 	self assert: (names includes: 'FM3.Class.attributes').
@@ -334,7 +335,7 @@ FMMetaRepositoryFilterTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Package').
 	self assert: (names includes: 'FM3.Package.extensions').
 	self assert: (names includes: 'FM3.Package.classes').
-	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 25
+	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 26
 ]
 
 { #category : #'tests-metarepository' }
@@ -361,6 +362,7 @@ FMMetaRepositoryFilterTest >> testFM3NewVersion [
 	self assert: (names includes: 'FM3.Class.root').
 	self assert: (names includes: 'FM3.Class.superclass').
 	self assert: (names includes: 'FM3.Class.subclasses').
+	self assert: (names includes: 'FM3.Class.traits').
 	self assert: (names includes: 'FM3.Class.package').
 	self assert: (names includes: 'FM3.Class.allAttributes').
 	self assert: (names includes: 'FM3.Class.attributes').
@@ -376,7 +378,7 @@ FMMetaRepositoryFilterTest >> testFM3NewVersion [
 	self assert: (names includes: 'FM3.Package').
 	self assert: (names includes: 'FM3.Package.extensions').
 	self assert: (names includes: 'FM3.Package.classes').
-	self assert: (names select: [ :n | n beginsWith: 'FM3' ]) size equals: 26
+	self assert: (names select: [ :n | n beginsWith: 'FM3' ]) size equals: 27
 ]
 
 { #category : #'tests-metarepository' }

--- a/src/Fame-Tests-Core/FMMetaRepositoryTest.class.st
+++ b/src/Fame-Tests-Core/FMMetaRepositoryTest.class.st
@@ -45,6 +45,7 @@ FMMetaRepositoryTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Class.root').
 	self assert: (names includes: 'FM3.Class.superclass').
 	self assert: (names includes: 'FM3.Class.subclasses').
+	self assert: (names includes: 'FM3.Class.traits').
 	self assert: (names includes: 'FM3.Class.package').
 	self assert: (names includes: 'FM3.Class.allAttributes').
 	self assert: (names includes: 'FM3.Class.attributes').
@@ -60,8 +61,8 @@ FMMetaRepositoryTest >> testFM3IsComplete [
 	self assert: (names includes: 'FM3.Package').
 	self assert: (names includes: 'FM3.Package.extensions').
 	self assert: (names includes: 'FM3.Package.classes').
-	self assert: names size equals: 26.
-	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 25
+	self assert: names size equals: 27.
+	self assert: (names select: [ :n | n beginsWith: 'FM3.' ]) size equals: 26
 ]
 
 { #category : #running }

--- a/src/Moose-Query/MooseOutgoingQueryResult.class.st
+++ b/src/Moose-Query/MooseOutgoingQueryResult.class.st
@@ -13,11 +13,6 @@ Class {
 }
 
 { #category : #private }
-MooseOutgoingQueryResult >> isOppositeMultivalued: aDependency [
-	^ (aDependency attributesTogetherWithGenerated detect: [ :att | att isTarget ]) isMultivalued
-]
-
-{ #category : #private }
 MooseOutgoingQueryResult >> opposite: aDependency [
 
 	^ aDependency to


### PR DESCRIPTION
We have bugs in MooseQuery because Fame was not adapted to the concept of Traits that are now used in Famix.

Here I update this to only process the local properties of a class and add the ones of the traits directly in #allAttributes.