### PR TITLE
1735-Generated-ImportingContext-should-have-an-importMaximum-method

### DIFF
--- a/src/Moose-Core/FmxImportingContext.class.st
+++ b/src/Moose-Core/FmxImportingContext.class.st
@@ -31,6 +31,14 @@ FmxImportingContext >> import: aClass traversed: traversedClasses [
 	
 ]
 
+{ #category : #'importing-filters' }
+FmxImportingContext >> importMaximum [
+	(self class methods
+		select: [ :m | m selector beginsWith: #import ]
+		thenCollect: #selector) \ #(importMaximum)
+		do: [ :aSelector | self perform: aSelector ]
+]
+
 { #category : #accessing }
 FmxImportingContext >> imports [
 	^ imports


### PR DESCRIPTION
fix #1735 - Add importing  importMaximum to FmxImporting context