### PR TITLE
Remove-unused-key-concept-from-properties

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -304,7 +304,6 @@ FM3Class >> primitiveProperties [
 FM3Class >> properties [
 	<MSEProperty: #properties type: 'FM3.Property' opposite: #class>
 	<multivalued>
-	<key: #name>
 	^ properties
 ]
 

--- a/src/Fame-Core/FM3Package.class.st
+++ b/src/Fame-Core/FM3Package.class.st
@@ -32,8 +32,7 @@ FM3Package >> classNamed: aString ifAbsent: aBlock [
 FM3Package >> classes [
 	<MSEProperty: #classes type: #FM3Class opposite: #package>
 	<multivalued>
-	<key: #name>
-	^classes
+	^ classes
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -7,7 +7,6 @@ Instance Variables
 	isContainer:		<Object>
 	isDerived:		<Object>
 	isMultivalued:		<Object>
-	key:		<Object>
 	opposite:		<Object>
 	package:		<Object>
 	type:		<Object>
@@ -24,7 +23,6 @@ Class {
 		'class',
 		'package',
 		'type',
-		'key',
 		'implementingSelector',
 		'isTarget',
 		'isSource'
@@ -86,11 +84,6 @@ FM3Property >> gtTypeString [
 { #category : #testing }
 FM3Property >> hasImplementingSelector [
 	^ self implementingSelector notNil
-]
-
-{ #category : #testing }
-FM3Property >> hasKey [
-	^ key isNotNil
 ]
 
 { #category : #testing }
@@ -205,18 +198,6 @@ FM3Property >> isTarget [
 { #category : #accessing }
 FM3Property >> isTarget: anObject [
 	isTarget := anObject
-]
-
-{ #category : #accessing }
-FM3Property >> key [
-	self flag: 'Todo, think about and meta-describe key'.
-	^ key
-]
-
-{ #category : #accessing }
-FM3Property >> key: anObject [
-
-	key := anObject asSymbol
 ]
 
 { #category : #accessing }

--- a/src/Fame-Core/FMAbstractCodeGenerator.class.st
+++ b/src/Fame-Core/FMAbstractCodeGenerator.class.st
@@ -59,7 +59,6 @@ FMAbstractCodeGenerator >> annotationStringForProperty: property [
 	ann := ann , '>'.
 	property isMultivalued ifTrue: [ ann := ann , ' <multivalued>' ].
 	property isDerived ifTrue: [ ann := ann , ' <derived>' ].
-	property hasKey ifTrue: [ ann := ann , ' <key: ' , property key printString , '>' ].
 	^ ann
 ]
 

--- a/src/Fame-Core/FMPragmaProcessor.class.st
+++ b/src/Fame-Core/FMPragmaProcessor.class.st
@@ -239,8 +239,7 @@ FMPragmaProcessor >> processInfosFrom: aMethod for: prop [
 	(aMethod pragmaAt: #derived) ifNotNil: [ prop isDerived: true ].
 	(aMethod pragmaAt: #source) ifNotNil: [ prop isSource: true ].
 	(aMethod pragmaAt: #target) ifNotNil: [ prop isTarget: true ].
-	(aMethod pragmaAt: #multivalued) ifNotNil: [ prop isMultivalued: true ].
-	(aMethod pragmaAt: #key:) ifNotNil: [ :p | prop key: (p argumentAt: 1) ]
+	(aMethod pragmaAt: #multivalued) ifNotNil: [ prop isMultivalued: true ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
FMProperty includes a concept of key but this is not used. 

Remove it.