### PR TITLE
Rename-some-classes-from-Fame

### DIFF
--- a/src/Fame-Core/FMMetaMetaModel.class.st
+++ b/src/Fame-Core/FMMetaMetaModel.class.st
@@ -15,7 +15,7 @@ FMMetaMetaModel >> initialize [
 	super initialize.
 	self
 		addAll:
-			(FMPragmaProcessor new
+			(FMMetaModelBuilder new
 				buildFM3;
 				elements)
 ]

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -30,7 +30,7 @@ Internal Representation and Key Implementation Points.
     Implementation Points
 "
 Class {
-	#name : #FMPragmaProcessor,
+	#name : #FMMetaModelBuilder,
 	#superclass : #Object,
 	#instVars : [
 		'elements',
@@ -49,16 +49,16 @@ Class {
 	#classVars : [
 		'ShouldValidateMetaModel'
 	],
-	#category : #'Fame-Core'
+	#category : #'Fame-Core-Utilities'
 }
 
 { #category : #'class initialization' }
-FMPragmaProcessor class >> initialize [
+FMMetaModelBuilder class >> initialize [
 	self shouldValidateMetaModel: true
 ]
 
 { #category : #processing }
-FMPragmaProcessor class >> metamodelFrom: aCollectionOfClasses [
+FMMetaModelBuilder class >> metamodelFrom: aCollectionOfClasses [
 	^ self new
 		queue: aCollectionOfClasses;
 		run;
@@ -66,7 +66,7 @@ FMPragmaProcessor class >> metamodelFrom: aCollectionOfClasses [
 ]
 
 { #category : #processing }
-FMPragmaProcessor class >> metamodelFromPackages: aCollectionOfPackages [
+FMMetaModelBuilder class >> metamodelFromPackages: aCollectionOfPackages [
 	^ self new
 		queue: (aCollectionOfPackages flatCollectAsSet: [ :p | p definedClasses asSet select: #isMetamodelEntity ]);
 		implementingPackages: aCollectionOfPackages;
@@ -75,41 +75,41 @@ FMPragmaProcessor class >> metamodelFromPackages: aCollectionOfPackages [
 ]
 
 { #category : #accessing }
-FMPragmaProcessor class >> shouldValidateMetaModel [
+FMMetaModelBuilder class >> shouldValidateMetaModel [
 	^ ShouldValidateMetaModel
 ]
 
 { #category : #accessing }
-FMPragmaProcessor class >> shouldValidateMetaModel: anObject [
+FMMetaModelBuilder class >> shouldValidateMetaModel: anObject [
 	ShouldValidateMetaModel := anObject
 ]
 
 { #category : #converting }
-FMPragmaProcessor >> asMetamodel [
+FMMetaModelBuilder >> asMetamodel [
 	^ FMMetaModel new
 		addAll: elements;
 		yourself
 ]
 
 { #category : #running }
-FMPragmaProcessor >> buildFM3 [
+FMMetaModelBuilder >> buildFM3 [
 	self
 		queue: (self class package definedClasses asSet select: #isMetamodelEntity);
 		run
 ]
 
 { #category : #accessing }
-FMPragmaProcessor >> classes [
+FMMetaModelBuilder >> classes [
 	^ elements select: #isFM3Class
 ]
 
 { #category : #accessing }
-FMPragmaProcessor >> elements [
+FMMetaModelBuilder >> elements [
 	^ elements
 ]
 
 { #category : #private }
-FMPragmaProcessor >> ensureClass: var [
+FMMetaModelBuilder >> ensureClass: var [
 	var isBehavior ifTrue: [ ^ classDict at: var ].
 	var isSymbol ifTrue: [ ^ classDict at: (self class environment at: var) ifAbsent: [ metaDict at: var asString ] ].
 	var isString ifTrue: [ ^ metaDict at: var ].
@@ -117,7 +117,7 @@ FMPragmaProcessor >> ensureClass: var [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> ensurePackage: name [
+FMMetaModelBuilder >> ensurePackage: name [
 	| symbol |
 	self assert: (name isSymbol or: [ name isString ]).
 	symbol := name asString.
@@ -130,22 +130,22 @@ FMPragmaProcessor >> ensurePackage: name [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> extractPackageFrom: method for: aFM3Element [
+FMMetaModelBuilder >> extractPackageFrom: method for: aFM3Element [
 	^ (method pragmaAt: #package:) ifNotNil: [ :p | packDict at: aFM3Element put: (p argumentAt: 1) ]
 ]
 
 { #category : #running }
-FMPragmaProcessor >> implementingPackages [
+FMMetaModelBuilder >> implementingPackages [
 	^ implementingPackages ifNil: [ implementingPackages := queue collectAsSet: #package ]
 ]
 
 { #category : #running }
-FMPragmaProcessor >> implementingPackages: aColl [
+FMMetaModelBuilder >> implementingPackages: aColl [
 	implementingPackages := aColl
 ]
 
 { #category : #initialization }
-FMPragmaProcessor >> initialize [
+FMMetaModelBuilder >> initialize [
 	"Used for queuing classes before running."
 
 	queue := OrderedCollection new.
@@ -167,24 +167,24 @@ FMPragmaProcessor >> initialize [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> methodsToProcessFrom: aClass [
+FMMetaModelBuilder >> methodsToProcessFrom: aClass [
 	"We need to process the methods from the class and the extensions methods comming from the packages containing the entites. We should reject extension methods comming from other packages."
 
 	^ aClass localMethods select: [ :method | method isExtension not or: [ self implementingPackages includes: method package ] ]
 ]
 
 { #category : #accessing }
-FMPragmaProcessor >> packages [
+FMMetaModelBuilder >> packages [
 	^ elements select: #isFM3Package
 ]
 
 { #category : #private }
-FMPragmaProcessor >> processClass: aClass [
+FMMetaModelBuilder >> processClass: aClass [
 	^ self processClass: aClass ifPragmaAbsent: [ self error: 'Fame Undeclared class ' , aClass name ]
 ]
 
 { #category : #private }
-FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
+FMMetaModelBuilder >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 	aClass metamodelDefinitionPragma
 		ifNil: anErrorBlock
 		ifNotNil: [ :pragma | 
@@ -205,7 +205,7 @@ FMPragmaProcessor >> processClass: aClass ifPragmaAbsent: anErrorBlock [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> processCompiledMethod: aMethod [
+FMMetaModelBuilder >> processCompiledMethod: aMethod [
 	| method |
 	method := aMethod.
 
@@ -231,7 +231,7 @@ FMPragmaProcessor >> processCompiledMethod: aMethod [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> processInfosFrom: aMethod for: prop [
+FMMetaModelBuilder >> processInfosFrom: aMethod for: prop [
 	prop implementingSelector: aMethod selector.
 	self extractPackageFrom: aMethod for: prop.
 	(aMethod pragmaAt: #container) ifNotNil: [ prop isContainer: true ].
@@ -242,7 +242,7 @@ FMPragmaProcessor >> processInfosFrom: aMethod for: prop [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> processSlot: aSlot in: aClass [
+FMMetaModelBuilder >> processSlot: aSlot in: aClass [
 	| prop |
 	prop := FM3Property named: aSlot name.
 	prop implementingSelector: aSlot name.
@@ -258,12 +258,12 @@ FMPragmaProcessor >> processSlot: aSlot in: aClass [
 ]
 
 { #category : #accessing }
-FMPragmaProcessor >> properties [
+FMMetaModelBuilder >> properties [
 	^ elements select: #isFM3Property
 ]
 
 { #category : #running }
-FMPragmaProcessor >> queue: var [
+FMMetaModelBuilder >> queue: var [
 	"Add one or many classes to be processed. Nothing is done before the run method is called"
 
 	var isBehavior  
@@ -279,7 +279,7 @@ FMPragmaProcessor >> queue: var [
 ]
 
 { #category : #private }
-FMPragmaProcessor >> resolveObjectReferences [
+FMMetaModelBuilder >> resolveObjectReferences [
 
 	"establish class-package and property-package links"
 	packDict keysAndValuesDo: [ :fm3Element :value | fm3Element package: (self ensurePackage: value) ].
@@ -304,7 +304,7 @@ FMPragmaProcessor >> resolveObjectReferences [
 ]
 
 { #category : #running }
-FMPragmaProcessor >> run [
+FMMetaModelBuilder >> run [
 	queue do: [ :cls | self processClass: cls ].
 	self resolveObjectReferences.
 	self class shouldValidateMetaModel ifTrue: [ FMMetamodelValidator for: self ]

--- a/src/Fame-Core/FMMetamodelFactory.class.st
+++ b/src/Fame-Core/FMMetamodelFactory.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'fm3Package'
 	],
-	#category : #'Fame-Core'
+	#category : #'Fame-Core-Utilities'
 }
 
 { #category : #'instance creation' }

--- a/src/Fame-Core/FMMetamodelValidator.class.st
+++ b/src/Fame-Core/FMMetamodelValidator.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'processor'
 	],
-	#category : #'Fame-Core'
+	#category : #'Fame-Core-Utilities'
 }
 
 { #category : #'instance creation' }

--- a/src/Fame-Core/FMRuntimeElement.class.st
+++ b/src/Fame-Core/FMRuntimeElement.class.st
@@ -14,7 +14,7 @@ Class {
 		'description',
 		'slots'
 	],
-	#category : #'Fame-Core'
+	#category : #'Fame-Core-Utilities'
 }
 
 { #category : #'instance creation' }

--- a/src/Fame-Example/LIBRoot.class.st
+++ b/src/Fame-Example/LIBRoot.class.st
@@ -21,7 +21,7 @@ LIBRoot class >> library [
 
 { #category : #examples }
 LIBRoot class >> libraryMetaModel [
-	^ FMPragmaProcessor metamodelFrom: {LIBLibrary . LIBBook . LIBPerson}
+	^ FMMetaModelBuilder metamodelFrom: {LIBLibrary . LIBBook . LIBPerson}
 ]
 
 { #category : #examples }

--- a/src/Fame-Tests/FMDungeonExample.class.st
+++ b/src/Fame-Tests/FMDungeonExample.class.st
@@ -26,7 +26,7 @@ FMDungeonExample class >> dungeonScript [
 { #category : #'as yet unclassified' }
 FMDungeonExample class >> metamodelString [
 	| builder |
-	builder := FMMetamodelBuilder client: FMMSEPrinter onString.
+	builder := FMMetamodelScripter client: FMMSEPrinter onString.
 	builder document: self dungeonScript.
 	^ builder client stream contents
 ]
@@ -34,7 +34,7 @@ FMDungeonExample class >> metamodelString [
 { #category : #running }
 FMDungeonExample >> setUp [
 	super setUp.
-	metamodel := FMPragmaProcessor metamodelFrom: {RPGDragon . RPGTreasure . RPGHero}
+	metamodel := FMMetaModelBuilder metamodelFrom: {RPGDragon . RPGTreasure . RPGHero}
 ]
 
 { #category : #running }

--- a/src/Fame-Tests/FMEquationSystemExample.class.st
+++ b/src/Fame-Tests/FMEquationSystemExample.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'As yet unclassified' }
 FMEquationSystemExample class >> createMetamodel [
-	^ FMPragmaProcessor
+	^ FMMetaModelBuilder
 		metamodelFrom: {EQCompound . EQEquation . EQEquationSystem . EQExpression . EQIdentifier . EQNumerical . EQOperator . EQSimple . EQVariable}
 ]
 

--- a/src/Fame-Tests/FMImporterTest.class.st
+++ b/src/Fame-Tests/FMImporterTest.class.st
@@ -32,7 +32,7 @@ FMImporterTest >> testElementNamed [
 FMImporterTest >> testImportBook [
 	| importer builder |
 	importer := FMImporter model: FMMetaModel new.
-	builder := FMModelBuilder client: importer.
+	builder := FMModelScripter client: importer.
 	builder document: [ builder new: 'FM3.Class' with: [ builder a: #name of: 'Book' ] ].
 
 	self assert: importer model elements size equals: 1.
@@ -79,7 +79,7 @@ FMImporterTest >> testOrderOfElements [
 FMImporterTest >> testResolving [
 	| importer builder |
 	importer := FMImporter model: FMMetaModel new.
-	builder := FMModelBuilder client: importer.
+	builder := FMModelScripter client: importer.
 	builder document: [ builder new: 'FM3.Class' with: [ builder a: #name of: 'MyName' ] ].
 	self assert: importer model elements size equals: 1.
 	self assert: importer model elements anyOne isFM3Class
@@ -89,7 +89,7 @@ FMImporterTest >> testResolving [
 FMImporterTest >> testResolvingId [
 	| importer builder |
 	importer := FMImporter model: FMMetaModel new.
-	builder := FMModelBuilder client: importer.
+	builder := FMModelScripter client: importer.
 	builder
 		document: [ builder
 				new: 'FM3.Class'

--- a/src/Fame-Tests/FMLibraryExample.class.st
+++ b/src/Fame-Tests/FMLibraryExample.class.st
@@ -112,7 +112,7 @@ FMLibraryExample >> testMetamodelSmalltalkBinding [
 { #category : #tests }
 FMLibraryExample >> testPragmaProcessing [
 	| pragmaProcessor |
-	pragmaProcessor := FMPragmaProcessor new
+	pragmaProcessor := FMMetaModelBuilder new
 		queue: {LIBBook . LIBLibrary . LIBPerson};
 		run.
 	self denyEmpty: pragmaProcessor elements.

--- a/src/Fame-Tests/FMMetaModel.extension.st
+++ b/src/Fame-Tests/FMMetaModel.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #FMMetaModel }
 
 { #category : #'*Fame-Tests' }
 FMMetaModel >> builderClass [
-	^ FMMetamodelBuilder
+	^ FMMetamodelScripter
 ]
 
 { #category : #'*Fame-Tests' }

--- a/src/Fame-Tests/FMMetamodelScripter.class.st
+++ b/src/Fame-Tests/FMMetamodelScripter.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #FMMetamodelBuilder,
-	#superclass : #FMModelBuilder,
+	#name : #FMMetamodelScripter,
+	#superclass : #FMModelScripter,
 	#instVars : [
 		'indexDict',
 		'stack',
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : #DSL }
-FMMetamodelBuilder >> class: name with: aBlock [
+FMMetamodelScripter >> class: name with: aBlock [
 
 	self new: 'FM3.Class' with: [
 		stack addLast: name.
@@ -21,7 +21,7 @@ FMMetamodelBuilder >> class: name with: aBlock [
 ]
 
 { #category : #initialization }
-FMMetamodelBuilder >> initialize [
+FMMetamodelScripter >> initialize [
 	super initialize.
 	indexDict := Dictionary"<String,Integer>" new.
 	stack := OrderedCollection"<String>" new.
@@ -29,7 +29,7 @@ FMMetamodelBuilder >> initialize [
 ]
 
 { #category : #private }
-FMMetamodelBuilder >> lookup: name [
+FMMetamodelScripter >> lookup: name [
 	"if it is a primitive type, return the name, metamodel will take care of this"
 
 	(FM3Constant constants anySatisfy: [ :const | const name = name ]) ifTrue: [ ^ name ].
@@ -38,12 +38,12 @@ FMMetamodelBuilder >> lookup: name [
 ]
 
 { #category : #private }
-FMMetamodelBuilder >> lookupSerial: name [
+FMMetamodelScripter >> lookupSerial: name [
 	^indexDict at: name ifAbsentPut: [ serial := serial + 1 ].
 ]
 
 { #category : #private }
-FMMetamodelBuilder >> nextSerial [
+FMMetamodelScripter >> nextSerial [
 	| name |
 	name := String new writeStream.
 	stack do: [ :each | name nextPutAll: each ] separatedBy: [ name nextPut: $. ].
@@ -51,7 +51,7 @@ FMMetamodelBuilder >> nextSerial [
 ]
 
 { #category : #DSL }
-FMMetamodelBuilder >> package: name with: aBlock [
+FMMetamodelScripter >> package: name with: aBlock [
 
 	self new: 'FM3.Package' with: [
 		stack addLast: name.
@@ -61,13 +61,13 @@ FMMetamodelBuilder >> package: name with: aBlock [
 ]
 
 { #category : #DSL }
-FMMetamodelBuilder >> property: name type: typeName opposite: oppositeName multivalued: multivalued [
+FMMetamodelScripter >> property: name type: typeName opposite: oppositeName multivalued: multivalued [
 	
 	self property: name type: typeName opposite: oppositeName multivalued: multivalued derived: false
 ]
 
 { #category : #DSL }
-FMMetamodelBuilder >> property: name type: typeName opposite: oppositeName multivalued: multivalued derived: derived [
+FMMetamodelScripter >> property: name type: typeName opposite: oppositeName multivalued: multivalued derived: derived [
 	
 	self new: 'FM3.Property' with: [
 		stack addLast: name.
@@ -82,13 +82,13 @@ FMMetamodelBuilder >> property: name type: typeName opposite: oppositeName multi
 ]
 
 { #category : #DSL }
-FMMetamodelBuilder >> property: name with: typeName opposite: oppositeName [ 
+FMMetamodelScripter >> property: name with: typeName opposite: oppositeName [ 
 	
 	self property: name type: typeName opposite: oppositeName multivalued: false
 ]
 
 { #category : #DSL }
-FMMetamodelBuilder >> property: name withMany: typeName opposite: oppositeName [ 
+FMMetamodelScripter >> property: name withMany: typeName opposite: oppositeName [ 
 	
 	self property: name type: typeName opposite: oppositeName multivalued: true
 ]

--- a/src/Fame-Tests/FMModelBuilderTest.class.st
+++ b/src/Fame-Tests/FMModelBuilderTest.class.st
@@ -8,7 +8,7 @@ Class {
 FMModelBuilderTest >> testDocument [
 	| client m s |
 	client := FMMSEPrinter onString.
-	m := FMModelBuilder client: client.
+	m := FMModelScripter client: client.
 	m document: [  ].
 	s := client stream contents.
 	self assert: s equals: '()'
@@ -18,7 +18,7 @@ FMModelBuilderTest >> testDocument [
 FMModelBuilderTest >> testPerson [
 	| client m s |
 	client := FMMSEPrinter onString.
-	m := FMModelBuilder client: client.
+	m := FMModelScripter client: client.
 	m document: [ m new: #Person with: [ m a: #name of: 'John Doe' ] ].
 	s := client stream contents.
 	self
@@ -33,7 +33,7 @@ FMModelBuilderTest >> testPerson [
 FMModelBuilderTest >> testPersonWithDog [
 	| client m s |
 	client := FMMSEPrinter onString.
-	m := FMModelBuilder client: client.
+	m := FMModelScripter client: client.
 	m
 		document: [ m
 				new: #Person
@@ -61,7 +61,7 @@ FMModelBuilderTest >> testPersonWithDog [
 FMModelBuilderTest >> testPersonWithDogUsingIdReferences [
 	| client m s |
 	client := FMMSEPrinter onString.
-	m := FMModelBuilder client: client.
+	m := FMModelScripter client: client.
 	m
 		document: [ m
 				new: #Person
@@ -89,7 +89,7 @@ FMModelBuilderTest >> testPersonWithDogUsingIdReferences [
 FMModelBuilderTest >> testPersonWithNicknames [
 	| client m s |
 	client := FMMSEPrinter onString.
-	m := FMModelBuilder client: client.
+	m := FMModelScripter client: client.
 	m
 		document: [ m
 				new: #Person

--- a/src/Fame-Tests/FMModelScripter.class.st
+++ b/src/Fame-Tests/FMModelScripter.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #FMModelBuilder,
+	#name : #FMModelScripter,
 	#superclass : #Object,
 	#instVars : [
 		'client'
@@ -8,32 +8,32 @@ Class {
 }
 
 { #category : #'instance creation' }
-FMModelBuilder class >> client: aClient [
+FMModelScripter class >> client: aClient [
 	^ self new
 		client: aClient;
 		yourself
 ]
 
 { #category : #'DSL-synonyms' }
-FMModelBuilder >> a: attributeName of: valueOrBodyOrArray [
+FMModelScripter >> a: attributeName of: valueOrBodyOrArray [
 	
 	self attribute: attributeName with: valueOrBodyOrArray
 ]
 
 { #category : #'DSL-synonyms' }
-FMModelBuilder >> add: attributeName with: valueOrBodyOrArray [
+FMModelScripter >> add: attributeName with: valueOrBodyOrArray [
 	
 	self attribute: attributeName with: valueOrBodyOrArray
 ]
 
 { #category : #'DSL-synonyms' }
-FMModelBuilder >> an: attributeName of: valueOrBodyOrArray [
+FMModelScripter >> an: attributeName of: valueOrBodyOrArray [
 	
 	self attribute: attributeName with: valueOrBodyOrArray
 ]
 
 { #category : #DSL }
-FMModelBuilder >> attribute: attributeName with: variant [
+FMModelScripter >> attribute: attributeName with: variant [
 	"Adds an attribute with primitive value or array, or with given body."
 
 	client
@@ -44,42 +44,42 @@ FMModelBuilder >> attribute: attributeName with: variant [
 ]
 
 { #category : #accessing }
-FMModelBuilder >> client [
+FMModelScripter >> client [
 	^ client
 ]
 
 { #category : #accessing }
-FMModelBuilder >> client: parseClient [ 
+FMModelScripter >> client: parseClient [ 
 	client := parseClient
 ]
 
 { #category : #DSL }
-FMModelBuilder >> document: body [
+FMModelScripter >> document: body [
 	"Creates a document with body (which is a block)."
 
 	client inDocumentDo: [ body valueWithPossibleArgument: self ]
 ]
 
 { #category : #DSL }
-FMModelBuilder >> element: elementName with: body [
+FMModelScripter >> element: elementName with: body [
 	"Addes an element with body (which is a block)."
 
 	client inElement: elementName do: [ body value ]
 ]
 
 { #category : #DSL }
-FMModelBuilder >> id: index [
+FMModelScripter >> id: index [
 
 	client serial: index
 ]
 
 { #category : #'DSL-synonyms' }
-FMModelBuilder >> new: elementName with: body [ 
+FMModelScripter >> new: elementName with: body [ 
 	
 	self element: elementName with: body
 ]
 
 { #category : #DSL }
-FMModelBuilder >> ref: reference [
+FMModelScripter >> ref: reference [
 	client referenceNumber: (reference isNumber ifTrue: [ reference ] ifFalse: [ reference asString ])
 ]

--- a/src/Fame-Tests/FMPragmaProcessorTest.class.st
+++ b/src/Fame-Tests/FMPragmaProcessorTest.class.st
@@ -52,7 +52,7 @@ FMPragmaProcessorTest >> testAnnotationTypes [
 { #category : #running }
 FMPragmaProcessorTest >> testBuildFM3 [
 	| processor all |
-	processor := FMPragmaProcessor new.
+	processor := FMMetaModelBuilder new.
 	processor buildFM3.	"There are some elements."
 	self denyEmpty: processor elements.	"There is one and only one package."
 	all := processor packages.
@@ -64,7 +64,7 @@ FMPragmaProcessorTest >> testBuildFM3 [
 FMPragmaProcessorTest >> testEmptyProcessor [
 	"An empty processor knows all primitives, but does not contain them as elements!"
 
-	self assertEmpty: FMPragmaProcessor new elements
+	self assertEmpty: FMMetaModelBuilder new elements
 ]
 
 { #category : #running }
@@ -72,7 +72,7 @@ FMPragmaProcessorTest >> testSimple [
 	"--- FIXME: these 4 lines are moot ---"
 
 	| processor rep elements originalSize props mmClass |
-	processor := FMPragmaProcessor new.
+	processor := FMMetaModelBuilder new.
 	originalSize := processor elements size.
 	processor queue: FMPragmaProcessorTestDummy.
 	processor run.

--- a/src/Famix-Deprecated/FMPragmaProcessor.class.st
+++ b/src/Famix-Deprecated/FMPragmaProcessor.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FMPragmaProcessor,
+	#superclass : #FMMetaModelBuilder,
+	#category : #'Famix-Deprecated'
+}
+
+{ #category : #testing }
+FMPragmaProcessor class >> isDeprecated [
+	^ true
+]

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -73,7 +73,7 @@ MooseModel class >> generateClassesFrom: aCollection [
 	"I generate the implementation for some meta-described classes. aCollection need to contain the full set of meta-described classes so that the metamodel is complete. Warning, part of classes will be overwritten."
 
 	FMDefaultCodeGenerator new
-		visit: (FMPragmaProcessor metamodelFrom: aCollection);
+		visit: (FMMetaModelBuilder metamodelFrom: aCollection);
 		previewChanges
 ]
 
@@ -87,7 +87,7 @@ MooseModel class >> generateClassesFrom: aCollection inPackage: aString [
 
 	| generator fm3Package |
 	generator := FMDefaultCodeGenerator new.
-	fm3Package := (FMPragmaProcessor metamodelFrom: aCollection) packageNamed: aString.
+	fm3Package := (FMMetaModelBuilder metamodelFrom: aCollection) packageNamed: aString.
 	generator acceptFamePackage: fm3Package.
 	self flag: #classExtensionNotSupported.	"currently the generator does not handle extension to other packages - cf #acceptFamePackage:"
 	generator previewChanges
@@ -215,7 +215,7 @@ MooseModel class >> packagesToProcessToCreateMetamodel [
 
 { #category : #meta }
 MooseModel class >> resetMetamodel [
-	metamodel := FMPragmaProcessor metamodelFromPackages: self packagesToProcessToCreateMetamodel.
+	metamodel := FMMetaModelBuilder metamodelFromPackages: self packagesToProcessToCreateMetamodel.
 
 	"MooseEntity has a cache for some infos. When we regenerate a MM we need to flush this cache."
 	metamodel classes do: [ :fm3Class | fm3Class implementingClass resetMooseEntityCache ].


### PR DESCRIPTION
Rename FM(Meta)ModelBuilder into FM(Meta)ModelScripter and FMPragmaProcessor into FMMetaModelBuilder.