### PR TITLE
Simplify-MSEParser

### DIFF
--- a/src/Fame-ImportExport/FMMSEParser.class.st
+++ b/src/Fame-ImportExport/FMMSEParser.class.st
@@ -4,11 +4,11 @@ Class {
 	#instVars : [
 		'stream',
 		'client',
-		'buf',
-		'char',
 		'progBar',
 		'lastUpdate',
-		'characterSet'
+		'characterSet',
+		'chararacter',
+		'buffer'
 	],
 	#category : #'Fame-ImportExport'
 }
@@ -19,13 +19,13 @@ FMMSEParser >> Attribute [
 
 	"Attribute := OPEN n:NAME { beginAttribute(n) } Value* CLOSE { endAttribute(n) }"
 
-	| pos n |
-	pos := self pos.
+	| pos name |
+	pos := self position.
 	self tOPEN ifFalse: [ ^ self backtrack: pos ].
-	n := self tNAME.
-	n ifNil: [ ^ self backtrack: pos ].
+	name := self tNAME.
+	name ifNil: [ ^ self backtrack: pos ].
 	client
-		inAttribute: n
+		inAttribute: name
 		do: [ [ self Value ] whileTrue.
 			self tCLOSE ifFalse: [ ^ self syntaxError ] ].
 	self tWHITESPACE.
@@ -59,20 +59,20 @@ FMMSEParser >> Element [
 
 	"Element := OPEN n:FULLNAME { beginElement(n) } Serial? Attribute* CLOSE { endElement(n) }"
 
-	| pos n |
-	pos := self pos.
+	| pos name |
+	pos := self position.
 	self tOPEN ifFalse: [ ^ self backtrack: pos ].
-	n := self tFULLNAME.
-	n ifNil: [ ^ self backtrack: pos ].
+	name := self tFULLNAME.
+	name ifNil: [ ^ self backtrack: pos ].
 	client
-		inElement: n
+		inElement: name
 		do: [ self Serial.
 			[ self Attribute ] whileTrue.
 			self tCLOSE ifFalse: [ ^ self syntaxError ] ].
 
 	self tWHITESPACE.
 
-	self increment.	"UI stuff"
+	self incrementProgressBar.	"UI stuff"
 	^ true
 ]
 
@@ -82,14 +82,14 @@ FMMSEParser >> Identifier [
 
 	"Identifier := digit+"
 
-	(self characterSet isDigit: char)
+	(self characterSet isDigit: chararacter)
 		ifFalse: [ ^ nil ].
 	
-	buf reset.
-	buf nextPut: char.
-	[ self characterSet isDigit: self next ] whileTrue: [ buf nextPut: char ].
+	buffer reset.
+	buffer nextPut: chararacter.
+	[ self characterSet isDigit: self next ] whileTrue: [ buffer nextPut: chararacter ].
 	self tWHITESPACE.
-	^ Integer readFrom: buf contents readStream
+	^ Integer readFrom: buffer contents readStream
 ]
 
 { #category : #expressions }
@@ -99,56 +99,56 @@ FMMSEParser >> Number [
 	"Number := hypen? digit+ ( dot digit+ ( e hypen? digit+ )? )?"
 
 	| pos |
-	pos := self pos.
-	buf reset.
+	pos := self position.
+	buffer reset.
 	"hypen?	"
-	$- == char
-		ifTrue: [ buf nextPut: char.
+	$- == chararacter
+		ifTrue: [ buffer nextPut: chararacter.
 			self next ].
 	"digit+"
-	(self characterSet isDigit: char)
+	(self characterSet isDigit: chararacter)
 		ifFalse: [ self backtrack: pos.
 			^ nil ].
-	[ buf nextPut: char.
+	[ buffer nextPut: chararacter.
 	self characterSet isDigit: self next ] whileTrue.
 	"(dot"
-	$. == char
-		ifTrue: [ buf nextPut: char.
+	$. == chararacter
+		ifTrue: [ buffer nextPut: chararacter.
 			self next.
 			"digit+"
-			(self characterSet isDigit: char)
+			(self characterSet isDigit: chararacter)
 				ifFalse: [ self syntaxError.
 					^ nil ].
-			[ buf nextPut: char.
+			[ buffer nextPut: chararacter.
 			self characterSet isDigit: self next ] whileTrue.
 			"(e"
-			$e == char
-				ifTrue: [ buf nextPut: char.
+			$e == chararacter
+				ifTrue: [ buffer nextPut: chararacter.
 					self next.
 					"hypen?"
-					$- == char
-						ifTrue: [ buf nextPut: char.
+					$- == chararacter
+						ifTrue: [ buffer nextPut: chararacter.
 							self next ].
 					"digit+"
-					(self characterSet isDigit: char)
+					(self characterSet isDigit: chararacter)
 						ifFalse: [ self syntaxError.
 							^ nil ].
-					[ buf nextPut: char.
+					[ buffer nextPut: chararacter.
 					self characterSet isDigit: self next ] whileTrue
 					")?)?" ] ].
 	self tWHITESPACE.
-	^ Number readFrom: buf contents readStream
+	^ Number readFrom: buffer contents readStream
 ]
 
 { #category : #expressions }
 FMMSEParser >> Primitive [
 	"Matches primitive value (returns boolean)."
 
-	| p |
-	p := self String.
-	p ifNotNil: [ client primitive: p. ^ true ].
-	p := self Number.
-	p ifNotNil: [ client primitive: p. ^ true ].
+	| primitive |
+	primitive := self String.
+	primitive ifNotNil: [ client primitive: primitive. ^ true ].
+	primitive := self Number.
+	primitive ifNotNil: [ client primitive: primitive. ^ true ].
 	self tTRUE ifTrue: [ client primitive: true. ^ true ].
 	self tFALSE ifTrue: [ client primitive: false. ^ true ].
 	^ false
@@ -158,12 +158,12 @@ FMMSEParser >> Primitive [
 FMMSEParser >> Reference [
 	"Matches a Reference node (returns boolean)."
 	"Reference --> OPEN REF n:Identifier { client referenceNumber: n } CLOSE"
-	| pos serial |
-	pos := self pos.
-	self tOPEN ifFalse: [ ^ self backtrack: pos ].
-	self tREF ifFalse: [ ^ self backtrack: pos ].
+	| position serial |
+	position := self position.
+	self tOPEN ifFalse: [ ^ self backtrack: position ].
+	self tREF ifFalse: [ ^ self backtrack: position ].
 	serial := self Identifier.
-	serial ifNil: [ ^ self backtrack: pos ].
+	serial ifNil: [ ^ self backtrack: position ].
 	client referenceNumber: serial.
 	self tCLOSE ifFalse: [ ^ self syntaxError ].
 	self tWHITESPACE.
@@ -174,13 +174,13 @@ FMMSEParser >> Reference [
 FMMSEParser >> Reference2 [
 	"Matches a Reference node (returns boolean)."
 	"Reference --> OPEN REF n:Name { client referenceName: n } CLOSE"
-	| pos n |
-	pos := self pos.
-	self tOPEN ifFalse: [ ^ self backtrack: pos ].
-	self tREF ifFalse: [ ^ self backtrack: pos ].
-	n := self tFULLNAME.
-	n ifNil: [ ^ self backtrack: pos ].
-	client referenceName: n.
+	| position name |
+	position := self position.
+	self tOPEN ifFalse: [ ^ self backtrack: position ].
+	self tREF ifFalse: [ ^ self backtrack: position ].
+	name := self tFULLNAME.
+	name ifNil: [ ^ self backtrack: position ].
+	client referenceName: name.
 	self tCLOSE ifFalse: [ ^ self syntaxError ].
 	self tWHITESPACE.
 	^ true
@@ -190,12 +190,12 @@ FMMSEParser >> Reference2 [
 FMMSEParser >> Serial [
 	"Matches a serial number node (returns boolean)."
 	"Serial --> OPEN ID n:Identifier { client serial: n } CLOSE"
-	| pos serial |
-	pos := self pos.
-	self tOPEN ifFalse: [ ^ self backtrack: pos ].
-	self tID ifFalse: [ ^ self backtrack: pos ].
+	| position serial |
+	position := self position.
+	self tOPEN ifFalse: [ ^ self backtrack: position ].
+	self tID ifFalse: [ ^ self backtrack: position ].
 	serial := self Identifier.
-	serial ifNil: [ ^ self backtrack: pos ].
+	serial ifNil: [ ^ self backtrack: position ].
 	client serial: serial.
 	self tCLOSE ifFalse: [ self syntaxError ].
 	self tWHITESPACE.
@@ -204,17 +204,16 @@ FMMSEParser >> Serial [
 
 { #category : #expressions }
 FMMSEParser >> String [
-	$' == char ifFalse: [ ^ nil ].
-	
-	buf reset.
-	
-	[ 
-	[ self next.
-	char ifNil: [ self syntaxError ].
-	$' == char ] whileFalse: [ buf nextPut: char ].
-	$' == self next ] whileTrue: [ buf nextPut: char ].
+	$' == chararacter ifFalse: [ ^ nil ].
+
+	buffer reset.
+
+	[ [ self next.
+	chararacter ifNil: [ self syntaxError ].
+	$' == chararacter ] whileFalse: [ buffer nextPut: chararacter ].
+	$' == self next ] whileTrue: [ buffer nextPut: chararacter ].
 	self tWHITESPACE.
-	^ buf contents
+	^ buffer contents
 ]
 
 { #category : #expressions }
@@ -228,40 +227,37 @@ FMMSEParser >> Value [
 
 { #category : #testing }
 FMMSEParser >> atEnd [
-	^ char isNil
+	^ chararacter isNil
 ]
 
 { #category : #private }
 FMMSEParser >> backtrack: integer [
 	"Backtracks to given integer."
 
-	integer ~~ stream position ifTrue: [
-		stream position: integer - 1. 
-		self next "fetch peek again" ]. 
-	^false
+	integer ~~ stream position
+		ifTrue: [ stream position: integer - 1.
+			self next	"fetch peek again" ].
+	^ false
 ]
 
 { #category : #running }
 FMMSEParser >> basicRun [
-
 	self Document.
-	self atEnd ifFalse: [ ^self syntaxError ]
+	self atEnd ifFalse: [ ^ self syntaxError ]
 ]
 
 { #category : #accessing }
 FMMSEParser >> characterSet [
-	^ characterSet ifNil: [ characterSet := char characterSet ]
+	^ characterSet ifNil: [ characterSet := chararacter characterSet ]
 ]
 
 { #category : #accessing }
 FMMSEParser >> client [
-
-	^client
+	^ client
 ]
 
 { #category : #accessing }
 FMMSEParser >> client: parseClient [
-
 	client := parseClient
 ]
 
@@ -271,32 +267,40 @@ FMMSEParser >> fromString: mseString [
 ]
 
 { #category : #running }
-FMMSEParser >> increment [
-	(progBar isNotNil and: [ (Time millisecondsSince: lastUpdate) >= 500 ])
-		ifTrue: [ 
-			progBar value: self pos.
-			lastUpdate := Time millisecondClockValue ]
+FMMSEParser >> incrementProgressBar [
+	(progBar isNotNil and: [ (Time millisecondsSince: lastUpdate) >= 500 ]) ifFalse: [ ^ self ].
+	progBar value: self position.
+	lastUpdate := Time millisecondClockValue
+]
+
+{ #category : #tokens }
+FMMSEParser >> matchesWord: aString [
+	"I am checking if the next part of the stream watches a word. If it matches, I also eat the next whitespace and return true. Else I return false (I do not backtrack)"
+
+	aString do: [ :char | char == chararacter ifTrue: [ self next ] ifFalse: [ ^ false ] ].
+	self tWHITESPACE.
+	^ true
 ]
 
 { #category : #private }
 FMMSEParser >> next [
-	^char := stream next
+	^ chararacter := stream next
 ]
 
 { #category : #testing }
 FMMSEParser >> nextCharIsAlphanumeric [
 	self next.
-	^ (self characterSet isLetter: char) or: [ self characterSet isDigit: char ]
+	^ (self characterSet isLetter: chararacter) or: [ self characterSet isDigit: chararacter ]
 ]
 
 { #category : #private }
 FMMSEParser >> peek [
-	^char
+	^ chararacter
 ]
 
 { #category : #private }
-FMMSEParser >> pos [
-	^stream position 
+FMMSEParser >> position [
+	^ stream position
 ]
 
 { #category : #running }
@@ -313,148 +317,109 @@ FMMSEParser >> run [
 
 { #category : #accessing }
 FMMSEParser >> stream [
-
-	^stream
+	^ stream
 ]
 
 { #category : #accessing }
 FMMSEParser >> stream: aStream [
-
 	stream := aStream.
-	buf := String new writeStream.
-	self next "look ahead"
+	buffer := '' writeStream.
+	self next	"look ahead"
 ]
 
 { #category : #private }
 FMMSEParser >> syntaxError [
-	self syntaxError: 'Syntax error at ', self pos printString.
-	^nil.
+	self syntaxError: 'Syntax error at ' , self position printString.
+	^ nil
 ]
 
 { #category : #private }
 FMMSEParser >> syntaxError: aString [
-	
-	(FMSyntaxError new parser: self; messageText: aString) signal. 
+	(FMSyntaxError new
+		parser: self;
+		messageText: aString) signal.
 
 	" Evaluate the following line to get text around the error:
 		(stream contents copyFrom: self pos -10 to: self pos + 10) inspect.
 	"
-	
-	^nil.
+
+	^ nil
 ]
 
 { #category : #tokens }
 FMMSEParser >> tCLOSE [
 	"Matches opening parenthesis (returns boolean)."
-	^ $) == char 
-		ifTrue: 
-			[ self
-				next;
-				tWHITESPACE.
-			true ]
-		ifFalse: [ false ]
+
+	^ self matchesWord: ')'
 ]
 
 { #category : #tokens }
 FMMSEParser >> tFALSE [
 	"Matches false keyword (returns boolean)."
-	$f == char ifTrue: 
-		[ $a == self next ifTrue: 
-			[ $l == self next ifTrue: 
-				[ $s == self next ifTrue: 
-					[ $e == self next ifTrue: 
-						[ self
-							next;
-							tWHITESPACE.
-						^ true ] ] ] ] ].
-	^ false
+
+	^ self matchesWord: 'false'
 ]
 
 { #category : #tokens }
 FMMSEParser >> tFULLNAME [
-	(self characterSet isLetter: char) ifFalse: [ ^ nil ].
-	
-	buf reset.
-	[	buf nextPut: char.
-		[ self nextCharIsAlphanumeric or: [ char = $- ] ] whileTrue: [ buf nextPut: char ].
-		$. == char ] whileTrue: 
-			[	buf nextPut: char.
-				(self characterSet isLetter: self next) ifFalse: [^self syntaxError ] ].
-	$: == char ifTrue: [ ^self syntaxError ].
+	(self characterSet isLetter: chararacter) ifFalse: [ ^ nil ].
+
+	buffer reset.
+	[ buffer nextPut: chararacter.
+	[ self nextCharIsAlphanumeric or: [ chararacter = $- ] ] whileTrue: [ buffer nextPut: chararacter ].
+	$. == chararacter ]
+		whileTrue: [ buffer nextPut: chararacter.
+			(self characterSet isLetter: self next) ifFalse: [ ^ self syntaxError ] ].
+	$: == chararacter ifTrue: [ ^ self syntaxError ].
 	self tWHITESPACE.
-	^buf contents
+	^ buffer contents
 ]
 
 { #category : #tokens }
 FMMSEParser >> tID [
 	"Match id keyword (returns boolean)."
-	$i == char ifTrue: 
-		[ $d == self next ifTrue: 
-			[ $: == self next ifTrue: 
-				[ self
-					next;
-					tWHITESPACE.
-				^ true ] ] ].
-	^ false
+
+	^ self matchesWord: 'id:'
 ]
 
 { #category : #tokens }
 FMMSEParser >> tNAME [
-	(self characterSet isLetter: char) ifFalse: [ ^ nil ].
-	
-	buf reset.
-	buf nextPut: char.
-	[ self nextCharIsAlphanumeric or: [char == $_] ] whileTrue: [ buf nextPut: char ].
+	(self characterSet isLetter: chararacter) ifFalse: [ ^ nil ].
+
+	buffer reset.
+	buffer nextPut: chararacter.
+	[ self nextCharIsAlphanumeric or: [ chararacter == $_ ] ] whileTrue: [ buffer nextPut: chararacter ].
 	self tWHITESPACE.
-	^ buf contents
+	^ buffer contents
 ]
 
 { #category : #tokens }
 FMMSEParser >> tOPEN [
 	"Matches opening parenthesis (returns boolean)."
 
-	^ $( == char
-		ifTrue: [ self
-				next;
-				tWHITESPACE.
-			true ]
-		ifFalse: [ false ]
+	^ self matchesWord: '('
 ]
 
 { #category : #tokens }
 FMMSEParser >> tREF [
 	"Matches ref keyword (returns boolean)."
-	$r == char ifTrue: 
-		[ $e == self next ifTrue: 
-			[ $f == self next ifTrue: 
-				[ $: == self next ifTrue: 
-					[ self
-						next;
-						tWHITESPACE.
-					^ true ] ] ] ].
-	^ false
+
+	^ self matchesWord: 'ref:'
 ]
 
 { #category : #tokens }
 FMMSEParser >> tTRUE [
 	"Match 'true' and whitespace"
-	$t == char ifTrue: 
-		[ $r == self next ifTrue: 
-			[ $u == self next ifTrue: 
-				[ $e == self next ifTrue: 
-					[ self
-						next;
-						tWHITESPACE.
-					^ true ] ] ] ].
-	^ false
+
+	^ self matchesWord: 'true'
 ]
 
 { #category : #tokens }
 FMMSEParser >> tWHITESPACE [
-	[ $" == char
+	[ $" == chararacter
 		ifTrue: [ [ [ self next.
-			nil == char ifTrue: [ ^ self syntaxError ].
-			$" == char ] whileFalse.
+			nil == chararacter ifTrue: [ ^ self syntaxError ].
+			$" == chararacter ] whileFalse.
 			$" == self next ] whileTrue ].
-	char isMSESeparator ] whileTrue: [ self next ]
+	chararacter isMSESeparator ] whileTrue: [ self next ]
 ]

--- a/src/Fame-ImportExport/FMModelExporter.class.st
+++ b/src/Fame-ImportExport/FMModelExporter.class.st
@@ -20,11 +20,9 @@ FMModelExporter class >> new [
 
 { #category : #exporting }
 FMModelExporter >> basicRun [
-
-	self exportHeader.
-	self roots do: [ :each |
-		self exportElement: each ].
-	self exportFooter.
+	printer beginDocument.
+	self roots do: [ :each | self exportElement: each ].
+	printer endDocument
 ]
 
 { #category : #exporting }
@@ -37,17 +35,7 @@ FMModelExporter >> exportElement: each [
 		do: [ printer serial: (self indexOf: each).
 			(self sortedPropertiesOf: meta) do: [ :property | self exportProperty: property for: each ] ].
 
-	self increment	"UI stuff"
-]
-
-{ #category : #exporting }
-FMModelExporter >> exportFooter [
-	printer endDocument
-]
-
-{ #category : #exporting }
-FMModelExporter >> exportHeader [
-	printer beginDocument
+	self incrementProgressBar
 ]
 
 { #category : #exporting }
@@ -75,7 +63,7 @@ FMModelExporter >> exportProperty: property withAll: values [
 ]
 
 { #category : #exporting }
-FMModelExporter >> increment [
+FMModelExporter >> incrementProgressBar [
 	nb := nb + 1.
 	(progBar isNotNil and: [ (Time millisecondsSince: lastUpdate) >= 500 ]) ifFalse: [ ^ self ].
 
@@ -85,7 +73,6 @@ FMModelExporter >> increment [
 
 { #category : #private }
 FMModelExporter >> indexOf: each [
-	each ifNil: [ self error ].
 	^ index at: each ifAbsentPut: [ index size + 1 ]
 ]
 

--- a/src/Fame-Tests/FMMSEParserTest.class.st
+++ b/src/Fame-Tests/FMMSEParserTest.class.st
@@ -595,12 +595,12 @@ FMMSEParserTest >> testAttributeWithStrings2 [
 ]
 
 { #category : #running }
-FMMSEParserTest >> testBacktracking [
+FMMSEParserTest >> testBacktrack [
 	| pos |
 	p fromString: 'abcdefg'.
 	self assert: p peek equals: $a.
 	self assert: p next equals: $b.
-	pos := p pos.
+	pos := p position.
 	self assert: p peek equals: $b.
 	self assert: p next equals: $c.
 	self assert: p next equals: $d.
@@ -991,7 +991,7 @@ FMMSEParserTest >> testValueNegativeNumberError [
 	p fromString: '--42'.
 	p Value.
 	self assertEmpty: r contents.
-	self assert: p pos equals: 1
+	self assert: p position equals: 1
 ]
 
 { #category : #running }


### PR DESCRIPTION
Simplify MSE parser.

- Rename variables to more explicit names
- factorize some code
- Rename methods to have more explicit names