### PR TITLE
2014-Remove-BooleanthreeWayCompareTo-from-Fame-Core

### DIFF
--- a/src/Fame-Core/Boolean.extension.st
+++ b/src/Fame-Core/Boolean.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #Boolean }
-
-{ #category : #'*Fame-Core' }
-Boolean >> threeWayCompareTo: anotherObject [
-	self flag: #todo.	"Remove me when https://github.com/pharo-project/pharo/pull/5023 will be integrated."
-	^ self asBit threeWayCompareTo: anotherObject asBit
-]


### PR DESCRIPTION
Remove unneeded methods now it is in pharo.

Fixes #2014