### PR TITLE
Remove-asMetaRepository-hack

### DIFF
--- a/src/Fame-Core/FMModel.class.st
+++ b/src/Fame-Core/FMModel.class.st
@@ -87,13 +87,6 @@ FMModel >> additionalProperty: aSymbol for: entityClass put: anObject [
 	^ (self additionalPropertiesFor: entityClass) at: aSymbol put: anObject
 ]
 
-{ #category : #'as yet unclassified' }
-FMModel >> asMetarepository [
-	^ FMMetaModel new
-		addAll: elements;
-		yourself
-]
-
 { #category : #accessing }
 FMModel >> cleanAdditionalProperties [
 	additionalProperties := IdentityDictionary new
@@ -165,10 +158,8 @@ FMModel >> isNotEmpty [
 ]
 
 { #category : #'accessing-meta' }
-FMModel >> metaDescriptionOf: element [ 
-	^ (element isKindOf: FMRuntimeElement) 
-		ifTrue: [ element description ]
-		ifFalse: [ self metamodel descriptionOf: element class ]
+FMModel >> metaDescriptionOf: element [
+	^ element metaDescriptionIn: self metamodel
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Fame-Core/FMRuntimeElement.class.st
+++ b/src/Fame-Core/FMRuntimeElement.class.st
@@ -62,6 +62,11 @@ FMRuntimeElement >> initialize [
 ]
 
 { #category : #accessing }
+FMRuntimeElement >> metaDescriptionIn: aMetamodel [
+	^ self description
+]
+
+{ #category : #accessing }
 FMRuntimeElement >> mmGetProperty: aFM3Property [
 	^ self at: aFM3Property name
 ]

--- a/src/Fame-Core/Object.extension.st
+++ b/src/Fame-Core/Object.extension.st
@@ -21,6 +21,13 @@ Object >> isMetamodelEntity [
 ]
 
 { #category : #'*Fame-Core' }
+Object >> metaDescriptionIn: aMetamodel [
+	"I return the metadescription corresponding to myself from the metamodel given as parameter."
+
+	^ aMetamodel descriptionOf: self class
+]
+
+{ #category : #'*Fame-Core' }
 Object >> metamodel [
 
 	^ self class metamodel

--- a/src/Fame-ImportExport/FMImporter.class.st
+++ b/src/Fame-ImportExport/FMImporter.class.st
@@ -16,9 +16,9 @@ Class {
 }
 
 { #category : #'instance creation' }
-FMImporter class >> repository: aRepository [
+FMImporter class >> model: aRepository [
 	^ self new
-		repository: aRepository;
+		model: aRepository;
 		yourself
 ]
 
@@ -63,6 +63,11 @@ FMImporter >> dangling: reference to: serial [
 	(reminderDict at: serial ifAbsentPut: [ OrderedCollection new ]) add: reference.
 	tally := tally + 1.
 	^ reference
+]
+
+{ #category : #accessing }
+FMImporter >> elements [
+	^ elements
 ]
 
 { #category : #parsing }
@@ -114,7 +119,13 @@ FMImporter >> metamodel [
 
 { #category : #accessing }
 FMImporter >> model [
-	^model
+	^ model
+]
+
+{ #category : #accessing }
+FMImporter >> model: aModel [
+	model := aModel.
+	metamodel := aModel metamodel
 ]
 
 { #category : #parsing }
@@ -133,19 +144,6 @@ FMImporter >> referenceName: name [
 FMImporter >> referenceNumber: serial [ 
 	
 	stack top current referenceNumber: serial
-]
-
-{ #category : #accessing }
-FMImporter >> repository [
-
-	^model
-]
-
-{ #category : #accessing }
-FMImporter >> repository: aRepository [
-
-	model := aRepository.
-	metamodel := aRepository metamodel.
 ]
 
 { #category : #running }

--- a/src/Fame-ImportExport/FMImporterFilter.class.st
+++ b/src/Fame-ImportExport/FMImporterFilter.class.st
@@ -25,13 +25,8 @@ FMImporterFilter >> model [
 ]
 
 { #category : #accessing }
-FMImporterFilter >> repository [
-	^ self parserClient repository
-]
-
-{ #category : #accessing }
-FMImporterFilter >> repository: aRepository [
-	^ self parserClient repository: aRepository
+FMImporterFilter >> model: aModel [
+	^ self parserClient model: aModel
 ]
 
 { #category : #running }

--- a/src/Fame-ImportExport/FMModel.extension.st
+++ b/src/Fame-ImportExport/FMModel.extension.st
@@ -39,7 +39,7 @@ FMModel >> gtExportAction [
 
 { #category : #'*Fame-ImportExport' }
 FMModel >> importStream: aReadStream [
-	(FMImporter repository: self)
+	(FMImporter model: self)
 		stream: aReadStream;
 		run
 ]

--- a/src/Fame-Tests-Core/FMDungeonExample.class.st
+++ b/src/Fame-Tests-Core/FMDungeonExample.class.st
@@ -25,13 +25,10 @@ FMDungeonExample class >> dungeonScript [
 
 { #category : #'as yet unclassified' }
 FMDungeonExample class >> metamodelString [
-
-	| m |
-	m := FMMetamodelBuilder new.
-	m client: FMMSEPrinter new onString.
-	m document: self dungeonScript.
-	^m client stream contents.
-		
+	| builder |
+	builder := FMMetamodelBuilder client: FMMSEPrinter new onString.
+	builder document: self dungeonScript.
+	^ builder client stream contents
 ]
 
 { #category : #running }

--- a/src/Fame-Tests-Core/FMEquationSystemExample.class.st
+++ b/src/Fame-Tests-Core/FMEquationSystemExample.class.st
@@ -11,15 +11,6 @@ FMEquationSystemExample class >> createMetamodel [
 ]
 
 { #category : #'As yet unclassified' }
-FMEquationSystemExample class >> createModel [
-	| metarepo repo |
-	metarepo := self createMetamodel.
-	repo := FMModel with: metarepo.
-	(FMImporter repository: repo) importString: self modelString.
-	^ repo
-]
-
-{ #category : #'As yet unclassified' }
 FMEquationSystemExample class >> modelString [
 
 ^'(

--- a/src/Fame-Tests-Core/FMImporterTest.class.st
+++ b/src/Fame-Tests-Core/FMImporterTest.class.st
@@ -20,18 +20,6 @@ FMImporterTest class >> simpleCompositeMetamodelExtension [
 ]
 
 { #category : #running }
-FMImporterTest >> testBookMetamodel [
-	| or m repo |
-	or := FMImporter repository: FMMetaModel new.
-	m := FMModelBuilder new client: or.
-	m document: [ m new: 'FM3.Class' with: [ m a: #name of: 'Book' ] ].
-	repo := or repository asMetarepository.
-	self denyEmpty: repo elements.
-	self assert: repo elements size equals: 1.
-	self assert: repo elements anyOne name equals: #Book
-]
-
-{ #category : #running }
 FMImporterTest >> testElementNamed [
 	| metamodel |
 	metamodel := FMMetaModel new.
@@ -39,6 +27,17 @@ FMImporterTest >> testElementNamed [
 	self shouldnt: [ metamodel elementNamed: 'HNK.Beer' ] raise: Error.
 	self assert: (metamodel elementNamed: 'HNK.Beer') isFM3Class.
 	self assert: (metamodel elementNamed: 'HNK.Beer') fullName equals: 'HNK.Beer'
+]
+
+{ #category : #running }
+FMImporterTest >> testImportBook [
+	| importer builder |
+	importer := FMImporter model: FMMetaModel new.
+	builder := FMModelBuilder client: importer.
+	builder document: [ builder new: 'FM3.Class' with: [ builder a: #name of: 'Book' ] ].
+
+	self assert: importer model elements size equals: 1.
+	self assert: importer model elements anyOne name equals: #Book
 ]
 
 { #category : #running }
@@ -81,80 +80,78 @@ FMImporterTest >> testOrderOfElements [
 
 { #category : #running }
 FMImporterTest >> testResolving [
-	| or m |
-	or := FMImporter repository: FMMetaModel new.
-	m := FMModelBuilder new client: or.
-	m document: [ m new: 'FM3.Class' with: [ m a: #name of: 'MyName' ] ].
-	self denyEmpty: or repository elements.
-	self assert: or repository elements size equals: 1.
-	self assert: or repository elements anyOne isFM3Class
+	| importer builder |
+	importer := FMImporter model: FMMetaModel new.
+	builder := FMModelBuilder client: importer.
+	builder document: [ builder new: 'FM3.Class' with: [ builder a: #name of: 'MyName' ] ].
+	self assert: importer model elements size equals: 1.
+	self assert: importer model elements anyOne isFM3Class
 ]
 
 { #category : #running }
 FMImporterTest >> testResolvingId [
-	| or m |
-	or := FMImporter repository: FMMetaModel new.
-	m := FMModelBuilder new client: or.
-	m
-		document: [ m
+	| importer builder |
+	importer := FMImporter model: FMMetaModel new.
+	builder := FMModelBuilder client: importer.
+	builder
+		document: [ builder
 				new: 'FM3.Class'
-				with: [ m id: 3.
-					m a: #name of: 'MyName'.
-					m a: #superclass of: [ m ref: 2 ] ].
-			m
+				with: [ builder id: 3.
+					builder a: #name of: 'MyName'.
+					builder a: #superclass of: [ builder ref: 2 ] ].
+			builder
 				new: 'FM3.Class'
-				with: [ m id: 2.
-					m a: #name of: 'MyName2' ] ].
-	self denyEmpty: or repository elements.
-	self assert: or repository elements size equals: 2
+				with: [ builder id: 2.
+					builder a: #name of: 'MyName2' ] ].
+	self assert: importer model elements size equals: 2
 ]
 
 { #category : #running }
 FMImporterTest >> testResolvingMultiArgs [
-	| or pack ref2 ref4 ref5 repo |
-	or := FMImporter repository: FMMetaModel new.
-	or beginDocument.
-	or beginElement: 'FM3.Package'.
-	or serial: 3.
-	or beginAttribute: 'name'.
-	or primitive: 'MyPackage'.
-	or endAttribute: 'name'.
-	or beginAttribute: 'classes'.
-	or referenceNumber: 2.
-	or referenceNumber: 4.
-	or referenceNumber: 2.
-	or referenceNumber: 5.
-	or endAttribute: 'classes'.
-	or endElement: 'FM3.Package'.
-	or beginElement: 'FM3.Class'.
-	or serial: 2.
-	or beginAttribute: 'name'.
-	or primitive: 'MyName2'.
-	or endAttribute: 'name'.
-	or beginAttribute: 'superclass'.
-	or referenceNumber: 5.
-	or endAttribute: 'superclass'.
-	or endElement: 'FM3.Class'.
-	or beginElement: 'FM3.Class'.
-	or serial: 4.
-	or beginAttribute: 'superclass'.
-	or referenceNumber: 2.
-	or endAttribute: 'superclass'.
-	or beginAttribute: 'name'.
-	or primitive: 'MyName4'.
-	or endAttribute: 'name'.
-	or endElement: 'FM3.Class'.
-	or beginElement: 'FM3.Class'.
-	or serial: 5.
-	or beginAttribute: 'name'.
-	or primitive: 'MyName5'.
-	or endAttribute: 'name'.
-	or endElement: 'FM3.Class'.
-	or endDocument.
-	repo := or repository asMetarepository.
-	self denyEmpty: repo elements.
-	self assert: repo elements size equals: 4.
-	pack := repo packageNamed: 'MyPackage'.
+	| importer pack ref2 ref4 ref5 model |
+	importer := (FMImporter model: FMMetaModel new)
+		beginDocument;
+		beginElement: 'FM3.Package';
+		serial: 3;
+		beginAttribute: 'name';
+		primitive: 'MyPackage';
+		endAttribute: 'name';
+		beginAttribute: 'classes';
+		referenceNumber: 2;
+		referenceNumber: 4;
+		referenceNumber: 2;
+		referenceNumber: 5;
+		endAttribute: 'classes';
+		endElement: 'FM3.Package';
+		beginElement: 'FM3.Class';
+		serial: 2;
+		beginAttribute: 'name';
+		primitive: 'MyName2';
+		endAttribute: 'name';
+		beginAttribute: 'superclass';
+		referenceNumber: 5;
+		endAttribute: 'superclass';
+		endElement: 'FM3.Class';
+		beginElement: 'FM3.Class';
+		serial: 4;
+		beginAttribute: 'superclass';
+		referenceNumber: 2;
+		endAttribute: 'superclass';
+		beginAttribute: 'name';
+		primitive: 'MyName4';
+		endAttribute: 'name';
+		endElement: 'FM3.Class';
+		beginElement: 'FM3.Class';
+		serial: 5;
+		beginAttribute: 'name';
+		primitive: 'MyName5';
+		endAttribute: 'name';
+		endElement: 'FM3.Class';
+		endDocument;
+		yourself.
+	model := importer model.
+	self assert: model elements size equals: 4.
+	pack := model packageNamed: 'MyPackage'.
 	ref2 := pack classNamed: 'MyName2'.
 	ref4 := pack classNamed: 'MyName4'.
 	ref5 := pack classNamed: 'MyName5'.

--- a/src/Fame-Tests-Core/FMMetaModel.extension.st
+++ b/src/Fame-Tests-Core/FMMetaModel.extension.st
@@ -7,7 +7,5 @@ FMMetaModel >> builderClass [
 
 { #category : #'*Fame-Tests-Core' }
 FMMetaModel >> document: scriptBlock [
-	self builderClass new
-		client: (FMImporter repository: self);
-		document: scriptBlock
+	(self builderClass client: (FMImporter model: self)) document: scriptBlock
 ]

--- a/src/Fame-Tests-Core/FMMetaRepositoryFilterTest.class.st
+++ b/src/Fame-Tests-Core/FMMetaRepositoryFilterTest.class.st
@@ -27,25 +27,24 @@ FMMetaRepositoryFilterTest >> buildRPG [
 
 { #category : #running }
 FMMetaRepositoryFilterTest >> setUp [
-
 	super setUp.
 	eqModel := self buildEQ.
 	libModel := self buildLIB.
-	rpgModel := self buildRPG.
+	rpgModel := self buildRPG
 ]
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testAnnotationTypes [
-	| repo package class property properties visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| metaModel package class property properties visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
-	repo := visitor newMetaRepository.
+	metaModel := visitor newMetaRepository.
 
-	package := repo elementNamed: 'FM3'.
-	class := repo elementNamed: 'FM3.Element'.
+	package := metaModel elementNamed: 'FM3'.
+	class := metaModel elementNamed: 'FM3.Element'.
 	self assert: class isFM3Class.
 	self assert: class superclass equals: FM3Object instance.
 	self assert: class implementingClass equals: FM3Element.
@@ -85,77 +84,58 @@ FMMetaRepositoryFilterTest >> testAnnotationTypes [
 	self assert: (properties noneSatisfy: #isContainer)
 ]
 
-{ #category : #'tests-metarepository' }
-FMMetaRepositoryFilterTest >> testBookMetamodel [
-	| or m repo fm3 visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
-	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
-	visitor run.
-	fm3 := visitor newMetaRepository.
-
-	or := FMImporter repository: (FMMetaModel withMetamodel: fm3).
-	m := FMModelBuilder new client: or.
-	m document: [ m new: 'FM3.Class' with: [ m a: #name of: 'Book' ] ].
-	repo := or repository asMetarepository.
-	self denyEmpty: repo elements.
-	self assert: repo elements size equals: 1.
-	self assert: repo elements anyOne name equals: #Book
-]
-
 { #category : #tests }
 FMMetaRepositoryFilterTest >> testClassWithoutPackage [
-	| aClassWithoutPackage repo visitor |
+	| aClassWithoutPackage metaModel visitor |
 	aClassWithoutPackage := FM3Class named: 'AClass'.
-	repo := FMMetaModel new.
-	repo add: aClassWithoutPackage.
+	metaModel := FMMetaModel new.
+	metaModel add: aClassWithoutPackage.
 
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repo;
+		metaRepository: metaModel;
 		classes: {aClassWithoutPackage}.
 	self shouldnt: [ visitor run ] raise: Error
 ]
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testExportAsMSE [
-	| repo visitor repoFM3 printer |
-	repoFM3 := FMMetaMetaModel new.
+	| metaModel visitor metaMetaModel printer |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
-	repo := visitor newMetaRepository.
+	metaModel := visitor newMetaRepository.
 
 	printer := FMMSEPrinter new onString.
-	repo accept: printer.
+	metaModel accept: printer.
 	self assert: printer stream contents isString.
 	self assert: printer stream contents first equals: $(
 ]
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testExportAsXML [
-	| repo visitor repoFM3 printer |
-	repoFM3 := FMMetaMetaModel new.
+	| metaModel visitor metaMetaModel printer |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
-	repo := visitor newMetaRepository.
+	metaModel := visitor newMetaRepository.
 
 	printer := FMXMLPrinter new onString.
-	repo accept: printer.
+	metaModel accept: printer.
 	self assert: printer stream contents isString.
 	self assert: printer stream contents first equals: $<
 ]
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testFM3 [
-	| fm3 repoFM3 visitor |
-	repoFM3 := FMMetaMetaModel new.
+	| fm3 metaMetaModel visitor |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
 	fm3 := visitor newMetaRepository.
 	self assert: fm3 notNil.
@@ -164,11 +144,11 @@ FMMetaRepositoryFilterTest >> testFM3 [
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testFM3Classes [
-	| fm3 visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| fm3 visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
 	fm3 := visitor newMetaRepository.
 	self assert: (fm3 descriptionOf: FM3Element) notNil.
@@ -184,19 +164,19 @@ FMMetaRepositoryFilterTest >> testFM3Classes [
 FMMetaRepositoryFilterTest >> testFM3IsComplete [
 	"More information about FM3 may be found on http://smallwiki.unibe.ch/fame/fm3/"
 
-	| repo names visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| metaModel names visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
-	repo := visitor newMetaRepository.
-	self assert: repo notNil.	"boot strapping FM3 does internally run the pragma processor"
-	names := repo elements collect: [ :each | each fullName ].	"The package"
+	metaModel := visitor newMetaRepository.
+	self assert: metaModel notNil.	"boot strapping FM3 does internally run the pragma processor"
+	names := metaModel elements collect: [ :each | each fullName ].	"The package"
 	self assert: (names includes: 'FM3').
 	self
-		assert: (repo elements detect: [ :el | el fullName = 'FM3.Class.package' ]) opposite
-		equals: (repo elements detect: [ :el | el fullName = 'FM3.Package.classes' ]).	"The superclass of everything"	"name, fullName, and owner are the 3 properties that define an element"
+		assert: (metaModel elements detect: [ :el | el fullName = 'FM3.Class.package' ]) opposite
+		equals: (metaModel elements detect: [ :el | el fullName = 'FM3.Package.classes' ]).	"The superclass of everything"	"name, fullName, and owner are the 3 properties that define an element"
 	self assert: (names includes: 'FM3.Element').
 	self assert: (names includes: 'FM3.Element.name').
 	self assert: (names includes: 'FM3.Element.fullName').
@@ -229,15 +209,15 @@ FMMetaRepositoryFilterTest >> testFM3IsComplete [
 FMMetaRepositoryFilterTest >> testFM3NewVersion [
 	"The current implementation of FameSystem does not provide a scope for its repository"
 
-	| repo names visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| metaModel names visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
-	repo := visitor newMetaRepository.
+	metaModel := visitor newMetaRepository.
 
-	names := repo elements collect: [ :each | each fullName ].	"The package"
+	names := metaModel elements collect: [ :each | each fullName ].	"The package"
 	self assert: (names includes: 'FM3').	"The superclass of everything"	"name, fullName, and owner are the 3 properties that define an element"
 	self assert: (names includes: 'FM3.Element').
 	self assert: (names includes: 'FM3.Element.name').
@@ -269,35 +249,54 @@ FMMetaRepositoryFilterTest >> testFM3NewVersion [
 ]
 
 { #category : #'tests-metarepository' }
-FMMetaRepositoryFilterTest >> testImporter [
-	| fm3 repoFM3 visitor string repo |
-	repoFM3 := FMMetaMetaModel new.
+FMMetaRepositoryFilterTest >> testImportBook [
+	| importer builder model fm3 visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
+	visitor run.
+	fm3 := visitor newMetaRepository.
+
+	importer := FMImporter model: (FMMetaModel withMetamodel: fm3).
+	builder := FMModelBuilder client: importer.
+	builder document: [ builder new: 'FM3.Class' with: [ builder a: #name of: 'Book' ] ].
+	model := importer model.
+	self denyEmpty: model elements.
+	self assert: model elements size equals: 1.
+	self assert: model elements anyOne name equals: #Book
+]
+
+{ #category : #'tests-metarepository' }
+FMMetaRepositoryFilterTest >> testImporter [
+	| fm3 metaMetaModel visitor string metaModel |
+	metaMetaModel := FMMetaMetaModel new.
+	visitor := FMMetaRepositoryFilter new
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
 	fm3 := visitor newMetaRepository.
 
 	string := '((FM3.Package (id: 1) (name ''Office'')))'.
-	repo := FMMetaModel withMetamodel: fm3.
-	(FMImporter repository: repo)
+	metaModel := FMMetaModel withMetamodel: fm3.
+	(FMImporter model: metaModel)
 		fromString: string;
 		run.
-	self assert: repo elements size equals: 1.
-	self assert: repo elements anyOne name equals: #Office.
-	self assert: repo elements anyOne fullName equals: 'Office'
+	self assert: metaModel elements size equals: 1.
+	self assert: metaModel elements anyOne name equals: #Office.
+	self assert: metaModel elements anyOne fullName equals: 'Office'
 ]
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQCompound [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQCompound)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Expression').
 	self assert: (names includes: 'EQ.Operator').
@@ -312,14 +311,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQCompound [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQEquation [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQEquation)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Equation').
 	self assert: (names includes: 'EQ.Expression').
@@ -334,14 +333,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQEquation [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQEquationSystem [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQEquationSystem)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Equation').
 	self assert: (names includes: 'EQ.EquationSystem').
@@ -356,14 +355,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQEquationSystem [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQExpression [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQExpression)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Expression').
 	self deny: (names includes: 'EQ.Equation').
@@ -378,14 +377,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQExpression [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQIdentifier [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQIdentifier)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Identifier').
 	self deny: (names includes: 'EQ.Expression').
@@ -400,14 +399,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQIdentifier [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQNumerical [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQNumerical)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Simple').
 	self assert: (names includes: 'EQ.Expression').
@@ -422,14 +421,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQNumerical [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQOperator [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQOperator)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Operator').
 	self deny: (names includes: 'EQ.Expression').
@@ -444,14 +443,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQOperator [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQSimple [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQSimple)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Simple').
 	self assert: (names includes: 'EQ.Expression').
@@ -466,14 +465,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQSimple [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeEQVariable [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: eqModel;
 		classes: {(eqModel descriptionOf: EQVariable)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'EQ').
 	self assert: (names includes: 'EQ.Variable').
 	self assert: (names includes: 'EQ.Simple').
@@ -488,14 +487,14 @@ FMMetaRepositoryFilterTest >> testIncludeEQVariable [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeLIBBook [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: libModel;
 		classes: {(libModel descriptionOf: LIBBook)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'LIB').
 	self assert: (names includes: 'LIB.Person').
 	self assert: (names includes: 'LIB.Book').
@@ -504,14 +503,14 @@ FMMetaRepositoryFilterTest >> testIncludeLIBBook [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeLIBLibrary [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: libModel;
 		classes: {(libModel descriptionOf: LIBLibrary)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'LIB').
 	self assert: (names includes: 'LIB.Library').
 	self assert: (names includes: 'LIB.Person').
@@ -520,14 +519,14 @@ FMMetaRepositoryFilterTest >> testIncludeLIBLibrary [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeLIBPerson [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: libModel;
 		classes: {(libModel descriptionOf: LIBPerson)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'LIB').
 	self assert: (names includes: 'LIB.Person').
 	self assert: (names includes: 'LIB.Book').
@@ -536,14 +535,14 @@ FMMetaRepositoryFilterTest >> testIncludeLIBPerson [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeRPGDragon [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: rpgModel;
 		classes: {(rpgModel descriptionOf: RPGDragon)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'RPG').
 	self assert: (names includes: 'RPG.Dragon').
 	self assert: (names includes: 'RPG.Hero').
@@ -552,14 +551,14 @@ FMMetaRepositoryFilterTest >> testIncludeRPGDragon [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeRPGHero [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: rpgModel;
 		classes: {(rpgModel descriptionOf: RPGHero)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'RPG').
 	self assert: (names includes: 'RPG.Dragon').
 	self assert: (names includes: 'RPG.Hero').
@@ -568,14 +567,14 @@ FMMetaRepositoryFilterTest >> testIncludeRPGHero [
 
 { #category : #'test-include-fameexamples' }
 FMMetaRepositoryFilterTest >> testIncludeRPGTreasure [
-	| repo names visitor |
+	| metaModel names visitor |
 	visitor := FMMetaRepositoryFilter new
 		metaRepository: rpgModel;
 		classes: {(rpgModel descriptionOf: RPGTreasure)}.
 	visitor run.
 
-	repo := visitor newMetaRepository.
-	names := repo elements collect: #fullName.
+	metaModel := visitor newMetaRepository.
+	names := metaModel elements collect: #fullName.
 	self assert: (names includes: 'RPG').
 	self assert: (names includes: 'RPG.Dragon').
 	self assert: (names includes: 'RPG.Hero').
@@ -584,101 +583,102 @@ FMMetaRepositoryFilterTest >> testIncludeRPGTreasure [
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testResolving [
-	| or m fm3 visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| importer builder fm3 visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
 	fm3 := visitor newMetaRepository.
 
-	or := FMImporter repository: (FMMetaModel withMetamodel: fm3).
-	m := FMModelBuilder new client: or.
-	m document: [ m new: 'FM3.Class' with: [ m a: #name of: 'MyName' ] ].
-	self denyEmpty: or repository elements.
-	self assert: or repository elements size equals: 1.
-	self assert: or repository elements anyOne isFM3Class
+	importer := FMImporter model: (FMMetaModel withMetamodel: fm3).
+	builder := FMModelBuilder client: importer.
+	builder document: [ builder new: 'FM3.Class' with: [ builder a: #name of: 'MyName' ] ].
+	self denyEmpty: importer model elements.
+	self assert: importer model elements size equals: 1.
+	self assert: importer model elements anyOne isFM3Class
 ]
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testResolvingId [
-	| or m fm3 visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| importer builder fm3 visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
 	fm3 := visitor newMetaRepository.
 
-	or := FMImporter repository: (FMMetaModel withMetamodel: fm3).
-	m := FMModelBuilder new client: or.
-	m
-		document: [ m
+	importer := FMImporter model: (FMMetaModel withMetamodel: fm3).
+	builder := FMModelBuilder client: importer.
+	builder
+		document: [ builder
 				new: 'FM3.Class'
-				with: [ m id: 3.
-					m a: #name of: 'MyName'.
-					m a: #superclass of: [ m ref: 2 ] ].
-			m
+				with: [ builder id: 3.
+					builder a: #name of: 'MyName'.
+					builder a: #superclass of: [ builder ref: 2 ] ].
+			builder
 				new: 'FM3.Class'
-				with: [ m id: 2.
-					m a: #name of: 'MyName2' ] ].
-	self denyEmpty: or repository elements.
-	self assert: or repository elements size equals: 2
+				with: [ builder id: 2.
+					builder a: #name of: 'MyName2' ] ].
+	self denyEmpty: importer model elements.
+	self assert: importer model elements size equals: 2
 ]
 
 { #category : #'tests-metarepository' }
 FMMetaRepositoryFilterTest >> testResolvingMultiArgs [
-	| or pack ref2 ref4 ref5 repo fm3 visitor repoFM3 |
-	repoFM3 := FMMetaMetaModel new.
+	| importer pack ref2 ref4 ref5 model fm3 visitor metaMetaModel |
+	metaMetaModel := FMMetaMetaModel new.
 	visitor := FMMetaRepositoryFilter new
-		metaRepository: repoFM3;
-		classes: repoFM3 classes.
+		metaRepository: metaMetaModel;
+		classes: metaMetaModel classes.
 	visitor run.
 	fm3 := visitor newMetaRepository.
 
-	or := FMImporter repository: (FMMetaModel withMetamodel: fm3).
-	or beginDocument.
-	or beginElement: 'FM3.Package'.
-	or serial: 3.
-	or beginAttribute: 'name'.
-	or primitive: 'MyPackage'.
-	or endAttribute: 'name'.
-	or beginAttribute: 'classes'.
-	or referenceNumber: 2.
-	or referenceNumber: 4.
-	or referenceNumber: 2.
-	or referenceNumber: 5.
-	or endAttribute: 'classes'.
-	or endElement: 'FM3.Package'.
-	or beginElement: 'FM3.Class'.
-	or serial: 2.
-	or beginAttribute: 'name'.
-	or primitive: 'MyName2'.
-	or endAttribute: 'name'.
-	or beginAttribute: 'superclass'.
-	or referenceNumber: 5.
-	or endAttribute: 'superclass'.
-	or endElement: 'FM3.Class'.
-	or beginElement: 'FM3.Class'.
-	or serial: 4.
-	or beginAttribute: 'superclass'.
-	or referenceNumber: 2.
-	or endAttribute: 'superclass'.
-	or beginAttribute: 'name'.
-	or primitive: 'MyName4'.
-	or endAttribute: 'name'.
-	or endElement: 'FM3.Class'.
-	or beginElement: 'FM3.Class'.
-	or serial: 5.
-	or beginAttribute: 'name'.
-	or primitive: 'MyName5'.
-	or endAttribute: 'name'.
-	or endElement: 'FM3.Class'.
-	or endDocument.
-	repo := or repository asMetarepository.
-	self denyEmpty: repo elements.
-	self assert: repo elements size equals: 4.
-	pack := repo packageNamed: 'MyPackage'.
+	importer := (FMImporter model: (FMMetaModel withMetamodel: fm3))
+		beginDocument;
+		beginElement: 'FM3.Package';
+		serial: 3;
+		beginAttribute: 'name';
+		primitive: 'MyPackage';
+		endAttribute: 'name';
+		beginAttribute: 'classes';
+		referenceNumber: 2;
+		referenceNumber: 4;
+		referenceNumber: 2;
+		referenceNumber: 5;
+		endAttribute: 'classes';
+		endElement: 'FM3.Package';
+		beginElement: 'FM3.Class';
+		serial: 2;
+		beginAttribute: 'name';
+		primitive: 'MyName2';
+		endAttribute: 'name';
+		beginAttribute: 'superclass';
+		referenceNumber: 5;
+		endAttribute: 'superclass';
+		endElement: 'FM3.Class';
+		beginElement: 'FM3.Class';
+		serial: 4;
+		beginAttribute: 'superclass';
+		referenceNumber: 2;
+		endAttribute: 'superclass';
+		beginAttribute: 'name';
+		primitive: 'MyName4';
+		endAttribute: 'name';
+		endElement: 'FM3.Class';
+		beginElement: 'FM3.Class';
+		serial: 5;
+		beginAttribute: 'name';
+		primitive: 'MyName5';
+		endAttribute: 'name';
+		endElement: 'FM3.Class';
+		endDocument;
+		yourself.
+	model := importer model.
+	self denyEmpty: model elements.
+	self assert: model elements size equals: 4.
+	pack := model packageNamed: 'MyPackage'.
 	ref2 := pack classNamed: 'MyName2'.
 	ref4 := pack classNamed: 'MyName4'.
 	ref5 := pack classNamed: 'MyName5'.

--- a/src/Fame-Tests-Core/FMMetaRepositoryTest.class.st
+++ b/src/Fame-Tests-Core/FMMetaRepositoryTest.class.st
@@ -18,7 +18,7 @@ FMMetaRepositoryTest >> testImportExtension [
 	| string repo |
 	repo := self testImporter.
 	string := '((FM3.Class (name ''Employee'') (package (ref: Office))))'.
-	(FMImporter repository: repo)
+	(FMImporter model: repo)
 		fromString: string;
 		run.
 	self assert: repo elements size equals: 2.
@@ -31,7 +31,7 @@ FMMetaRepositoryTest >> testImporter [
 	| string repo |
 	string := '((FM3.Package (id: 1) (name ''Office'')))'.
 	repo := FMMetaModel new.
-	(FMImporter repository: repo)
+	(FMImporter model: repo)
 		fromString: string;
 		run.
 	self assert: repo elements size equals: 1.

--- a/src/Fame-Tests-Core/FMModelBuilder.class.st
+++ b/src/Fame-Tests-Core/FMModelBuilder.class.st
@@ -7,6 +7,13 @@ Class {
 	#category : #'Fame-Tests-Core'
 }
 
+{ #category : #'instance creation' }
+FMModelBuilder class >> client: aClient [
+	^ self new
+		client: aClient;
+		yourself
+]
+
 { #category : #'DSL-synonyms' }
 FMModelBuilder >> a: attributeName of: valueOrBodyOrArray [
 	

--- a/src/Fame-Tests-Core/FMModelBuilderTest.class.st
+++ b/src/Fame-Tests-Core/FMModelBuilderTest.class.st
@@ -8,7 +8,7 @@ Class {
 FMModelBuilderTest >> testDocument [
 	| client m s |
 	client := FMMSEPrinter new onString.
-	m := FMModelBuilder new client: client.
+	m := FMModelBuilder client: client.
 	m document: [  ].
 	s := client stream contents.
 	self assert: s equals: '()'
@@ -18,7 +18,7 @@ FMModelBuilderTest >> testDocument [
 FMModelBuilderTest >> testPerson [
 	| client m s |
 	client := FMMSEPrinter new onString.
-	m := FMModelBuilder new client: client.
+	m := FMModelBuilder client: client.
 	m document: [ m new: #Person with: [ m a: #name of: 'John Doe' ] ].
 	s := client stream contents.
 	self
@@ -33,7 +33,7 @@ FMModelBuilderTest >> testPerson [
 FMModelBuilderTest >> testPersonWithDog [
 	| client m s |
 	client := FMMSEPrinter new onString.
-	m := FMModelBuilder new client: client.
+	m := FMModelBuilder client: client.
 	m
 		document: [ m
 				new: #Person
@@ -61,7 +61,7 @@ FMModelBuilderTest >> testPersonWithDog [
 FMModelBuilderTest >> testPersonWithDogUsingIdReferences [
 	| client m s |
 	client := FMMSEPrinter new onString.
-	m := FMModelBuilder new client: client.
+	m := FMModelBuilder client: client.
 	m
 		document: [ m
 				new: #Person
@@ -89,7 +89,7 @@ FMModelBuilderTest >> testPersonWithDogUsingIdReferences [
 FMModelBuilderTest >> testPersonWithNicknames [
 	| client m s |
 	client := FMMSEPrinter new onString.
-	m := FMModelBuilder new client: client.
+	m := FMModelBuilder client: client.
 	m
 		document: [ m
 				new: #Person

--- a/src/Famix-Deprecated/FMImporter.extension.st
+++ b/src/Famix-Deprecated/FMImporter.extension.st
@@ -20,3 +20,21 @@ FMImporter >> nameTranslator: anObject [
 		dictionary: anObject;
 		yourself
 ]
+
+{ #category : #'*Famix-Deprecated' }
+FMImporter >> repository [
+	self deprecated: 'Use #model instead' transformWith: '`@receiver repository' -> '`@receiver model'.
+	^ self model
+]
+
+{ #category : #'*Famix-Deprecated' }
+FMImporter class >> repository: aModel [
+	self deprecated: 'Use #model: instead' transformWith: '`@receiver repository: `@arg' -> '`@receiver model: `@arg'.
+	^ self model: aModel
+]
+
+{ #category : #'*Famix-Deprecated' }
+FMImporter >> repository: aModel [
+	self deprecated: 'Use #model: instead' transformWith: '`@receiver repository: `@arg' -> '`@receiver model: `@arg'.
+	^ self model: aModel
+]

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -111,7 +111,7 @@ MooseModel class >> importFrom: aStream withMetamodel: aMetamodel [
 	| model importer areWarningsEnabled |
 	model := FMModel withMetamodel: aMetamodel.
 	importer := MSEImporter new.
-	importer repository: model.
+	importer model: model.
 	importer stream: aStream.
 
 	"We are currently updating the meta models and most parsers are not up to date.

--- a/src/Moose-Tests-Core/FamixTest.class.st
+++ b/src/Moose-Tests-Core/FamixTest.class.st
@@ -49,12 +49,12 @@ FamixTest >> oneClassAndOneMethod [
 { #category : #tests }
 FamixTest >> testMSEImport [
 	| importer model |
-	importer := (FMImporter repository: (FMModel withMetamodel: FamixTest3Model metamodel))
+	importer := (FMImporter model: (FMModel withMetamodel: FamixTest3Model metamodel))
 		fromString: self oneClassAndOneMethod;
 		run.
-	self assert: importer repository elements size equals: 2.
+	self assert: importer model elements size equals: 2.
 	model := FamixTest3Model new.
-	model addAll: importer repository elements.
+	model addAll: importer model elements.
 	self assert: model allClasses size equals: 1.
 	self assert: model allMethods size equals: 1
 ]
@@ -62,13 +62,13 @@ FamixTest >> testMSEImport [
 { #category : #tests }
 FamixTest >> testRobustMSEImport [
 	| importer model |
-	importer := (FMImporter repository: (FMModel withMetamodel: FamixTest3Model metamodel))
+	importer := (FMImporter model: (FMModel withMetamodel: FamixTest3Model metamodel))
 		fromString: self classWithUnknownAttribute;
 		run.
 
-	self assert: importer repository elements size equals: 4.
+	self assert: importer model elements size equals: 4.
 	model := FamixTest3Model new.
-	model addAll: importer repository elements.
+	model addAll: importer model elements.
 	self assert: model allClasses size equals: 2.
 	self assert: model allMethods size equals: 1.
 	self assert: model allReferences size equals: 1


### PR DESCRIPTION
There is a method #asMetaRepository that should not exist because it makes no sense to cast a model as a metamodel. I removed it.

I also: 
- Introduced a constructor for the FMMetamodelBuilder
- Renamed some variables to have more explicit names
- Removed some dead code 
- Renamed #repository into #model in some places.