### PR TITLE
Remove-system-of-anonymous-classes-in-Fame

### DIFF
--- a/src/Fame-Core/FM3Boolean.class.st
+++ b/src/Fame-Core/FM3Boolean.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FM3Boolean,
+	#superclass : #FM3Primitive,
+	#category : #'Fame-Core'
+}
+
+{ #category : #accessing }
+FM3Boolean class >> constantName [
+	^ #Boolean
+]

--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -21,12 +21,6 @@ Class {
 		'traits',
 		'properties'
 	],
-	#classInstVars : [
-		'object',
-		'boolean',
-		'number',
-		'string'
-	],
 	#category : #'Fame-Core'
 }
 
@@ -37,34 +31,9 @@ FM3Class class >> annotation [
 
 ]
 
-{ #category : #constants }
-FM3Class class >> boolean [
-	^ boolean
-		ifNil: [ boolean := self booleanClass basicNew.
-			boolean initialize.
-			boolean name: #Boolean.
-			"FM3Boolean beImmutable"
-			boolean ]
-]
-
-{ #category : #'private-anonymous classes' }
-FM3Class class >> booleanClass [
-	| class |
-	class := Class new.
-	self setSuperclassClassOf: class.
-	class setFormat: self format.
-	class methodDict: MethodDictionary new.
-	class methodDict at: #isPrimitive put: (self methodNamed: #anonymousReturnTrue).
-	class setName: 'AnonymousClass'.
-	^ class
-]
-
-{ #category : #constants }
-FM3Class class >> constantsDo: aBlock [
-	aBlock value: self boolean.
-	aBlock value: self number.
-	aBlock value: self object.
-	aBlock value: self string
+{ #category : #accessing }
+FM3Class class >> defaultSuperclass [
+	^ FM3Object instance
 ]
 
 { #category : #examples }
@@ -78,91 +47,6 @@ FM3Class class >> gtExampleWithOnePrimitiveProperty: description [
 	<gtExample>
 	<depends: #gtExampleBasic>
 	^ description properties add: FM3Property new
-]
-
-{ #category : #constants }
-FM3Class class >> number [
-	^ number
-		ifNil: [ number := self numberClass basicNew.
-			number initialize.
-			number name: #Number.
-			"FM3Number beImmutable"
-			number ]
-]
-
-{ #category : #'private-anonymous classes' }
-FM3Class class >> numberClass [
-
-	| class |
-	class := Class new.
-	self setSuperclassClassOf: class.
-	class setFormat: self format.
-	class methodDict: MethodDictionary new.
-	class methodDict at: #isPrimitive put: (self methodNamed: #anonymousReturnTrue).
-	class setName: 'AnonymousClass'.
-	^class
-]
-
-{ #category : #constants }
-FM3Class class >> object [
-	^ object
-		ifNil: [ object := self objectClass basicNew.
-			object initialize.
-			object superclass: nil.
-			object name: #Object.
-			"FM3Object beImmutable"
-			object ]
-]
-
-{ #category : #'private-anonymous classes' }
-FM3Class class >> objectClass [
-
-	| class |
-	class := Class new.
-	self setSuperclassClassOf: class.
-	class setFormat: self format.
-	class methodDict: MethodDictionary new.
-	class methodDict at: #isRoot put: (self  methodNamed: #anonymousReturnTrue).
-	class setName: 'AnonymousClass'.
-	^class
-]
-
-{ #category : #private }
-FM3Class class >> privateOnlyCallMeIfYourAreBDFLOrSystemAdminFromHellFlush [
-	<script>
-	string := number := object := boolean := nil
-]
-
-{ #category : #'private-anonymous classes' }
-FM3Class class >> setSuperclassClassOf: class [
-	"This method is an hack I do to correct a change in Pharo 7 since Moose will soon get a new stable version with the project MooseNG."
-
-	SystemVersion current major < 7
-		ifTrue: [ class superclass: self ]
-		ifFalse: [ class basicSuperclass: self ]
-]
-
-{ #category : #constants }
-FM3Class class >> string [
-	^ string
-		ifNil: [ string := self stringClass basicNew.
-			string initialize.
-			string name: #String.
-			"FM3String beImmutable"
-			string ]
-]
-
-{ #category : #'private-anonymous classes' }
-FM3Class class >> stringClass [
-
-	| class |
-	class := Class new.
-	self setSuperclassClassOf: class.
-	class setFormat: self format.
-	class methodDict: MethodDictionary new.
-	class methodDict at: #isPrimitive put: (self methodNamed: #anonymousReturnTrue).
-	class setName: 'AnonymousClass'.
-	^class
 ]
 
 { #category : #adding }
@@ -234,11 +118,6 @@ FM3Class >> allSuperclasses [
 { #category : #accessing }
 FM3Class >> allSuperclassesDo: aBlock [
 	self allSuperclasses do: [ :each | aBlock value: each ]
-]
-
-{ #category : #'private-anonymous behaviour' }
-FM3Class >> anonymousReturnTrue [
-	^ true
 ]
 
 { #category : #'accessing-query' }
@@ -353,8 +232,7 @@ FM3Class >> initialize [
 	super initialize.
 	properties := FMMultivalueLink on: self opposite: #mmClass:.
 	isAbstract := false.
-	superclass := FM3Class object.
-	self flag: 'Not sure if this is valid, maybe, superclass must be nil?'.
+	superclass := self class defaultSuperclass.
 	subclasses := FMMultivalueLink on: self opposite: #superclass:.
 	traits := Set new
 ]

--- a/src/Fame-Core/FM3Constant.class.st
+++ b/src/Fame-Core/FM3Constant.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : #FM3Constant,
+	#superclass : #FM3Class,
+	#classInstVars : [
+		'uniqueInstance'
+	],
+	#category : #'Fame-Core'
+}
+
+{ #category : #accessing }
+FM3Constant class >> constantClasses [
+	^ self allSubclasses reject: #isAbstract
+]
+
+{ #category : #accessing }
+FM3Constant class >> constantName [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FM3Constant class >> constants [
+	^ self constantClasses collect: #instance
+]
+
+{ #category : #constants }
+FM3Constant class >> constantsDo: aBlock [
+	self constants do: [ :const | aBlock value: const ]
+]
+
+{ #category : #accessing }
+FM3Constant class >> instance [
+	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
+]
+
+{ #category : #testing }
+FM3Constant class >> isAbstract [
+	^ self = FM3Constant
+]
+
+{ #category : #private }
+FM3Constant class >> privateOnlyCallMeIfYourAreBDFLOrSystemAdminFromHellFlush [
+	<script>
+	self constantClasses do: #reset
+]
+
+{ #category : #initialization }
+FM3Constant class >> reset [
+	uniqueInstance := nil
+]
+
+{ #category : #initialization }
+FM3Constant >> initialize [
+	super initialize.
+	self name: self class constantName
+]

--- a/src/Fame-Core/FM3Number.class.st
+++ b/src/Fame-Core/FM3Number.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FM3Number,
+	#superclass : #FM3Primitive,
+	#category : #'Fame-Core'
+}
+
+{ #category : #accessing }
+FM3Number class >> constantName [
+	^ #Number
+]

--- a/src/Fame-Core/FM3Object.class.st
+++ b/src/Fame-Core/FM3Object.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #FM3Object,
+	#superclass : #FM3Constant,
+	#category : #'Fame-Core'
+}
+
+{ #category : #accessing }
+FM3Object class >> constantName [
+	^ #Object
+]
+
+{ #category : #'accessing-query' }
+FM3Object class >> defaultSuperclass [
+	^ nil
+]
+
+{ #category : #'accessing-query' }
+FM3Object >> isRoot [
+	^ true
+]

--- a/src/Fame-Core/FM3Primitive.class.st
+++ b/src/Fame-Core/FM3Primitive.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #FM3Primitive,
+	#superclass : #FM3Constant,
+	#category : #'Fame-Core'
+}
+
+{ #category : #testing }
+FM3Primitive class >> isAbstract [
+	^ self = FM3Primitive
+]
+
+{ #category : #'accessing-query' }
+FM3Primitive >> isPrimitive [
+	^ true
+]

--- a/src/Fame-Core/FM3String.class.st
+++ b/src/Fame-Core/FM3String.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FM3String,
+	#superclass : #FM3Primitive,
+	#category : #'Fame-Core'
+}
+
+{ #category : #accessing }
+FM3String class >> constantName [
+	^ #String
+]

--- a/src/Fame-Core/FMMetaRepository.class.st
+++ b/src/Fame-Core/FMMetaRepository.class.st
@@ -237,16 +237,8 @@ FMMetaRepository >> properties [
 
 { #category : #private }
 FMMetaRepository >> updateCache [
-	nameDict := Dictionary new.
-	nameDict at: 'String' put: FM3Class string.
-	nameDict at: 'Boolean' put: FM3Class boolean.
-	nameDict at: 'Number' put: FM3Class number.
-	nameDict at: 'Object' put: FM3Class object.
-	classDict := Dictionary new.
-	classDict at: FM3Class string class put: FM3Class string.
-	classDict at: FM3Class boolean class put: FM3Class boolean.
-	classDict at: FM3Class number class put: FM3Class number.
-	classDict at: FM3Class object class put: FM3Class object.
+	nameDict := (FM3Constant constants collect: [ :const | const name asString -> const ]) asDictionary.
+	classDict := (FM3Constant constants collect: [ :const | const class -> const ]) asDictionary.
 	self elements do: [ :each | self updateCacheWith: each ]
 ]
 

--- a/src/Fame-ImportExport/FMRepositoryVisitor.class.st
+++ b/src/Fame-ImportExport/FMRepositoryVisitor.class.st
@@ -109,8 +109,7 @@ FMRepositoryVisitor >> initialize [
 
 { #category : #private }
 FMRepositoryVisitor >> isPrimitiveTypeOrObject: each [
-	FM3Class constantsDo: [ :const | const = each ifTrue: [ ^ true ] ].
-	^ false
+	^ FM3Constant constants includes: each
 ]
 
 { #category : #accessing }
@@ -158,7 +157,7 @@ FMRepositoryVisitor >> shouldIgnoreProperty: property [
 FMRepositoryVisitor >> shouldIgnoreProperty: property withAll: values [
 	values ifNil: [ ^ true ].
 
-	^ values isEmpty or: [ property type = FM3Class boolean and: [ values size = 1 and: [ values first = false ] ] ]
+	^ values isEmpty or: [ property type = FM3Boolean instance and: [ values size = 1 and: [ values first = false ] ] ]
 ]
 
 { #category : #private }

--- a/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
+++ b/src/Fame-SmalltalkBinding/FMPragmaProcessor.class.st
@@ -160,15 +160,11 @@ FMPragmaProcessor >> initialize [
 	typeDict := IdentityDictionary new.
 	oppositeDict := IdentityDictionary new.
 	mmClassDict := IdentityDictionary new.
-	metaDict := Dictionary new.
 	traitsDict := IdentityDictionary new.
 
 	"Must use the cannonical primitives here!"
-	"Please do not at these primitives to elements!"
-	metaDict at: 'String' put: FM3Class string.
-	metaDict at: 'Boolean' put: FM3Class boolean.
-	metaDict at: 'Number' put: FM3Class number.
-	metaDict at: 'Object' put: FM3Class object
+	"Please do not add these primitives to elements!"
+	metaDict := (FM3Constant constants collect: [ :const | const name asString -> const ]) asDictionary
 ]
 
 { #category : #private }

--- a/src/Fame-Tests-Core/FM3MetaDescriptionTest.class.st
+++ b/src/Fame-Tests-Core/FM3MetaDescriptionTest.class.st
@@ -52,22 +52,22 @@ FM3MetaDescriptionTest >> testAllSuperclasses [
 	self assert: elem allSuperclasses isCollection.
 	self assert: elem allSuperclasses size equals: 2.
 
-	elem := FM3Class object.
+	elem := FM3Object instance.
 	self assert: elem allSuperclasses isNotNil.
 	self assert: elem allSuperclasses isCollection.
 	self assertEmpty: elem allSuperclasses.
 
-	elem := FM3Class string.
+	elem := FM3String instance.
 	self assert: elem allSuperclasses isNotNil.
 	self assert: elem allSuperclasses isCollection.
 	self assert: elem allSuperclasses size equals: 1.
 
-	elem := FM3Class number.
+	elem := FM3Number instance.
 	self assert: elem allSuperclasses isNotNil.
 	self assert: elem allSuperclasses isCollection.
 	self assert: elem allSuperclasses size equals: 1.
 
-	elem := FM3Class boolean.
+	elem := FM3Boolean instance.
 	self assert: elem allSuperclasses isNotNil.
 	self assert: elem allSuperclasses isCollection.
 	self assert: elem allSuperclasses size equals: 1
@@ -115,10 +115,10 @@ FM3MetaDescriptionTest >> testAttributesIsHot [
 
 { #category : #running }
 FM3MetaDescriptionTest >> testHasOwner [
-	self deny: FM3Class object hasOwner.
-	self deny: FM3Class string hasOwner.
-	self deny: FM3Class number hasOwner.
-	self deny: FM3Class boolean hasOwner.
+	self deny: FM3Object instance hasOwner.
+	self deny: FM3String instance hasOwner.
+	self deny: FM3Number instance hasOwner.
+	self deny: FM3Boolean instance hasOwner.
 	self assert: tower metaMetamodel classes anyOne hasOwner.
 	self assert: tower metaMetamodel properties anyOne hasOwner.
 	self deny: tower metaMetamodel packages anyOne hasOwner
@@ -126,43 +126,41 @@ FM3MetaDescriptionTest >> testHasOwner [
 
 { #category : #running }
 FM3MetaDescriptionTest >> testHasPackage [
-	self deny: FM3Class object hasPackage.
-	self deny: FM3Class string hasPackage.
-	self deny: FM3Class number hasPackage.
-	self deny: FM3Class boolean hasPackage.
+	self deny: FM3Object instance hasPackage.
+	self deny: FM3String instance hasPackage.
+	self deny: FM3Number instance hasPackage.
+	self deny: FM3Boolean instance hasPackage.
 	self assert: tower metaMetamodel classes anyOne hasPackage
 ]
 
 { #category : #running }
 FM3MetaDescriptionTest >> testHasSuperclass [
-	self deny: FM3Class object hasSuperclass.
-	self assert: FM3Class string hasSuperclass.
-	self assert: FM3Class number hasSuperclass.
-	self assert: FM3Class boolean hasSuperclass.
+	self deny: FM3Object instance hasSuperclass.
+	self assert: FM3String instance hasSuperclass.
+	self assert: FM3Number instance hasSuperclass.
+	self assert: FM3Boolean instance hasSuperclass.
 	self assert: tower metaMetamodel classes anyOne hasSuperclass
 ]
 
 { #category : #running }
 FM3MetaDescriptionTest >> testIsPrimitive [
-	self deny: FM3Class object isPrimitive.
-	self assert: FM3Class string isPrimitive.
-	self assert: FM3Class number isPrimitive.
-	self assert: FM3Class boolean isPrimitive.
+	self deny: FM3Object instance isPrimitive.
+	self assert: FM3String instance isPrimitive.
+	self assert: FM3Number instance isPrimitive.
+	self assert: FM3Boolean instance isPrimitive.
 	self deny: tower metaMetamodel classes anyOne isPrimitive
 ]
 
 { #category : #running }
 FM3MetaDescriptionTest >> testIsRoot [
-	self assert: FM3Class object isRoot.
-	self deny: FM3Class string isRoot.
-	self deny: FM3Class number isRoot.
-	self deny: FM3Class boolean isRoot.
+	self assert: FM3Object instance isRoot.
+	self deny: FM3String instance isRoot.
+	self deny: FM3Number instance isRoot.
+	self deny: FM3Boolean instance isRoot.
 	self deny: tower metaMetamodel classes anyOne isRoot
 ]
 
 { #category : #running }
 FM3MetaDescriptionTest >> testSubclasses [
-	| elem |
-	elem := tower metaMetamodel elementNamed: 'FM3.Element'.
-	self denyEmpty: elem subclasses
+	self denyEmpty: (tower metaMetamodel elementNamed: 'FM3.Element') subclasses
 ]

--- a/src/Fame-Tests-Core/FMLibraryExample.class.st
+++ b/src/Fame-Tests-Core/FMLibraryExample.class.st
@@ -120,21 +120,21 @@ FMLibraryExample >> testMetamodelSmalltalkBinding [
 	self assert: mm properties anyOne isFM3Property.
 	b := mm elementNamed: 'LIB.Book'.
 	self assert: b notNil.
-	self assert: (b isKindOf: FM3Class).
+	self assert: b isFM3Class.
 	self assert: b name equals: #Book.
 	self assert: b package name equals: #LIB.
 	self assert: b properties size equals: 2.
 	self assert: b implementingClass equals: LIBBook.
 	p := mm elementNamed: 'LIB.Person'.
 	self assert: p notNil.
-	self assert: (p isKindOf: FM3Class).
+	self assert: p isFM3Class.
 	self assert: p name equals: #Person.
 	self assert: p package name equals: #LIB.
 	self assert: p properties size equals: 2.
 	self assert: p implementingClass equals: LIBPerson.
 	lib := mm elementNamed: 'LIB.Library'.
 	self assert: lib notNil.
-	self assert: (lib isKindOf: FM3Class).
+	self assert: lib isFM3Class.
 	self assert: lib name equals: #Library.
 	self assert: lib package name equals: #LIB.
 	self assert: lib properties size equals: 2.

--- a/src/Fame-Tests-Core/FMMetaRepositoryFilterTest.class.st
+++ b/src/Fame-Tests-Core/FMMetaRepositoryFilterTest.class.st
@@ -159,13 +159,13 @@ FMMetaRepositoryFilterTest >> testAnnotationTypes [
 	package := repo elementNamed: 'FM3'.
 	class := repo elementNamed: 'FM3.Element'.
 	self assert: class isFM3Class.
-	self assert: class superclass equals: FM3Class object.
+	self assert: class superclass equals: FM3Object instance.
 	self assert: class implementingClass equals: FM3Element.
 	self assert: (class at: 'name') isFM3Property.
 	self assert: (class at: 'name') name equals: #name.
 	self assert: (class at: 'name') mmClass equals: class.
 	self assert: (class at: 'name') owner equals: class.
-	self assert: (class at: 'name') type equals: FM3Class string.
+	self assert: (class at: 'name') type equals: FM3String instance.
 	self deny: (class at: 'name') isContainer.
 	self deny: (class at: 'name') isMultivalued.
 	self deny: (class at: 'name') isComposite.

--- a/src/Fame-Tests-Core/FMMetamodelBuilder.class.st
+++ b/src/Fame-Tests-Core/FMMetamodelBuilder.class.st
@@ -30,12 +30,11 @@ FMMetamodelBuilder >> initialize [
 
 { #category : #private }
 FMMetamodelBuilder >> lookup: name [
-
 	"if it is a primitive type, return the name, metamodel will take care of this"
-	FM3Class constantsDo: [ :prim | 
-		prim name asString = name ifTrue: [ ^ name ] ].
-	^ self lookupSerial: name
 
+	(FM3Constant constants anySatisfy: [ :const | const name = name ]) ifTrue: [ ^ name ].
+
+	^ self lookupSerial: name
 ]
 
 { #category : #private }

--- a/src/Fame-Tests-Core/FMPragmaProcessorTest.class.st
+++ b/src/Fame-Tests-Core/FMPragmaProcessorTest.class.st
@@ -11,13 +11,13 @@ FMPragmaProcessorTest >> testAnnotationTypes [
 	package := repo elementNamed: 'FM3'.
 	class := repo elementNamed: 'FM3.Element'.
 	self assert: class isFM3Class.
-	self assert: class superclass equals: FM3Class object.
+	self assert: class superclass equals: FM3Object instance.
 	self assert: class implementingClass equals: FM3Element.
 	self assert: (class at: 'name') isFM3Property.
 	self assert: (class at: 'name') name equals: #name.
 	self assert: (class at: 'name') mmClass equals: class.
 	self assert: (class at: 'name') owner equals: class.
-	self assert: (class at: 'name') type equals: FM3Class string.
+	self assert: (class at: 'name') type equals: FM3String instance.
 	self deny: (class at: 'name') isContainer.
 	self deny: (class at: 'name') isMultivalued.
 	self deny: (class at: 'name') isComposite.

--- a/src/Famix-Compatibility-Tests-Core/FAMIXMetricTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXMetricTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 FAMIXMetricTest >> assertNoErrorForAllMetricsOf: entity [
-	(entity mooseDescription allProperties select: [ :attr | attr type = FM3Class number ])
+	(entity mooseDescription allProperties select: [ :attr | attr type = FM3Number instance ])
 		do: [ :each | self shouldnt: (entity mmGetProperty: each) raise: Error ]
 ]
 

--- a/src/Famix-Deprecated/FM3Class.extension.st
+++ b/src/Famix-Deprecated/FM3Class.extension.st
@@ -63,9 +63,33 @@ FM3Class >> attributesNamed: arg1 [
 ]
 
 { #category : #'*Famix-Deprecated' }
+FM3Class class >> boolean [
+	self deprecated: 'Use FM3Boolean class>>#instance instead.' transformWith: 'FM3Class boolean' -> 'FM3Boolean instance'.
+	^ FM3Boolean instance
+]
+
+{ #category : #'*Famix-Deprecated' }
 FM3Class >> complexAttributes [
 	self deprecated: 'Use #complexProperties instead.' transformWith: '``@object complexAttributes' -> '``@object complexProperties'.
 	^ self complexProperties
+]
+
+{ #category : #'*Famix-Deprecated' }
+FM3Class class >> constantsDo: aBlock [
+	self deprecated: 'Use FM3Constant class>>constantsDo: instead.' transformWith: 'FM3Class constantsDo: `@arg' -> 'FM3Constant constantsDo: `@arg'.
+	FM3Constant constantsDo: aBlock
+]
+
+{ #category : #'*Famix-Deprecated' }
+FM3Class class >> number [
+	self deprecated: 'Use FM3Number class>>#instance instead.' transformWith: 'FM3Class number' -> 'FM3Number instance'.
+	^ FM3Number instance
+]
+
+{ #category : #'*Famix-Deprecated' }
+FM3Class class >> object [
+	self deprecated: 'Use FM3Object class>>#instance instead.' transformWith: 'FM3Class object' -> 'FM3Object instance'.
+	^ FM3Object instance
 ]
 
 { #category : #'*Famix-Deprecated' }
@@ -90,4 +114,10 @@ FM3Class >> primitiveAttributes [
 FM3Class >> setImplementingClass: arg1 [ 
 	self deprecated: 'Use #implementingClass: instead.' transformWith: '``@object setImplementingClass: ``@arg1 ' -> '``@object implementingClass: ``@arg1 '.
 	^ self implementingClass: arg1 
+]
+
+{ #category : #'*Famix-Deprecated' }
+FM3Class class >> string [
+	self deprecated: 'Use FM3String class>>#instance instead.' transformWith: 'FM3Class string' -> 'FM3String instance'.
+	^ FM3String instance
 ]

--- a/src/Moose-Finder/MooseEntity.extension.st
+++ b/src/Moose-Finder/MooseEntity.extension.st
@@ -83,7 +83,7 @@ MooseEntity >> gtInspectorPresentationsIn: composite inContext: aGTInspector [
 
 { #category : #'*Moose-Finder' }
 MooseEntity >> mooseDescriptionsOfNumberProperties [
-	^ self mooseDescription allProperties select: [:each | each type = FM3Class number ]
+	^ self mooseDescription allProperties select: [ :each | each type = FM3Number instance ]
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-Finder/MooseMetaExplorer.class.st
+++ b/src/Moose-Finder/MooseMetaExplorer.class.st
@@ -57,19 +57,16 @@ MooseMetaExplorer >> buildBrowser [
 
 { #category : #private }
 MooseMetaExplorer >> hierarchyIn: a [
-	^ (a tree)
+	^ a tree
 		title: 'Entities';
-		display: [ :all | (all classes select: [ :each | each superclass = FM3Class object ]) sorted: [:x :y | x fullName < y fullName] ];
-		children: [ :c | c subclasses sorted: [:x :y | x fullName < y fullName] ];
+		display: [ :all | (all classes select: [ :each | each superclass = FM3Object instance ]) sorted: [ :x :y | x fullName < y fullName ] ];
+		children: [ :c | c subclasses sorted: [ :x :y | x fullName < y fullName ] ];
 		format: [ :each | self abstractFormattedNameOf: each ];
-		tags: [ :each | 
-					each package isNil
-						ifTrue: [ #() ]
-						ifFalse: [ each package name ] ];
-		morphicSelectionAct: [ :list | list selection implementingClass browse ] 
-							icon: GLMUIThemeExtraIcons glamorousBrowse 
-							on: $b
-							entitled: 'Browse implementation';
+		tags: [ :each | each package isNil ifTrue: [ #() ] ifFalse: [ each package name ] ];
+		morphicSelectionAct: [ :list | list selection implementingClass browse ]
+			icon: GLMUIThemeExtraIcons glamorousBrowse
+			on: $b
+			entitled: 'Browse implementation';
 		morphicSelectionAct: [ :list | list selection inspect ] entitled: 'Inspect'
 ]
 


### PR DESCRIPTION
Refactor Fame to not use anonymous classes.

In Fame we have a concept of classes. The classes represent types in Fame. We can instantiate them but we have 4 constantes:
- Object (root class)
- Number (primitive)
- String (primitive)
- Boolean (primitive)

Those 4 classes were managed via anonymous classes but the code was hard to understand. Here I did a refactoring to replace this system of anonymous classes by real classes. 

We now have a concept of FM3Constant and a concept of FM3Primitive and their subclasses are singletons holding those constants.

Maybe we can do better than singleton later but this is already better than the previous implementation.