### PR TITLE
1962-Add-validation-that-every-containersourcetarget-relations-have-an-opposite

### DIFF
--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -270,14 +270,6 @@ FM3Property >> opposite: new [
 ]
 
 { #category : #accessing }
-FM3Property >> originClass [
-	"Return the origin class implementing the selector of the property.
-	This mean that if the property is defined in a trait named Foo used in a class Bar, implementingClass will return Bar while originClass will return Foo."
-
-	^ self implementingClass findOriginClassOf: self compiledMethod
-]
-
-{ #category : #accessing }
 FM3Property >> owner [
 	^self mmClass
 ]

--- a/src/Fame-SmalltalkBinding/FMMetamodelValidator.class.st
+++ b/src/Fame-SmalltalkBinding/FMMetamodelValidator.class.st
@@ -28,7 +28,22 @@ FMMetamodelValidator >> processor: anObject [
 FMMetamodelValidator >> validate [
 	self
 		validateLinksAreBijectifs;
-		validatePropertiesHaveOpposites
+		validatePropertiesHaveOpposites;
+		validateContainersAreNotMultivalued
+]
+
+{ #category : #accessing }
+FMMetamodelValidator >> validateContainersAreNotMultivalued [
+	"It is not possible to have <multivalue> and <container> on the same method. A container represents a aggregation UML link that is incompatible with the multivalue kind of the link."
+
+	| iterator |
+	iterator := 
+		(self processor elements iterator
+			| [ :element | element isFM3Property ] selectIt
+			| [ :property | property isContainer ] selectIt
+			| [ :property | property isMultivalued ] selectIt).
+
+	self assert: iterator atEnd description: 'It is not possible to have <multivalue> and <container> on the same method. A container represents a aggregation UML link that is incompatible with the multivalue kind of the link.'
 ]
 
 { #category : #accessing }
@@ -53,13 +68,12 @@ FMMetamodelValidator >> validatePropertiesHaveOpposites [
 	
 	We validate here that it is the case."
 
-	self flag: #todo. "There is a bug in Fame currently preventing me to enable this check for now."
-	"| properties propertiesThatShouldHaveOpposites wrongProperties |
-	properties := self processor elements select: [ :element | element isFM3Property ].
+	| iterator |
+	iterator := 
+		(self processor elements iterator
+			| [ :element | element isFM3Property ] selectIt
+			| [ :property | property isContainer or: [ property isSource or: [ property isTarget ] ] ] selectIt
+			| [ :property | property hasOpposite ] rejectIt).
 
-	propertiesThatShouldHaveOpposites := properties select: [ :property | property isContainer or: [ property isSource or: [ property isTarget ] ] ].
-
-	wrongProperties := propertiesThatShouldHaveOpposites reject: [ :property | property hasOpposite ].
-
-	self assert: wrongProperties isEmpty description: 'In a metamodel all container, source and target properties should have an opposite.'"
+	self assert: iterator atEnd description: 'In a metamodel all container, source and target properties should have an opposite.'
 ]

--- a/src/Fame-SmalltalkBinding/FMMetamodelValidator.class.st
+++ b/src/Fame-SmalltalkBinding/FMMetamodelValidator.class.st
@@ -48,15 +48,12 @@ FMMetamodelValidator >> validateContainersAreNotMultivalued [
 
 { #category : #accessing }
 FMMetamodelValidator >> validateLinksAreBijectifs [
-	| fullDict wronglySetOpposites |
 	"Check that opposite link is bijective, i.e. there are not 2 values that references the same opposite."
-	fullDict := Dictionary new.
-	self processor oppositeDict keysAndValuesDo: [ :prop :oppName | (fullDict at: (prop type propertyNamed: oppName) ifAbsentPut: [ Set new ]) add: prop originClass ].
-	wronglySetOpposites := fullDict select: [ :e | e size ~= 1 ].
 
-	self assert: wronglySetOpposites isEmpty description: 'Link to opposite links should be a bijective operation... Please check your model!'.
-
-	self assert: (fullDict at: nil ifAbsent: [ #() ]) isEmpty description: 'Some opposite links are not definied in your model.. Please check your model!'
+	((self processor elements select: [ :e | e isFM3Property and: [ e hasOpposite ] ]) groupedBy: #opposite)
+		valuesDo: [ :props | 
+			self assert: props size = 1 description: 'Link to opposite links should be a bijective operation... Please check your model because here you have a property with multiple opposites!'.
+			self assert: props anyOne hasOpposite description: 'Some opposite links are not definied in your model.. Please check your model because here you have a property that is the opposite of another one but that is not referencing it back!' ]
 ]
 
 { #category : #accessing }

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -248,12 +248,7 @@ FMPragmaProcessor >> processInfosFrom: aMethod for: prop [
 	(aMethod pragmaAt: #derived) ifNotNil: [ prop isDerived: true ].
 	(aMethod pragmaAt: #source) ifNotNil: [ prop isSource: true ].
 	(aMethod pragmaAt: #target) ifNotNil: [ prop isTarget: true ].
-	(aMethod pragmaAt: #multivalued)
-		ifNotNil: [ self flag: #todo.	"This should maybe be moved to FMMetamodelValidator."
-			self
-				assert: prop isContainer not
-				description: 'It is not possible to have <multivalue> and <container> on the same method. container represents a aggregation UML link that is incompatible with the multivalue kind of the link'.
-			prop isMultivalued: true ].
+	(aMethod pragmaAt: #multivalued) ifNotNil: [ prop isMultivalued: true ].
 	(aMethod pragmaAt: #key:) ifNotNil: [ :p | prop key: (p argumentAt: 1) ]
 ]
 

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -179,11 +179,6 @@ FMPragmaProcessor >> methodsToProcessFrom: aClass [
 ]
 
 { #category : #accessing }
-FMPragmaProcessor >> oppositeDict [
-	^ oppositeDict
-]
-
-{ #category : #accessing }
 FMPragmaProcessor >> packages [
 	^ elements select: [ :e | e isFM3Package ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -68,12 +68,9 @@ FAMIXType >> classSide [
 
 { #category : #accessing }
 FAMIXType >> container [
-
 	<MSEProperty: #container type: #FAMIXContainerEntity>
 	<MSEComment: 'Deprected, use typeContainer'>
-	<container>
 	<derived>
-
 	^ self typeContainer
 ]
 

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -216,22 +216,6 @@ MooseModel class >> metamodelClasses [
 	^ MooseEntity withAllSubclasses
 ]
 
-{ #category : #'import-export' }
-MooseModel class >> metamodelComposedOf: aCollectionOfMetamodels [
-	
-	| elements  builder repo |
-	
-	elements := aCollectionOfMetamodels flatCollect: #elements.
-
-	builder := FMPragmaProcessor new.
-	builder buildFM3.
-	repo := FMMetaRepository basicNew.
-	repo initialize: repo.
-	repo addAll: elements.
-
-	^ repo
-]
-
 { #category : #'instance creation' }
 MooseModel class >> named: aString [
 	^ self new


### PR DESCRIPTION
Add validations to MM generation.Fixes #1962