### PR TITLE
Remove-methods-acting-on-containment-as-a-tree-instead-of-a-dag

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -265,13 +265,6 @@ FM3Class >> ownerProperties [
 	^ self allProperties select: #isContainer
 ]
 
-{ #category : #'accessing-query' }
-FM3Class >> ownerProperty [
-	self flag: #FIXME.
-	self flag: 'It is possible that several containers exists for a given entity -> we have not a tree, but we should not get cycles at ALL'.
-	^self allProperties detect: #isContainer ifNone: [ nil ]
-]
-
 { #category : #accessing }
 FM3Class >> package [
 	<MSEProperty: #package type: #FM3Package opposite: #classes>

--- a/src/Fame-Core/FMModel.class.st
+++ b/src/Fame-Core/FMModel.class.st
@@ -99,13 +99,10 @@ FMModel >> coerceProperty: propertyOrName receiver: receiver [
 ]
 
 { #category : #'accessing-meta' }
-FMModel >> containerOf: element [
+FMModel >> containersOf: element [
 	^ (self metaDescriptionOf: element)
-		ifNil: [ nil ]
-		ifNotNil: [ :meta |
-			meta ownerProperty
-				ifNil: [ nil ]
-				ifNotNil: [ :property | self get: property element: element ] ]
+		ifNil: [ #() ]
+		ifNotNil: [ :meta | meta ownerProperties flatCollectAsSet: [ :property | self get: property element: element ] ]
 ]
 
 { #category : #initialization }

--- a/src/Fame-ImportExport/FMModelExporter.class.st
+++ b/src/Fame-ImportExport/FMModelExporter.class.st
@@ -128,8 +128,11 @@ FMModelExporter >> roots [
 		flag:
 			'VBL - Add a test to detect that the repository is a meta model or not. If  it is, the exporter works normally else, only the roots are exported (issue was detected when adding the container pragmas). I don''t know if it is the better fix to do.'.
 	^ roots
-		ifNil:
-			[ roots := repository elements select: [ :each | (self isPrimitiveTypeOrObject: each) not and: [ repository isMetamodel not or: [ (repository containerOf: each) isEmptyOrNil ] ] ] ]
+		ifNil: [
+			roots := repository elements iterator
+							| [ :each | self isPrimitiveTypeOrObject: each ] rejectIt
+							| [ :each | repository isMetamodel not or: [ (repository containersOf: each) isEmpty ] ] selectIt
+							> Array ]
 ]
 
 { #category : #exporting }

--- a/src/Famix-Deprecated/FM3Class.extension.st
+++ b/src/Famix-Deprecated/FM3Class.extension.st
@@ -99,12 +99,6 @@ FM3Class class >> object [
 ]
 
 { #category : #'*Famix-Deprecated' }
-FM3Class >> ownerAttribute [
-	self deprecated: 'Use #ownerProperty instead.' transformWith: '``@object ownerAttribute' -> '``@object ownerProperty'.
-	^ self ownerProperty
-]
-
-{ #category : #'*Famix-Deprecated' }
 FM3Class >> ownerAttributes [
 	self deprecated: 'Use #ownerProperties instead.' transformWith: '``@object ownerAttributes' -> '``@object ownerProperties'.
 	^ self ownerProperties


### PR DESCRIPTION
The containment in Fame is a DAG and not a Tree. Remove the methods using it as a tree.