### PR TITLE
Romve-MSE-references-from-fame-core

### DIFF
--- a/src/Fame-Core/FM3Class.class.st
+++ b/src/Fame-Core/FM3Class.class.st
@@ -26,7 +26,7 @@ Class {
 
 { #category : #meta }
 FM3Class class >> annotation [
-	<MSEClass: #Class super: #FM3Element>
+	<FMClass: #Class super: #FM3Element>
 	<package: #FM3>
 
 ]
@@ -63,7 +63,7 @@ FM3Class >> allPrimitiveProperties [
 
 { #category : #'accessing-query' }
 FM3Class >> allProperties [
-	<MSEProperty: #allProperties type: 'FM3.Property'>
+	<FMProperty: #allProperties type: 'FM3.Property'>
 	<multivalued>
 	<derived>
 	| nameDict |
@@ -217,7 +217,7 @@ FM3Class >> initialize [
 
 { #category : #accessing }
 FM3Class >> isAbstract [
-	<MSEProperty: #abstract type: #Boolean>
+	<FMProperty: #abstract type: #Boolean>
 	^ isAbstract
 ]
 
@@ -243,14 +243,14 @@ FM3Class >> isFM3Class [
 
 { #category : #testing }
 FM3Class >> isPrimitive [
-	<MSEProperty: #primitive type: #Boolean>
+	<FMProperty: #primitive type: #Boolean>
 	<derived>
 	^ false
 ]
 
 { #category : #testing }
 FM3Class >> isRoot [
-	<MSEProperty: #root type: #Boolean>
+	<FMProperty: #root type: #Boolean>
 	<derived>
 	^ false
 ]
@@ -267,7 +267,7 @@ FM3Class >> ownerProperties [
 
 { #category : #accessing }
 FM3Class >> package [
-	<MSEProperty: #package type: #FM3Package opposite: #classes>
+	<FMProperty: #package type: #FM3Package opposite: #classes>
 	<container>
 	^ package
 ]
@@ -288,7 +288,7 @@ FM3Class >> primitiveProperties [
 
 { #category : #accessing }
 FM3Class >> properties [
-	<MSEProperty: #properties type: 'FM3.Property' opposite: #class>
+	<FMProperty: #properties type: 'FM3.Property' opposite: #class>
 	<multivalued>
 	^ properties
 ]
@@ -317,7 +317,7 @@ FM3Class >> propertyNamed: aString ifAbsent: aBlock [
 
 { #category : #accessing }
 FM3Class >> subclasses [ 
-	<MSEProperty: #subclasses type: #FM3Class opposite: #superclass>
+	<FMProperty: #subclasses type: #FM3Class opposite: #superclass>
 	<derived>
 	<multivalued>
 	^subclasses
@@ -330,7 +330,7 @@ FM3Class >> subclasses: anObject [
 
 { #category : #accessing }
 FM3Class >> superclass [
-	<MSEProperty: #superclass type: #FM3Class opposite: #subclasses>
+	<FMProperty: #superclass type: #FM3Class opposite: #subclasses>
 	^ superclass
 ]
 
@@ -345,7 +345,7 @@ FM3Class >> superclass: newClass [
 
 { #category : #accessing }
 FM3Class >> traits [
-	<MSEProperty: #traits type: #FM3Class>
+	<FMProperty: #traits type: #FM3Class>
 	<multivalued>
 	^ traits
 ]

--- a/src/Fame-Core/FM3Element.class.st
+++ b/src/Fame-Core/FM3Element.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #meta }
 FM3Element class >> annotation [
-	<MSEClass: #Element super: #Object>
+	<FMClass: #Element super: #Object>
 	<package: #FM3>
 	<abstract>
 
@@ -40,7 +40,7 @@ FM3Element >> accept: arg1 [
 
 { #category : #accessing }
 FM3Element >> fullName [
-	<MSEProperty: #fullName type: #String>
+	<FMProperty: #fullName type: #String>
 	<derived>
 	self name ifNil: [ ^ nil ].
 
@@ -57,7 +57,7 @@ FM3Element >> hasOwner [
 
 { #category : #accessing }
 FM3Element >> name [
-	<MSEProperty: #name type: #String>
+	<FMProperty: #name type: #String>
 	^name 
 ]
 
@@ -68,7 +68,7 @@ FM3Element >> name: aString [
 
 { #category : #accessing }
 FM3Element >> owner [
-	<MSEProperty: #owner type: #FM3Element>
+	<FMProperty: #owner type: #FM3Element>
 	<derived>
 	^ self subclassResponsibility
 ]

--- a/src/Fame-Core/FM3Package.class.st
+++ b/src/Fame-Core/FM3Package.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #meta }
 FM3Package class >> annotation [
-	<MSEClass: #Package super: #FM3Element>
+	<FMClass: #Package super: #FM3Element>
 	<package: #FM3>
 
 ]
@@ -30,7 +30,7 @@ FM3Package >> classNamed: aString ifAbsent: aBlock [
 
 { #category : #accessing }
 FM3Package >> classes [
-	<MSEProperty: #classes type: #FM3Class opposite: #package>
+	<FMProperty: #classes type: #FM3Class opposite: #package>
 	<multivalued>
 	^ classes
 ]
@@ -43,7 +43,7 @@ FM3Package >> classes: elementCollection [
 
 { #category : #accessing }
 FM3Package >> extensions [
-	<MSEProperty: #extensions type: 'FM3.Property' opposite: #package>
+	<FMProperty: #extensions type: 'FM3.Property' opposite: #package>
 	<multivalued>
 	
 	^extensions

--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -32,7 +32,7 @@ Class {
 
 { #category : #meta }
 FM3Property class >> annotation [
-	<MSEClass: #Property super: #FM3Element>
+	<FMClass: #Property super: #FM3Element>
 	<package: #FM3>
 
 ]
@@ -107,14 +107,14 @@ FM3Property >> initialize [
 
 { #category : #testing }
 FM3Property >> isChildrenProperty [
-	<MSEProperty: #composite type: #Boolean>
+	<FMProperty: #composite type: #Boolean>
 	<derived>
 	^ self hasOpposite and: [ self opposite isContainer ]
 ]
 
 { #category : #accessing }
 FM3Property >> isContainer [
-	<MSEProperty: #container type: #Boolean>
+	<FMProperty: #container type: #Boolean>
 	^isContainer
 ]
 
@@ -125,7 +125,7 @@ FM3Property >> isContainer: anObject [
 
 { #category : #accessing }
 FM3Property >> isDerived [
-	<MSEProperty: #derived type: #Boolean>
+	<FMProperty: #derived type: #Boolean>
 	^isDerived
 ]
 
@@ -146,7 +146,7 @@ FM3Property >> isFM3Property [
 
 { #category : #accessing }
 FM3Property >> isMultivalued [
-	<MSEProperty: #multivalued type: #Boolean>
+	<FMProperty: #multivalued type: #Boolean>
 	^isMultivalued
 ]
 
@@ -177,7 +177,7 @@ FM3Property >> isTarget: anObject [
 
 { #category : #accessing }
 FM3Property >> mmClass [
-	<MSEProperty: #class type: #FM3Class opposite: #properties>
+	<FMProperty: #class type: #FM3Class opposite: #properties>
 	<container>
 	
 	^class 
@@ -193,7 +193,7 @@ FM3Property >> mmClass: newClass [
 
 { #category : #accessing }
 FM3Property >> opposite [
-	<MSEProperty: #opposite type: 'FM3.Property' opposite: #opposite>
+	<FMProperty: #opposite type: 'FM3.Property' opposite: #opposite>
 	
 	^opposite 
 ]
@@ -216,7 +216,7 @@ FM3Property >> owner [
 
 { #category : #accessing }
 FM3Property >> package [
-	<MSEProperty: #package type: #FM3Package opposite: #extensions>
+	<FMProperty: #package type: #FM3Package opposite: #extensions>
 	self flag: 'Must return null when not an extensions method.'.
 	^ package
 ]
@@ -255,7 +255,7 @@ FM3Property >> setOn: element values: array [
 
 { #category : #accessing }
 FM3Property >> type [
-	<MSEProperty: #type type: #FM3Class>
+	<FMProperty: #type type: #FM3Class>
 	^type
 ]
 

--- a/src/Fame-Core/FMMetaModelBuilder.class.st
+++ b/src/Fame-Core/FMMetaModelBuilder.class.st
@@ -217,14 +217,16 @@ FMMetaModelBuilder >> processCompiledMethod: aMethod [
 				compiledMethod ].
 	self assert: method isCompiledMethod.
 
+	"29 of October 2019: The MSEProperty:type:(opposite:) pragma is deprecated and should not be used anymore. But we still keep it for some time for backward compatibility."
 	method pragmas
-		detect: [ :each | #(#MSEProperty:type:opposite: #MSEProperty:type:) includes: each selector ]
+		detect: [ :each | #(#MSEProperty:type:opposite: #MSEProperty:type: #FMProperty:type:opposite: #FMProperty:type:) includes: each selector ]
 		ifFound: [ :pragma | 
 			| prop |
 			prop := FM3Property named: (pragma argumentAt: 1) asString.
 			typeDict at: prop put: (pragma argumentAt: 2).
 			mmClassDict at: prop put: method methodClass.
-			pragma selector = #MSEProperty:type:opposite: ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
+			(pragma selector = #MSEProperty:type:opposite: or: [ pragma selector = #FMProperty:type:opposite: ])
+				ifTrue: [ oppositeDict at: prop put: (pragma argumentAt: 3) ].
 			self processInfosFrom: method for: prop.
 
 			elements add: prop ]

--- a/src/Fame-Core/Metaclass.extension.st
+++ b/src/Fame-Core/Metaclass.extension.st
@@ -7,7 +7,9 @@ Metaclass >> isMetamodelEntity [
 
 { #category : #'*Fame-Core' }
 Metaclass >> metamodelDefinitionPragma [
-	^ (Pragma allNamed: #MSEClass:super: in: self)
+	"29 of October 2019: The MSEClass:super: pragma is deprecated and should not be used anymore. But we still keep it for some time for backward compatibility."
+
+	^ (Pragma allNamed: #FMClass:super: in: self) , (Pragma allNamed: #MSEClass:super: in: self)
 		ifEmpty: [ nil ]
 		ifNotEmpty: [ :p | 
 			p size = 1 ifFalse: [ self error: 'It should not be possible to have two pragmas to define a FM3 class.' ].

--- a/src/Fame-Example/EQCompound.class.st
+++ b/src/Fame-Example/EQCompound.class.st
@@ -10,14 +10,14 @@ Class {
 
 { #category : #meta }
 EQCompound class >> annotation [
-	<MSEClass: #Compound super: #EQExpression >
+	<FMClass: #Compound super: #EQExpression >
 	<package: #EQ>
 	<abstract>
 ]
 
 { #category : #Fame }
 EQCompound >> args [
-	<MSEProperty: #args type: #EQExpression>
+	<FMProperty: #args type: #EQExpression>
 	<multivalued>
 	^args
 ]
@@ -29,7 +29,7 @@ EQCompound >> args: anObject [
 
 { #category : #Fame }
 EQCompound >> op [
-	<MSEProperty: #op type: #EQOperator>
+	<FMProperty: #op type: #EQOperator>
 	^op
 ]
 

--- a/src/Fame-Example/EQEquation.class.st
+++ b/src/Fame-Example/EQEquation.class.st
@@ -10,13 +10,13 @@ Class {
 
 { #category : #meta }
 EQEquation class >> annotation [
-	<MSEClass: #Equation super: #Object>
+	<FMClass: #Equation super: #Object>
 	<package: #EQ>
 ]
 
 { #category : #Fame }
 EQEquation >> leftHandSide [
-	<MSEProperty: #leftHandSide type: #EQVariable>
+	<FMProperty: #leftHandSide type: #EQVariable>
 	^leftHandSide
 ]
 
@@ -33,7 +33,7 @@ EQEquation >> printOn: stream [
 
 { #category : #Fame }
 EQEquation >> rightHandSide [
-	<MSEProperty: #rightHandSide type: #EQExpression>
+	<FMProperty: #rightHandSide type: #EQExpression>
 	^rightHandSide
 ]
 

--- a/src/Fame-Example/EQEquationSystem.class.st
+++ b/src/Fame-Example/EQEquationSystem.class.st
@@ -9,13 +9,13 @@ Class {
 
 { #category : #meta }
 EQEquationSystem class >> annotation [
-	<MSEClass: #EquationSystem super: #Object>
+	<FMClass: #EquationSystem super: #Object>
 	<package: #EQ>
 ]
 
 { #category : #Fame }
 EQEquationSystem >> equations [
-	<MSEProperty: #equations type: #EQEquation>
+	<FMProperty: #equations type: #EQEquation>
 	<multivalued>
 	^equations
 ]

--- a/src/Fame-Example/EQExpression.class.st
+++ b/src/Fame-Example/EQExpression.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #meta }
 EQExpression class >> annotation [
-	<MSEClass: #Expression super: #Object >
+	<FMClass: #Expression super: #Object >
 	<package: #EQ>
 	<abstract>
 ]

--- a/src/Fame-Example/EQIdentifier.class.st
+++ b/src/Fame-Example/EQIdentifier.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 EQIdentifier class >> annotation [
-	<MSEClass: #Identifier super: #Object>
+	<FMClass: #Identifier super: #Object>
 	<package: #EQ>
 ]
 
@@ -21,7 +21,7 @@ EQIdentifier >> printOn: stream [
 
 { #category : #accessing }
 EQIdentifier >> symbol [
-	<MSEProperty: #symbol type: #String>
+	<FMProperty: #symbol type: #String>
 	^symbol
 ]
 

--- a/src/Fame-Example/EQNumerical.class.st
+++ b/src/Fame-Example/EQNumerical.class.st
@@ -9,14 +9,14 @@ Class {
 
 { #category : #meta }
 EQNumerical class >> annotation [
-	<MSEClass: #Numerical super: #EQSimple>
+	<FMClass: #Numerical super: #EQSimple>
 	<package: #EQ>
 	<abstract>
 ]
 
 { #category : #accessing }
 EQNumerical >> number [
-	<MSEProperty: #number type: #Number>
+	<FMProperty: #number type: #Number>
 	^number
 ]
 

--- a/src/Fame-Example/EQOperator.class.st
+++ b/src/Fame-Example/EQOperator.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 EQOperator class >> annotation [
-	<MSEClass: #Operator super: #Object>
+	<FMClass: #Operator super: #Object>
 	<package: #EQ>
 ]
 
@@ -21,7 +21,7 @@ EQOperator >> printOn: stream [
 
 { #category : #accessing }
 EQOperator >> symbol [
-	<MSEProperty: #symbol type: #String>
+	<FMProperty: #symbol type: #String>
 	^symbol
 ]
 

--- a/src/Fame-Example/EQSimple.class.st
+++ b/src/Fame-Example/EQSimple.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #meta }
 EQSimple class >> annotation [
-	<MSEClass: #Simple super: #EQExpression >
+	<FMClass: #Simple super: #EQExpression >
 	<package: #EQ>
 	<abstract>
 ]

--- a/src/Fame-Example/EQVariable.class.st
+++ b/src/Fame-Example/EQVariable.class.st
@@ -9,14 +9,14 @@ Class {
 
 { #category : #meta }
 EQVariable class >> annotation [
-	<MSEClass: #Variable super: #EQSimple>
+	<FMClass: #Variable super: #EQSimple>
 	<package: #EQ>
 	<abstract>
 ]
 
 { #category : #Fame }
 EQVariable >> identifier [
-	<MSEProperty: #identifier type: #EQIdentifier>
+	<FMProperty: #identifier type: #EQIdentifier>
 	^identifier
 ]
 

--- a/src/Fame-Example/LIBBook.class.st
+++ b/src/Fame-Example/LIBBook.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #meta }
 LIBBook class >> annotation [
-	<MSEClass: #Book super: #Object>
+	<FMClass: #Book super: #Object>
 	<package: #LIB>
 	
 ]
@@ -25,7 +25,7 @@ LIBBook class >> title: aString authors: aCollection [
 
 { #category : #accessing }
 LIBBook >> authors [
-	<MSEProperty: #authors type: #LIBPerson opposite: #books> <multivalued>
+	<FMProperty: #authors type: #LIBPerson opposite: #books> <multivalued>
 	^authors
 ]
 
@@ -48,7 +48,7 @@ LIBBook >> prettyString [
 
 { #category : #accessing }
 LIBBook >> title [
-	<MSEProperty: #title type: #String>
+	<FMProperty: #title type: #String>
 	^title
 ]
 

--- a/src/Fame-Example/LIBLibrary.class.st
+++ b/src/Fame-Example/LIBLibrary.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #meta }
 LIBLibrary class >> annotation [
-	<MSEClass: #Library super: #Object>
+	<FMClass: #Library super: #Object>
 	<package: #LIB>
 	
 ]
@@ -25,7 +25,7 @@ LIBLibrary class >> librarian: aPerson books: aCollection [
 
 { #category : #accessing }
 LIBLibrary >> books [
-	<MSEProperty: #books type: #LIBBook> <multivalued>
+	<FMProperty: #books type: #LIBBook> <multivalued>
 	^books
 ]
 
@@ -43,7 +43,7 @@ LIBLibrary >> initialize [
 
 { #category : #accessing }
 LIBLibrary >> librarian [
-	<MSEProperty: #librarian type: #LIBPerson>
+	<FMProperty: #librarian type: #LIBPerson>
 	^librarian
 ]
 

--- a/src/Fame-Example/LIBPerson.class.st
+++ b/src/Fame-Example/LIBPerson.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #meta }
 LIBPerson class >> annotation [
-	<MSEClass: #Person super: #Object>
+	<FMClass: #Person super: #Object>
 	<package: #LIB>
 ]
 
@@ -23,7 +23,7 @@ LIBPerson class >> named: aString [
 
 { #category : #accessing }
 LIBPerson >> books [
-	<MSEProperty: #books type: #LIBBook opposite: #authors> <multivalued>
+	<FMProperty: #books type: #LIBBook opposite: #authors> <multivalued>
 	^books
 ]
 
@@ -41,7 +41,7 @@ LIBPerson >> initialize [
 
 { #category : #accessing }
 LIBPerson >> name [
-	<MSEProperty: #name type: #String>
+	<FMProperty: #name type: #String>
 	^name
 ]
 

--- a/src/Fame-Example/RPGDragon.class.st
+++ b/src/Fame-Example/RPGDragon.class.st
@@ -10,14 +10,15 @@ Class {
 
 { #category : #meta }
 RPGDragon class >> annotation [
-	<MSEClass: #Dragon super: #Object>
+	<FMClass: #Dragon super: #Object>
 	<package: #RPG>
 ]
 
 { #category : #accessing }
 RPGDragon >> hoard [
-	<MSEProperty: #hoard type: #RPGTreasure opposite: #keeper> <multivalued>
-	^hoard
+	<FMProperty: #hoard type: #RPGTreasure opposite: #keeper>
+	<multivalued>
+	^ hoard
 ]
 
 { #category : #accessing }
@@ -34,8 +35,9 @@ RPGDragon >> initialize [
 
 { #category : #accessing }
 RPGDragon >> killedBy [
-	<MSEProperty: #killedBy type: #RPGHero opposite: #kills> <multivalued>
-	^killedBy
+	<FMProperty: #killedBy type: #RPGHero opposite: #kills>
+	<multivalued>
+	^ killedBy
 ]
 
 { #category : #accessing }

--- a/src/Fame-Example/RPGHero.class.st
+++ b/src/Fame-Example/RPGHero.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #meta }
 RPGHero class >> annotation [
-	<MSEClass: #Hero super: #Object>
+	<FMClass: #Hero super: #Object>
 	<package: #RPG>
 ]
 
@@ -25,8 +25,9 @@ RPGHero >> initialize [
 
 { #category : #accessing }
 RPGHero >> kills [
-	<MSEProperty: #kills type: #RPGDragon opposite: #killedBy> <multivalued>
-	^kills
+	<FMProperty: #kills type: #RPGDragon opposite: #killedBy>
+	<multivalued>
+	^ kills
 ]
 
 { #category : #accessing }
@@ -36,7 +37,7 @@ RPGHero >> kills: aDragon [
 
 { #category : #accessing }
 RPGHero >> talisman [
-	<MSEProperty: #talisman type: #RPGTreasure opposite: #owner>
+	<FMProperty: #talisman type: #RPGTreasure opposite: #owner>
 	^talisman
 ]
 
@@ -51,9 +52,9 @@ RPGHero >> talisman: aTreasure [
 
 { #category : #accessing }
 RPGHero >> twin [
-	<moot: #'4chan'>
-	<MSEProperty: #twin type: #RPGHero opposite: #twin>
-	^twin
+	<moot: #'4chan' >
+	<FMProperty: #twin type: #RPGHero opposite: #twin>
+	^ twin
 ]
 
 { #category : #accessing }

--- a/src/Fame-Example/RPGTreasure.class.st
+++ b/src/Fame-Example/RPGTreasure.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #meta }
 RPGTreasure class >> annotation [
-	<MSEClass: #Treasure super: #Object>
+	<FMClass: #Treasure super: #Object>
 	<package: #RPG>
 ]
 
@@ -23,7 +23,7 @@ RPGTreasure >> initialize [
 
 { #category : #accessing }
 RPGTreasure >> keeper [
-	<MSEProperty: #keeper type: #RPGDragon opposite: #hoard>
+	<FMProperty: #keeper type: #RPGDragon opposite: #hoard>
 	^keeper
 ]
 
@@ -37,7 +37,7 @@ RPGTreasure >> keeper: aDragon [
 
 { #category : #accessing }
 RPGTreasure >> owner [
-	<MSEProperty: #owner type: #RPGHero opposite: #talisman>
+	<FMProperty: #owner type: #RPGHero opposite: #talisman>
 	^owner
 ]
 

--- a/src/Fame-ImportExport/FMAbstractCodeGenerator.class.st
+++ b/src/Fame-ImportExport/FMAbstractCodeGenerator.class.st
@@ -54,7 +54,7 @@ FMAbstractCodeGenerator >> acceptFameProperty: fameProperty [
 FMAbstractCodeGenerator >> annotationStringForProperty: property [
 	| ann |
 	self assert: property type isNotNil.
-	ann := '%<MSEProperty: <1s> type: <2s>' expandMacrosWith: property name asSymbol printString with: (self classNameFor: property type) printString.
+	ann := '%<FMProperty: <1s> type: <2s>' expandMacrosWith: property name asSymbol printString with: (self classNameFor: property type) printString.
 	property hasOpposite ifTrue: [ ann := ann , ' opposite: ' , (self oppositeNameFor: property) printString ].
 	ann := ann , '>'.
 	property isMultivalued ifTrue: [ ann := ann , ' <multivalued>' ].
@@ -102,7 +102,7 @@ FMAbstractCodeGenerator >> compileClass: fameClass superclass: rbSuperclass [
 FMAbstractCodeGenerator >> compileClassAnnotation: fameClass [
 	| annotationString |
 	annotationString := ('annotation<n>',
-		'<t>%<MSEClass: <1p>',
+		'<t>%<FMClass: <1p>',
 		' super: <2p>><n>',
 		'<t>%<package: <3p>><n><t>',
 		(fameClass isAbstract ifTrue: [ '%<abstract><n><t>' ] ifFalse: ['']))

--- a/src/Fame-Rules/FameNameConventionBetweenFM3AndSmalltalkRule.class.st
+++ b/src/Fame-Rules/FameNameConventionBetweenFM3AndSmalltalkRule.class.st
@@ -24,7 +24,7 @@ FameNameConventionBetweenFM3AndSmalltalkRule >> addClass: aClass toMetaBuilderCo
 	aClass methodDict
 		valuesDo: [ :each | 
 			each pragmas
-				detect: [ :p | #(#MSEProperty:type:opposite: #MSEProperty:type:) includes: p selector ]
+				detect: [ :p | #(#FMProperty:type:opposite: #FMProperty:type:) includes: p selector ]
 				ifFound: [ :pragma | 
 					classToAdd := (pragma argumentAt: 2) asString.
 					(#('String' 'Number' 'Boolean' 'Object') includes: classToAdd)
@@ -36,7 +36,7 @@ FameNameConventionBetweenFM3AndSmalltalkRule >> addClass: aClass toMetaBuilderCo
 	aClass classSide
 		compiledMethodAt: #annotation
 		ifPresent: [ :compiledMethod | 
-			(compiledMethod pragmaAt: #MSEClass:super:)
+			(compiledMethod pragmaAt: #FMClass:super:)
 				ifNotNil: [ :pragma | 
 					| argument |
 					argument := pragma argumentAt: 2.
@@ -54,7 +54,7 @@ FameNameConventionBetweenFM3AndSmalltalkRule >> addClass: aClass toMetaBuilderCo
 FameNameConventionBetweenFM3AndSmalltalkRule >> checkClass: aContext [
 	| class pragmas pragma metaName |
 	class := aContext.
-	pragmas := Pragma allNamed: #MSEClass:super: in: class.
+	pragmas := Pragma allNamed: #FMClass:super: in: class.
 	pragmas ifEmpty: [ ^ self ].
 	pragmas size > 1
 		ifTrue: [ result addClass: class.

--- a/src/Fame-Rules/FameOppositeAttributeShouldPointBackRule.class.st
+++ b/src/Fame-Rules/FameOppositeAttributeShouldPointBackRule.class.st
@@ -16,7 +16,7 @@ FameOppositeAttributeShouldPointBackRule class >> uniqueIdentifierName [
 FameOppositeAttributeShouldPointBackRule >> checkMethod: aContext [
 	| class |
 	class := aContext methodClass.
-	((class methodNamed: aContext selector) pragmaAt: #MSEProperty:type:opposite:)
+	((class methodNamed: aContext selector) pragmaAt: #FMProperty:type:opposite:)
 		ifNotNil: [ :pragma | 
 			self class environment
 				at: (pragma argumentAt: 2)
@@ -24,7 +24,7 @@ FameOppositeAttributeShouldPointBackRule >> checkMethod: aContext [
 					oppositeClass
 						compiledMethodAt: (pragma argumentAt: 3)
 						ifPresent: [ :oppositeCompiledMethod | 
-							(oppositeCompiledMethod pragmaAt: #MSEProperty:type:opposite:)
+							(oppositeCompiledMethod pragmaAt: #FMProperty:type:opposite:)
 								ifNotNil: [ :oppositePragma | 
 									(oppositePragma argumentAt: 2) = class name asSymbol
 										ifFalse: [ result addClass: class selector: aContext selector.

--- a/src/Fame-Rules/FameOppositeClassNotExistRule.class.st
+++ b/src/Fame-Rules/FameOppositeClassNotExistRule.class.st
@@ -16,7 +16,7 @@ FameOppositeClassNotExistRule class >> uniqueIdentifierName [
 FameOppositeClassNotExistRule >> checkMethod: aContext [
 	| class |
 	class := aContext methodClass.
-	((class methodNamed: aContext selector) pragmaAt: #MSEProperty:type:opposite:)
+	((class methodNamed: aContext selector) pragmaAt: #FMProperty:type:opposite:)
 		ifNotNil: [ :pragma | self class environment at: (pragma argumentAt: 2) ifPresent: [ :oppositeClass | result addClass: class selector: aContext selector ] ]
 ]
 

--- a/src/Fame-Rules/FameSuperclassMetaDescribedExistRule.class.st
+++ b/src/Fame-Rules/FameSuperclassMetaDescribedExistRule.class.st
@@ -16,7 +16,7 @@ FameSuperclassMetaDescribedExistRule class >> uniqueIdentifierName [
 FameSuperclassMetaDescribedExistRule >> checkClass: aContext [
 	| class pragmas pragma substrings metaSuperclassName |
 	class := aContext.
-	pragmas := Pragma allNamed: #MSEClass:super: in: class.
+	pragmas := Pragma allNamed: #FMClass:super: in: class.
 	pragmas ifEmpty: [ ^ self ].
 	pragmas size > 1
 		ifTrue: [ result addClass: class.

--- a/src/Fame-Tests/FMPragmaProcessorTestDummy.class.st
+++ b/src/Fame-Tests/FMPragmaProcessorTestDummy.class.st
@@ -6,11 +6,11 @@ Class {
 
 { #category : #meta }
 FMPragmaProcessorTestDummy class >> annotation [
-	<MSEClass: #FMAnnotationTest super: #Object>
+	<FMClass: #FMAnnotationTest super: #Object>
 ]
 
 { #category : #'as yet unclassified' }
 FMPragmaProcessorTestDummy >> simpleProperty [
-	<MSEProperty: #aPropertyName type: #Boolean>
+	<FMProperty: #aPropertyName type: #Boolean>
 
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXAbstractFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAbstractFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAbstractFileAnchor class >> annotation [
 
-	<MSEClass: #AbstractFileAnchor super: #FAMIXSourceAnchor>
+	<FMClass: #AbstractFileAnchor super: #FAMIXSourceAnchor>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -23,14 +23,21 @@ FAMIXAbstractFileAnchor >> <= aFileAnchor [
 { #category : #'Famix-File' }
 FAMIXAbstractFileAnchor >> correspondingFile [
 	"file pointed to by this source anchor, ideally this value should never be nil for file-based systems"
-	<MSEProperty: #correspondingFile type: #FAMIXFile>
-	<MSEComment: 'File associated to this source anchor'>
+	<FMProperty: #correspondingFile type: #FAMIXFile>
+	<FMComment: 'File associated to this source anchor'>
 	^ self privateState attributeAt: #correspondingFile ifAbsent: [ nil ]
 ]
 
 { #category : #'Famix-File' }
 FAMIXAbstractFileAnchor >> correspondingFile: aFAMIXFile [
 	self privateState attributeAt: #correspondingFile put: aFAMIXFile
+]
+
+{ #category : #accessing }
+FAMIXAbstractFileAnchor >> encoding [
+	<FMProperty: #encoding type: #String>
+	<FMComment: 'A string representing the encoding of a file'>
+	^ encoding ifNil: [ encoding := self detectEncoding ]
 ]
 
 { #category : #'Moose-Finder' }

--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAccess class >> annotation [
 
-	<MSEClass: #Access super: #FAMIXAssociation>
+	<FMClass: #Access super: #FAMIXAssociation>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -28,6 +28,31 @@ FAMIXAccess class >> toMethod [
 { #category : #testing }
 FAMIXAccess >> isAccess [
 	^true
+]
+
+{ #category : #accessing }
+FAMIXAccess >> isRead [
+	<FMProperty: #isRead type: #Boolean> <derived>
+	<FMComment: 'Read access'>
+	
+	^ isWrite isNil ifTrue: [ false ] ifFalse: [ isWrite not ]
+]
+
+{ #category : #accessing }
+FAMIXAccess >> isReadWriteUnknown [
+	<FMProperty: #isReadWriteUnknown type: #Boolean> <derived>
+	<FMComment: ''>
+	
+	^ isWrite isNil
+]
+
+{ #category : #accessing }
+FAMIXAccess >> isWrite [
+
+	<FMProperty: #isWrite type: #Boolean> 
+	<derived>
+	<FMComment: 'Write access'>
+	^ isWrite ifNil: [ false ]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAnnotationInstance class >> annotation [
 
-	<MSEClass: #AnnotationInstance super: #FAMIXSourcedEntity>
+	<FMClass: #AnnotationInstance super: #FAMIXSourcedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -43,6 +43,14 @@ FAMIXAnnotationInstance >> name [
 			stream << '@'
 				<< (self annotationType ifNil: [ super name ] ifNotNil: [ :type | type name ])
 				<< ' on ' << (self annotatedEntity ifNotNil: #name ifNil: [ 'undefined' ]) ]
+]
+
+{ #category : #accessing }
+FAMIXAnnotationInstance >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]
 
 { #category : #'query dependencies' }

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAnnotationInstanceAttribute class >> annotation [
 
-	<MSEClass: #AnnotationInstanceAttribute super: #FAMIXSourcedEntity>
+	<FMClass: #AnnotationInstanceAttribute super: #FAMIXSourcedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -27,4 +27,12 @@ FAMIXAnnotationInstanceAttribute >> name [
 	^ self annotationTypeAttribute notNil 
 		ifTrue: [ self annotationTypeAttribute name ]
 		ifFalse: [ nil ]
+]
+
+{ #category : #accessing }
+FAMIXAnnotationInstanceAttribute >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAnnotationType class >> annotation [
 
-	<MSEClass: #AnnotationType super: #FAMIXType>
+	<FMClass: #AnnotationType super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationTypeAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationTypeAttribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAnnotationTypeAttribute class >> annotation [
 
-	<MSEClass: #AnnotationTypeAttribute super: #FAMIXAttribute>
+	<FMClass: #AnnotationTypeAttribute super: #FAMIXAttribute>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -17,8 +17,8 @@ FAMIXAnnotationTypeAttribute class >> annotation [
 
 { #category : #accessing }
 FAMIXAnnotationTypeAttribute >> parentAnnotationType [
-	<MSEProperty: #parentAnnotationType type: #FAMIXAnnotationType> <derived> 
-	<MSEComment: 'This is an alias pointing to the AnnotationType that defines this attribute'>
+	<FMProperty: #parentAnnotationType type: #FAMIXAnnotationType> <derived> 
+	<FMComment: 'This is an alias pointing to the AnnotationType that defines this attribute'>
 
 	^ self parentType
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAssociation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAssociation class >> annotation [
 
-	<MSEClass: #Association super: #FAMIXSourcedEntity>
+	<FMClass: #Association super: #FAMIXSourcedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -28,8 +28,8 @@ FAMIXAssociation >> from [
 	It should be refined by subclasses by delegating to a concrete property.
 	This property should always remain derived."
 	
-	<MSEProperty: #from type: #FAMIXNamedEntity> <derived>
-	<MSEComment: 'Generic accessor to the entity originating the association. Refined by subclasses'>
+	<FMProperty: #from type: #FAMIXNamedEntity> <derived>
+	<FMComment: 'Generic accessor to the entity originating the association. Refined by subclasses'>
 	^ self subclassResponsibility
 ]
 
@@ -57,7 +57,7 @@ FAMIXAssociation >> to [
 	It should be refined by subclasses by delegating to a concrete property.
 	This property should always remain derived."
 
-	<MSEProperty: #to type: #FAMIXNamedEntity> <derived>
-	<MSEComment: 'Generic accessor to the target entity of the association'>
+	<FMProperty: #to type: #FAMIXNamedEntity> <derived>
+	<FMComment: 'Generic accessor to the target entity of the association'>
 	^ self subclassResponsibility
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FAMIXAttribute class >> annotation [
 
-	<MSEClass: #Attribute super: #FAMIXStructuralEntity>
+	<FMClass: #Attribute super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -23,6 +23,14 @@ FAMIXAttribute class >> requirements [
 
 	<generated>
 	^ { FAMIXType }
+]
+
+{ #category : #accessing }
+FAMIXAttribute >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #'Famix-Smalltalk' }
@@ -39,8 +47,8 @@ FAMIXAttribute >> beSharedVariable [
 
 { #category : #accessing }
 FAMIXAttribute >> hasClassScope [
-	<MSEProperty: #hasClassScope type: #Boolean>
-	<MSEComment: 'True if class-side attribute'>
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'True if class-side attribute'>
 
 	^ hasClassScope
 ]
@@ -53,9 +61,9 @@ FAMIXAttribute >> hasClassScope: aBoolean [
 
 { #category : #'Famix-Extensions' }
 FAMIXAttribute >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'Attribute hierarchy nesting level'>
+	<FMComment: 'Attribute hierarchy nesting level'>
 		
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -90,6 +98,61 @@ FAMIXAttribute >> mooseNameOn: aStream [
 		[ parent mooseNameOn: aStream.
 		aStream nextPut: $. ].
 	self name ifNotNil: [ aStream nextPutAll: self name ].
+]
+
+{ #category : #accessing }
+FAMIXAttribute >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXAttribute >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FAMIXAttribute >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FAMIXAttribute >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXAttribute >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXBehaviouralEntity class >> annotation [
 
-	<MSEClass: #BehaviouralEntity super: #FAMIXContainerEntity>
+	<FMClass: #BehaviouralEntity super: #FAMIXContainerEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -17,8 +17,8 @@ FAMIXBehaviouralEntity class >> annotation [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> clientBehaviours [
-	<MSEProperty: #clientBehaviours type: #FAMIXBehaviouralEntity> <multivalued> <derived>
-	<MSEComment: 'All behaviours that depend on the receiver'>
+	<FMProperty: #clientBehaviours type: #FAMIXBehaviouralEntity> <multivalued> <derived>
+	<FMComment: 'All behaviours that depend on the receiver'>
 	^ self invokingBehaviours 
 ]
 
@@ -42,8 +42,8 @@ FAMIXBehaviouralEntity >> computeNumberOfLinesOfCodeIfSmalltalk [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> cyclomaticComplexity [
-	<MSEProperty: #cyclomaticComplexity type: #Number>
-	<MSEComment: 'The number of linear-independent paths through a method.'>
+	<FMProperty: #cyclomaticComplexity type: #Number>
+	<FMComment: 'The number of linear-independent paths through a method.'>
 	^ self
 		lookUpPropertyNamed: #cyclomaticComplexity
 		computedAs: [ self mooseModel isSmalltalk
@@ -90,9 +90,9 @@ FAMIXBehaviouralEntity >> isBehaviouralEntity [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfAccesses [
-	<MSEProperty: #numberOfAccesses type: #Number>
+	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
-	<MSEComment: 'The number of accesses from a method'>
+	<FMComment: 'The number of accesses from a method'>
 	
 	^ self 
 		lookUpPropertyNamed: #numberOfAccesses
@@ -101,8 +101,8 @@ FAMIXBehaviouralEntity >> numberOfAccesses [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfComments [
-	<MSEProperty: #numberOfComments type: #Number>
-	<MSEComment: 'The number of comment fragments'>
+	<FMProperty: #numberOfComments type: #Number>
+	<FMComment: 'The number of comment fragments'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
 ]
@@ -115,8 +115,8 @@ FAMIXBehaviouralEntity >> numberOfComments: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfConditionals [
-	<MSEProperty: #numberOfConditionals type: #Number>
-	<MSEComment: 'The number of conditionals in a method'>
+	<FMProperty: #numberOfConditionals type: #Number>
+	<FMComment: 'The number of conditionals in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfConditionals
 		computedAs: [ 
@@ -137,8 +137,8 @@ FAMIXBehaviouralEntity >> numberOfConditionals: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
-	<MSEComment: 'The number of lines of code in a method.'>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCode
 		computedAs: [ self computeNumberOfLinesOfCode ]
@@ -152,9 +152,9 @@ FAMIXBehaviouralEntity >> numberOfLinesOfCode: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfMessageSends [
-	<MSEProperty: #numberOfMessageSends type: #Number>
+	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
-	<MSEComment: 'The number of message from a method'>
+	<FMComment: 'The number of message from a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfMessageSends
 		computedAs: [ 
@@ -169,19 +169,27 @@ FAMIXBehaviouralEntity >> numberOfMessageSends [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfOutgoingInvocations [
-	<MSEProperty: #numberOfOutgoingInvocations type: #Number>
+	<FMProperty: #numberOfOutgoingInvocations type: #Number>
 	<derived>
-	<MSEComment: 'The number of invocations in a method'>
+	<FMComment: 'The number of invocations in a method'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfOutgoingInvocations
 		computedAs: [self outgoingInvocations size]
 ]
 
+{ #category : #accessing }
+FAMIXBehaviouralEntity >> numberOfParameters [
+	<FMProperty: #numberOfParameters type: #Number>
+	<FMComment: 'The number of parameters in a method'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
+]
+
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfStatements [
-	<MSEProperty: #numberOfStatements type: #Number>
-	<MSEComment: 'The number of statements in a method'>
+	<FMProperty: #numberOfStatements type: #Number>
+	<FMComment: 'The number of statements in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfStatements
 		computedAs: [ self mooseModel isSmalltalk
@@ -199,8 +207,8 @@ FAMIXBehaviouralEntity >> outgoingTypeDeclarations [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> providerBehaviours [
-	<MSEProperty: #providerBehaviours type: #FAMIXBehaviouralEntity> <derived> <multivalued>
-	<MSEComment: 'All behaviours that the receiver depends on'>
+	<FMProperty: #providerBehaviours type: #FAMIXBehaviouralEntity> <derived> <multivalued>
+	<FMComment: 'All behaviours that the receiver depends on'>
 
 	^ self invokedBehaviours 
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXCFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCFile.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXCFile class >> annotation [
 
-	<MSEClass: #CFile super: #FAMIXFile>
+	<FMClass: #CFile super: #FAMIXFile>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -35,16 +35,16 @@ FAMIXCFile >> allIncomingIncludeRelations: visitedPath [
 
 { #category : #accessing }
 FAMIXCFile >> includedFiles [
-	<MSEProperty: #includedFiles type: #FAMIXCFile> <multivalued> <derived>
-	<MSEComment: 'Files included by this file.'>
+	<FMProperty: #includedFiles type: #FAMIXCFile> <multivalued> <derived>
+	<FMComment: 'Files included by this file.'>
 
 	^ outgoingIncludeRelations collect: [ :each | each target ]
 ]
 
 { #category : #accessing }
 FAMIXCFile >> includingFiles [
-	<MSEProperty: #includingFiles type: #FAMIXCFile> <multivalued> <derived>
-	<MSEComment: 'Files that include this file.'>
+	<FMProperty: #includingFiles type: #FAMIXCFile> <multivalued> <derived>
+	<FMComment: 'Files that include this file.'>
 
 	^ incomingIncludeRelations collect: [ :each | each source ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXCSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCSourceLanguage.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXCSourceLanguage class >> annotation [
 
-	<MSEClass: #CSourceLanguage super: #FAMIXSourceLanguage>
+	<FMClass: #CSourceLanguage super: #FAMIXSourceLanguage>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXCaughtException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCaughtException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXCaughtException class >> annotation [
 
-	<MSEClass: #CaughtException super: #FAMIXException>
+	<FMClass: #CaughtException super: #FAMIXException>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXClass.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FAMIXClass class >> annotation [
 
-	<MSEClass: #Class super: #FAMIXType>
+	<FMClass: #Class super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -40,6 +40,14 @@ FAMIXClass >> containsTheReceiverOf: anInvocation [
 						ifTrue: [anInvocation receivingVariable belongsTo == self] 
 						ifFalse: [false]]] 
 		ifFalse: [false]
+]
+
+{ #category : #metrics }
+FAMIXClass >> fanIn [
+	<FMProperty: #fanIn type: #Number>
+	<derived>
+	<FMComment: 'Number of client classes'>
+	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
 ]
 
 { #category : #initialization }
@@ -89,10 +97,10 @@ FAMIXClass >> isAccessedBy: anAccess [
 
 { #category : #'Famix-Java' }
 FAMIXClass >> isIgnored [
-	<MSEProperty: #isIgnored type: #Boolean>
+	<FMProperty: #isIgnored type: #Boolean>
 	<multivalued>
 	<derived>
-	<MSEComment:
+	<FMComment:
 		'If the class is a test class, it can be annotated with Ignore, all the tests of contained are bypassed'>
 	^ (self isAnnotatedWith: 'Ignore') 
 ]
@@ -105,8 +113,8 @@ FAMIXClass >> isInheritedBy: anInheritance [
 
 { #category : #accessing }
 FAMIXClass >> isInterface [
-	<MSEProperty: #isInterface type: #Boolean>
-	<MSEComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces. It is particularly relevant for Java systems.'>
+	<FMProperty: #isInterface type: #Boolean>
+	<FMComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces. It is particularly relevant for Java systems.'>
 	^ isInterface ifNil: [ false ]
 ]
 
@@ -127,6 +135,16 @@ FAMIXClass >> isInvokedBy: anInvocation [
 		ifFalse: [false]
 ]
 
+{ #category : #testing }
+FAMIXClass >> isTestCase [
+
+	<FMProperty: #isTestCase type: #Boolean>
+	<FMComment: 'True if the method is considered as a test'>
+	<derived>
+
+	^ self privateState attributeAt: #isTestCase ifAbsent: [ false ]
+]
+
 { #category : #'Famix-Extensions-metrics-support' }
 FAMIXClass >> methodsWithoutSutbsAndConstructors [
 
@@ -134,6 +152,225 @@ FAMIXClass >> methodsWithoutSutbsAndConstructors [
 	
 	^ (self methods select: [ :each | 
 		each isStub not and: [each isConstructor not]]) asSet
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfAbstractMethods [
+	<FMProperty: #numberOfAbstractMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of abstract methods in the class'>
+	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfAccessesToForeignData [
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
+	<derived>
+	<FMComment: 'Number of accesses to foreign data'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessesToForeignData
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfAccessorMethods [
+	<FMProperty: #numberOfAccessorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of accessor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfAccessorMethods
+		computedAs: [ 
+			| noa |
+			noa := 0.
+			self methods
+				do: [ :method | 
+					method isPureAccessor
+						ifNotNil: [ 
+							(method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNil not ])
+								ifTrue: [ noa := noa + 1 ] ] ].
+			noa ]
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXClass >> numberOfAttributes [
+	<FMProperty: #numberOfAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in the class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributes
+		computedAs: [self attributes size]
+]
+
+{ #category : #accessing }
+FAMIXClass >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfDuplicatedLinesOfCodeInternally [
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<derived>
+	<FMComment: 'The number of duplicated lines of code internally'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfLinesOfCode [
+
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<derived>
+	<FMComment: 'The number of lines of code in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [self methodsGroup sumNumbers: #numberOfLinesOfCode]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message sends from a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfMethodProtocols [
+	<FMProperty: #numberOfMethodProtocols type: #Number>
+	<derived>
+	<FMComment: 'The number of method protocols in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodProtocols
+		computedAs: [((self methods collect: [:each | each protocol]) reject: #isNil) asSet size]
+]
+
+{ #category : #accessing }
+FAMIXClass >> numberOfMethods [
+	<FMProperty: #numberOfMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfMethods
+		computedAs: [self methods size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfPrivateAttributes [
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of private attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPrivateAttributes
+		computedAs: [(self attributes select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfPrivateMethods [
+	<FMProperty: #numberOfPrivateMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of private methods in a class'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfPrivateMethods
+		computedAs: [(self methods select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfProtectedAttributes [
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of protected attributes in a class'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedAttributes
+		computedAs: [(self attributes select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfProtectedMethods [
+	<FMProperty: #numberOfProtectedMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of protected methods in a class'>		
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedMethods
+		computedAs: [(self methods select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfPublicAttributes [
+	<FMProperty: #numberOfPublicAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPublicAttributes
+		computedAs: [(self attributes select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfPublicMethods [
+	<FMProperty: #numberOfPublicMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of public methods in a class'>		
+		
+	^self
+		lookUpPropertyNamed: #numberOfPublicMethods
+		computedAs: [(self methods select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfRevealedAttributes [
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfRevealedAttributes
+		computedAs:
+			[self numberOfPublicAttributes + self numberOfAccessorMethods]
+]
+
+{ #category : #metrics }
+FAMIXClass >> numberOfSubclasses [
+	<FMProperty: #numberOfSubclasses type: #Number>
+	<derived>
+	<FMComment: 'The number of subclasses of a class'>
+	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
 ]
 
 { #category : #'Famix-Implementation' }
@@ -157,4 +394,66 @@ FAMIXClass >> sourceText [
 { #category : #'Famix-Extensions' }
 FAMIXClass >> structuralChildren [
 	^ (OrderedCollection withAll: self methods), self attributes
+]
+
+{ #category : #metrics }
+FAMIXClass >> tightClassCohesion [
+	<FMProperty: #tightClassCohesion type: #Number>
+	<derived>
+	<FMComment: 'Tight class cohesion of a class'>
+	self flag: #TODO.
+	^ self
+		lookUpPropertyNamed: #tightClassCohesion
+		computedAs: [ 
+			| tcc accessDictionary nom |
+			tcc := 0.
+			accessDictionary := Dictionary new.
+			self
+				methods do: [ :eachMethod | 
+					eachMethod accesses
+						do: [ :eachAccess | 
+							| var |
+							var := eachAccess variable.
+							var isAttribute
+								ifTrue: [ 
+									| varName accessedFrom |
+									varName := var name.
+									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
+									accessedFrom isNil
+										ifTrue: [ 
+											accessedFrom := Set new.
+											accessDictionary at: varName put: accessedFrom ].
+									accessedFrom add: eachMethod name ] ] ].
+			accessDictionary values
+				do: [ :each | 
+					| size |
+					size := each size.
+					tcc := tcc + (size * (size - 1) / 2) ].
+			nom := self numberOfMethods.
+			tcc := (nom = 0 or: [ nom = 1 ])
+				ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				ifTrue: [ 0 ].
+			tcc asFloat ]
+]
+
+{ #category : #metrics }
+FAMIXClass >> weightOfAClass [
+	<FMProperty: #weightOfAClass type: #Number>
+	<derived>
+	<FMComment: 'Weight of a class'>	
+			
+	^self
+		lookUpPropertyNamed: #weightOfAClass
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FAMIXClass >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<derived>
+	<FMComment: 'The sum of the complexity in a class'>
+			
+	^self
+		lookUpPropertyNamed: #weightedMethodCount
+		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXComment.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXComment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXComment class >> annotation [
 
-	<MSEClass: #Comment super: #FAMIXSourcedEntity>
+	<FMClass: #Comment super: #FAMIXSourcedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXCompilationUnit.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCompilationUnit.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXCompilationUnit class >> annotation [
 
-	<MSEClass: #CompilationUnit super: #FAMIXCFile>
+	<FMClass: #CompilationUnit super: #FAMIXCFile>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXContainerEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXContainerEntity class >> annotation [
 
-	<MSEClass: #ContainerEntity super: #FAMIXNamedEntity>
+	<FMClass: #ContainerEntity super: #FAMIXNamedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -24,6 +24,14 @@ FAMIXContainerEntity >> addClass: aClass [
 { #category : #accessing }
 FAMIXContainerEntity >> addFunction: aFunction [ 
 	functions add: aFunction
+]
+
+{ #category : #metrics }
+FAMIXContainerEntity >> fanOut [
+	<FMProperty: #fanOut type: #Number>
+	<derived>
+	<FMComment: 'Number of provider classes'>
+	^ self lookUpPropertyNamed: #fanOut computedAs: [ (self allProvidersAtScope: FamixTType) size ]
 ]
 
 { #category : #'Famix-Java' }

--- a/src/Famix-Compatibility-Entities/FAMIXCppSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCppSourceLanguage.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXCppSourceLanguage class >> annotation [
 
-	<MSEClass: #CppSourceLanguage super: #FAMIXCSourceLanguage>
+	<FMClass: #CppSourceLanguage super: #FAMIXCSourceLanguage>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXCustomSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXCustomSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXCustomSourceLanguage class >> annotation [
 
-	<MSEClass: #CustomSourceLanguage super: #FAMIXSourceLanguage>
+	<FMClass: #CustomSourceLanguage super: #FAMIXSourceLanguage>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXDeclaredException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXDeclaredException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXDeclaredException class >> annotation [
 
-	<MSEClass: #DeclaredException super: #FAMIXException>
+	<FMClass: #DeclaredException super: #FAMIXException>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXDereferencedInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXDereferencedInvocation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXDereferencedInvocation class >> annotation [
 
-	<MSEClass: #DereferencedInvocation super: #FAMIXInvocation>
+	<FMClass: #DereferencedInvocation super: #FAMIXInvocation>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEntity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXEntity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXEnum.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnum.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXEnum class >> annotation [
 
-	<MSEClass: #Enum super: #FAMIXType>
+	<FMClass: #Enum super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXEnumValue class >> annotation [
 
-	<MSEClass: #EnumValue super: #FAMIXStructuralEntity>
+	<FMClass: #EnumValue super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXException class >> annotation [
 
-	<MSEClass: #Exception super: #FAMIXEntity>
+	<FMClass: #Exception super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -36,8 +36,8 @@ FAMIXException >> definingMethod [
 
 { #category : #compatibility }
 FAMIXException >> definingMethod: aMethod [
-	<MSEProperty: #definingMethod type: #FAMIXMethod>
-	<MSEComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	<FMProperty: #definingMethod type: #FAMIXMethod>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
 	^ self definingEntity: aMethod
 ]
 

--- a/src/Famix-Compatibility-Entities/FAMIXFile.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFile.class.st
@@ -9,10 +9,22 @@ Class {
 { #category : #meta }
 FAMIXFile class >> annotation [
 
-	<MSEClass: #File super: #FAMIXNamedEntity>
+	<FMClass: #File super: #FAMIXNamedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FAMIXFile >> averageNumberOfCharactersPerLine [
+	<FMProperty: #averageNumberOfCharactersPerLine type: #Number>
+	<FMComment: 'Average number of characters per line of text in a file.'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #averageNumberOfCharactersPerLine
+		computedAs: [ self numberOfLinesOfText isZero
+			ifFalse: [ (self numberOfCharacters / self numberOfLinesOfText) asFloat ]
+			ifTrue: [ 0 ] ]
 ]
 
 { #category : #'Famix-C-testing' }
@@ -29,4 +41,66 @@ FAMIXFile >> isHeader [
 FAMIXFile >> isSourceCodeLoaded [
 	self propertyNamed: #sourceText ifAbsentPut: [ ^ false].
 	^ true
+]
+
+{ #category : #properties }
+FAMIXFile >> numberOfBytes [
+	<FMProperty: #numberOfBytes type: #Number>
+	<FMComment: 'Number of bytes in a file.'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #numberOfBytes
+		computedAs: [ self fileExists
+				ifTrue: [ self fileReference size ]
+				ifFalse: [ 0 ] ]
+]
+
+{ #category : #properties }
+FAMIXFile >> numberOfCharacters [
+	<FMProperty: #numberOfCharacters type: #Number>
+	<FMComment: 'Number of characters in a file.'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfCharacters computedAs: [ self sourceText size ]
+]
+
+{ #category : #properties }
+FAMIXFile >> numberOfEmptyLinesOfText [
+	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
+	<FMComment: 'Number of empty lines of text'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #numberOfEmptyLinesOfText
+		computedAs: [ self fileExists
+				ifTrue: [ (self sourceText lines select: #isEmpty) size ]
+				ifFalse: [ 0 ] ]
+]
+
+{ #category : #properties }
+FAMIXFile >> numberOfKiloBytes [
+	<FMProperty: #numberOfKiloBytes type: #Number>
+	<FMComment: 'Number of kilo bytes in a file.'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfKiloBytes computedAs: [ (self numberOfBytes / 1024) asFloat ]
+]
+
+{ #category : #accessing }
+FAMIXFile >> numberOfLinesOfText [
+	<FMProperty: #numberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text which are not empty in a file'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
+]
+
+{ #category : #properties }
+FAMIXFile >> totalNumberOfLinesOfText [
+	<FMProperty: #totalNumberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #totalNumberOfLinesOfText
+		computedAs: [ self sourceText isEmpty
+				ifFalse: [ self sourceText lineCount ]
+				ifTrue: [ (self name isNotNil and: [ self exists ])
+					ifTrue: [ (self sourceText select: [ :each | each = Character cr ]) size + 1 ]
+					ifFalse: [ 0 ] ] ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXFileAnchor class >> annotation [
 
-	<MSEClass: #FileAnchor super: #FAMIXAbstractFileAnchor>
+	<FMClass: #FileAnchor super: #FAMIXAbstractFileAnchor>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXFolder.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFolder.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXFolder class >> annotation [
 
-	<MSEClass: #Folder super: #FAMIXNamedEntity>
+	<FMClass: #Folder super: #FAMIXNamedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -18,4 +18,52 @@ FAMIXFolder class >> annotation [
 { #category : #testing }
 FAMIXFolder >> isFolder [
 	^ true
+]
+
+{ #category : #properties }
+FAMIXFolder >> numberOfEmptyLinesOfText [
+	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
+	<FMComment: 'Number of empty lines of text'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfEmptyLinesOfText computedAs: [ 
+		self files, self folders sumNumbers: #numberOfEmptyLinesOfText
+	]
+]
+
+{ #category : #properties }
+FAMIXFolder >> numberOfFiles [
+	<FMProperty: #numberOfFiles type: #Number>
+	<FMComment: 'The number of files in a folder'>
+	<derived>
+	^self
+		lookUpPropertyNamed: #numberOfFiles
+		computedAs: [self files size]
+]
+
+{ #category : #properties }
+FAMIXFolder >> numberOfFolders [
+	<FMProperty: #numberOfFolders type: #Number>
+	<FMComment: 'The number of folders in a folder'>
+	<derived>
+	^self
+		lookUpPropertyNamed: #numberOfFolders
+		computedAs: [self folders size]
+]
+
+{ #category : #accessing }
+FAMIXFolder >> numberOfLinesOfText [
+	<FMProperty: #numberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text which are not empty in a file'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
+]
+
+{ #category : #properties }
+FAMIXFolder >> totalNumberOfLinesOfText [
+	<FMProperty: #totalNumberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #totalNumberOfLinesOfText
+		computedAs: [ self files , self folders sumNumbers: #totalNumberOfLinesOfText ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXFunction class >> annotation [
 
-	<MSEClass: #Function super: #FAMIXBehaviouralEntity>
+	<FMClass: #Function super: #FAMIXBehaviouralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXGlobalVariable class >> annotation [
 
-	<MSEClass: #GlobalVariable super: #FAMIXStructuralEntity>
+	<FMClass: #GlobalVariable super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -22,6 +22,14 @@ FAMIXGlobalVariable class >> requirements [
 	^ { FAMIXScopingEntity }
 ]
 
+{ #category : #accessing }
+FAMIXGlobalVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
 { #category : #'Famix-Extensions' }
 FAMIXGlobalVariable >> isPrivate [
 	^ self isPublic not
@@ -32,6 +40,61 @@ FAMIXGlobalVariable >> isPublic [
 	"checker whether I am called outside the module in which I am defined"
 	^ self incomingAccesses anySatisfy: [:inv |
 			inv accessor parentScope ~~ self parentScope]
+]
+
+{ #category : #accessing }
+FAMIXGlobalVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXGlobalVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FAMIXGlobalVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FAMIXGlobalVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXGlobalVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXHeader.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXHeader.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXHeader class >> annotation [
 
-	<MSEClass: #Header super: #FAMIXCFile>
+	<FMClass: #Header super: #FAMIXCFile>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXImplicitVariable class >> annotation [
 
-	<MSEClass: #ImplicitVariable super: #FAMIXStructuralEntity>
+	<FMClass: #ImplicitVariable super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -20,6 +20,14 @@ FAMIXImplicitVariable class >> requirements [
 
 	<generated>
 	^ { FAMIXBehaviouralEntity }
+]
+
+{ #category : #accessing }
+FAMIXImplicitVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #'Famix-Implementation' }
@@ -41,6 +49,61 @@ FAMIXImplicitVariable >> mooseNameOn: stream [
 		stream nextPut: $. ].
 
 	self name ifNotNil: [ stream nextPutAll: self name ]
+]
+
+{ #category : #accessing }
+FAMIXImplicitVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXImplicitVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FAMIXImplicitVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FAMIXImplicitVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXImplicitVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXInclude class >> annotation [
 
-	<MSEClass: #Include super: #FAMIXAssociation>
+	<FMClass: #Include super: #FAMIXAssociation>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXIndexedFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXIndexedFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXIndexedFileAnchor class >> annotation [
 
-	<MSEClass: #IndexedFileAnchor super: #FAMIXAbstractFileAnchor>
+	<FMClass: #IndexedFileAnchor super: #FAMIXAbstractFileAnchor>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXInheritance class >> annotation [
 
-	<MSEClass: #Inheritance super: #FAMIXAssociation>
+	<FMClass: #Inheritance super: #FAMIXAssociation>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXInvocation class >> annotation [
 
-	<MSEClass: #Invocation super: #FAMIXAssociation>
+	<FMClass: #Invocation super: #FAMIXAssociation>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXJavaSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXJavaSourceLanguage.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXJavaSourceLanguage class >> annotation [
 
-	<MSEClass: #JavaSourceLanguage super: #FAMIXSourceLanguage>
+	<FMClass: #JavaSourceLanguage super: #FAMIXSourceLanguage>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLeafEntity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXLeafEntity class >> annotation [
 
-	<MSEClass: #LeafEntity super: #FAMIXNamedEntity>
+	<FMClass: #LeafEntity super: #FAMIXNamedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXLocalVariable class >> annotation [
 
-	<MSEClass: #LocalVariable super: #FAMIXStructuralEntity>
+	<FMClass: #LocalVariable super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -22,6 +22,14 @@ FAMIXLocalVariable class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
+{ #category : #accessing }
+FAMIXLocalVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
 { #category : #'Famix-Implementation' }
 FAMIXLocalVariable >> mooseNameOn: stream [ 
 	| parent |
@@ -30,6 +38,61 @@ FAMIXLocalVariable >> mooseNameOn: stream [
 		[ parent mooseNameOn: stream.
 		stream nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
+]
+
+{ #category : #accessing }
+FAMIXLocalVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXLocalVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FAMIXLocalVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FAMIXLocalVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXLocalVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FAMIXMethod class >> annotation [
 
-	<MSEClass: #Method super: #FAMIXBehaviouralEntity>
+	<FMClass: #Method super: #FAMIXBehaviouralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -46,8 +46,8 @@ FAMIXMethod >> accessedAttributes [
 
 { #category : #'Famix-Smalltalk' }
 FAMIXMethod >> category [
-	<MSEProperty: #category type: #String>
-	<MSEComment: 'Category of the method'>
+	<FMProperty: #category type: #String>
+	<FMComment: 'Category of the method'>
 	<package: 'Smalltalk'>
 	
 	^ self privateState attributeAt: #category ifAbsentPut: [ nil ]
@@ -75,8 +75,8 @@ FAMIXMethod >> cyclomaticComplexity [
 
 	"redefine this method because we need to override an implementation provided by FamixTMethod"
 
-	<MSEProperty: #cyclomaticComplexity type: #Number>
-	<MSEComment: 'The number of linear-independent paths through a method.'>
+	<FMProperty: #cyclomaticComplexity type: #Number>
+	<FMComment: 'The number of linear-independent paths through a method.'>
 	^ self
 		lookUpPropertyNamed: #cyclomaticComplexity
 		computedAs: [ self mooseModel isSmalltalk
@@ -94,9 +94,9 @@ FAMIXMethod >> hasInnerClassImplementingMethods [
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'The nesting level in the hierarchy'>
+	<FMComment: 'The nesting level in the hierarchy'>
 	
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -128,16 +128,16 @@ FAMIXMethod >> innerClassesImplementingMethods [
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> invokedMethods [
-	<MSEProperty: #invokedMethods type: #FAMIXMethod> <derived> <multivalued>
-	<MSEComment: 'The methods invoked by the receiver'>
+	<FMProperty: #invokedMethods type: #FAMIXMethod> <derived> <multivalued>
+	<FMComment: 'The methods invoked by the receiver'>
 	
 	^ self invokedBehaviours select: [ :each | each isMethod ]
 ]
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> invokingMethods [
-	<MSEProperty: #invokingMethods type: #FAMIXMethod> <derived> <multivalued>
-	<MSEComment: 'The methods invoking the receiver'>
+	<FMProperty: #invokingMethods type: #FAMIXMethod> <derived> <multivalued>
+	<FMComment: 'The methods invoking the receiver'>
 
 	^ self invokingBehaviours select: [ :each | each isMethod ]
 ]
@@ -151,11 +151,29 @@ FAMIXMethod >> isCalledInternally [
 
 { #category : #'Famix-Implementation' }
 FAMIXMethod >> isClassInitializer [
-	<MSEProperty: #isClassInitializer type: #Boolean>
+	<FMProperty: #isClassInitializer type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is an initializer of the class (i.e. contains the attribute init env)'>
+	<FMComment: 'True if the method is an initializer of the class (i.e. contains the attribute init env)'>
 	^ #initializer = self kind
 		or: [ self privateState propertyAt: #isClassInitializer ifAbsent: [ false ] ]
+]
+
+{ #category : #testing }
+FAMIXMethod >> isConstant [
+	<FMProperty: #isConstant type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method simply returns a constant'>
+	^#constant = self kind
+]
+
+{ #category : #testing }
+FAMIXMethod >> isConstructor [
+	<FMProperty: #isConstructor type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a constructor of the class'>
+
+	^ #constructor = self kind or: [ 
+		self privateState propertyAt: #isConstructor ifAbsent: [false] ]
 ]
 
 { #category : #'Famix-Extensions' }
@@ -172,11 +190,20 @@ FAMIXMethod >> isDetectedSetter [
 			self accesses first isWrite ] ]
 ]
 
+{ #category : #testing }
+FAMIXMethod >> isGetter [
+	<FMProperty: #isGetter type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a getter of an attribute'>
+	
+	^#getter = self kind
+]
+
 { #category : #'Famix-Java' }
 FAMIXMethod >> isImplementing [
-	<MSEProperty: #isImplementing type: #Boolean>
+	<FMProperty: #isImplementing type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is implementing a method defined in an interface'>
+	<FMComment: 'The method is implementing a method defined in an interface'>
 	^ self belongsTo directSuperclasses
 		anySatisfy: [ :each | each isInterface and: [ each understands: self signature ] ]
 ]
@@ -190,9 +217,9 @@ FAMIXMethod >> isInitializer [
 
 { #category : #'Famix-Smalltalk' }
 FAMIXMethod >> isInternalImplementation [
-	<MSEProperty: #isInternalImplementation type: #Boolean>
+	<FMProperty: #isInternalImplementation type: #Boolean>
 	<derived>
-	<MSEComment: 'Public Interface Layer Method'>
+	<FMComment: 'Public Interface Layer Method'>
 	<package: 'Smalltalk'>
 	^ (self isInitializer not and: [ self isCalledInternally ])
 		and: [ self isPureAccessor not ]
@@ -200,17 +227,17 @@ FAMIXMethod >> isInternalImplementation [
 
 { #category : #'Famix-Java' }
 FAMIXMethod >> isJUnit4Test [
-	<MSEProperty: #isJUnit4Test type: #Boolean>
+	<FMProperty: #isJUnit4Test type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Junit 4 Java test'>
+	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
 	^ self isAnnotatedWith: 'Test'
 ]
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> isOverriden [
-	<MSEProperty: #isOverriden type: #Boolean>
+	<FMProperty: #isOverriden type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is overrided in a sub class'>
+	<FMComment: 'The method is overrided in a sub class'>
 	"If we have a stub and we don't have the container, we can't have the information"
 	(self belongsTo isNil and: [ self isStub ]) ifTrue: [ ^ false ].
 	
@@ -219,12 +246,21 @@ FAMIXMethod >> isOverriden [
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> isOverriding [
-	<MSEProperty: #isOverriding type: #Boolean>
+	<FMProperty: #isOverriding type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is overrinding a method defined in a super class'>
+	<FMComment: 'The method is overrinding a method defined in a super class'>
 	
 	^self belongsTo directSuperclasses anySatisfy: [:each | 
 		each isInterface not and: [each understands: self signature]]
+]
+
+{ #category : #testing }
+FAMIXMethod >> isSetter [
+	<FMProperty: #isSetter type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a setter on an attribute'>
+
+	^#setter = self kind
 ]
 
 { #category : #'Famix-Extensions-InvocationTesting' }
@@ -251,9 +287,9 @@ FAMIXMethod >> isSurelyInvokedBy: aFAMIXMethod [
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> numberOfAnnotationInstances [
-	<MSEProperty: #numberOfAnnotationInstances type: #Number>
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
 	<derived>
-	<MSEComment: 'The number of annotation instances defined in the method'>
+	<FMComment: 'The number of annotation instances defined in the method'>
 
 	^self
 		lookUpPropertyNamed: #numberOfAnnotationInstances
@@ -262,8 +298,8 @@ FAMIXMethod >> numberOfAnnotationInstances [
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> numberOfInvokedMethods [
-	<MSEProperty: #numberOfInvokedMethods type: #Number>
-	<MSEComment: 'Return a number corresponding to the number of invoked methods'>
+	<FMProperty: #numberOfInvokedMethods type: #Number>
+	<FMComment: 'Return a number corresponding to the number of invoked methods'>
 	<derived>
 	
 	^ self privateState propertyAt: #numberOfInvokedMethods ifAbsentPut: [self invokedMethods size]
@@ -271,9 +307,9 @@ FAMIXMethod >> numberOfInvokedMethods [
 
 { #category : #'Famix-Extensions' }
 FAMIXMethod >> numberOfMessageSends [
-	<MSEProperty: #numberOfMessageSends type: #Number>
+	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
-	<MSEComment: 'The number of message from a method'>
+	<FMComment: 'The number of message from a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfMessageSends
 		computedAs: [ 
@@ -284,6 +320,14 @@ FAMIXMethod >> numberOfMessageSends [
 					parser processMethod: self usingImporter: nil inModel: nil.
 					parser numberOfMessageSends ]
 				ifFalse: [ self notExistentMetricValue ] ]
+]
+
+{ #category : #accessing }
+FAMIXMethod >> numberOfParameters [
+	<FMProperty: #numberOfParameters type: #Number>
+	<FMComment: 'The number of parameters in a method'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
 ]
 
 { #category : #'Famix-Implementation' }
@@ -334,8 +378,8 @@ FAMIXMethod >> sourceText [
 
 { #category : #'Famix-Smalltalk' }
 FAMIXMethod >> timeStamp [
-	<MSEProperty: #timeStamp type: #String>
-	<MSEComment: 'TimeStamp of the method with author and time of the last change'>
+	<FMProperty: #timeStamp type: #String>
+	<FMComment: 'TimeStamp of the method with author and time of the last change'>
 	<package: 'Smalltalk'>
 	
 	^ self privateState attributeAt: #timeStamp ifAbsentPut: ['']

--- a/src/Famix-Compatibility-Entities/FAMIXModel.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXModel.class.st
@@ -12,7 +12,7 @@ FAMIXModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FAMIXModel class >> annotation [
-	<MSEClass: #FAMIXModel super: #MooseModel>
+	<FMClass: #FAMIXModel super: #MooseModel>
 	<package: #FAMIX>
 	<generated>
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXModule.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXModule.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXModule class >> annotation [
 
-	<MSEClass: #Module super: #FAMIXScopingEntity>
+	<FMClass: #Module super: #FAMIXScopingEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXMultipleFileAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMultipleFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXMultipleFileAnchor class >> annotation [
 
-	<MSEClass: #MultipleFileAnchor super: #FAMIXSourceAnchor>
+	<FMClass: #MultipleFileAnchor super: #FAMIXSourceAnchor>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -18,6 +18,15 @@ FAMIXMultipleFileAnchor class >> annotation [
 { #category : #public }
 FAMIXMultipleFileAnchor >> addFileAnchorWithPath: aPath [
 	self allFiles detect: [ :each | each fileName = aPath ] ifNone: [ self createAnchorWithPath: aPath ]
+]
+
+{ #category : #accessing }
+FAMIXMultipleFileAnchor >> allFiles [
+
+	<FMProperty: #allFiles type: #FamixTFileAnchor>
+	<multivalued>
+	<FMComment: 'All source code definition files'>
+	^ allFiles ifNil: [ allFiles := OrderedCollection new. ]
 ]
 
 { #category : #adding }

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXNamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FAMIXSourcedEntity>
+	<FMClass: #NamedEntity super: #FAMIXSourcedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -25,6 +25,91 @@ FAMIXNamedEntity class >> requirements [
 
 	<generated>
 	^ { FAMIXPackage }
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXNamedEntity >> isAbstract [
+	<FMProperty: #isAbstract type: #Boolean> <derived>
+	<FMComment: 'Flag true for abstract entities. Language dependent.'>
+	
+	^ self modifiers includes: #abstract
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXNamedEntity >> isFinal [
+	<FMProperty: #isFinal type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities defined as being final. Language dependent.'>	
+
+	^ self modifiers includes: #final
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXNamedEntity >> isPackage [
+	<FMProperty: #isPackage type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities that have a package visibility. Language dependent.'>
+	
+	^ self modifiers includes: #package
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXNamedEntity >> isPrivate [
+	<FMProperty: #isPrivate type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities invisible out of their owner scope. Language dependent.'>
+	
+	^ self modifiers includes: #private
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXNamedEntity >> isProtected [
+	<FMProperty: #isProtected type: #Boolean> <derived>
+	<FMComment: 'Flag true for protected entities, depending on language semantics.'>
+	
+	^ self modifiers includes: #protected
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXNamedEntity >> isPublic [
+	<FMProperty: #isPublic type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities accessible from anywhere. Language dependent.'>	
+
+	^ self modifiers includes: #public
+]
+
+{ #category : #accessing }
+FAMIXNamedEntity >> isStub [
+
+	<FMProperty: #isStub type: #Boolean>
+	<FMComment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'>
+	^ isStub ifNil: [ false ]
+]
+
+{ #category : #accessing }
+FAMIXNamedEntity >> modifiers [
+
+	<FMProperty: #modifiers type: #String>
+	<multivalued>
+	<FMComment: 'Generic container for language dependent modifiers.'>
+	^ modifiers ifNil: [ modifiers := Set new ]
+]
+
+{ #category : #metrics }
+FAMIXNamedEntity >> numberOfAnnotationInstances [
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
+	<derived>
+	<FMComment: 'The number of annotation instances defined in the class or in any of its methods'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAnnotationInstances
+		computedAs: [
+			self annotationInstances size + (self methods inject: 0 into: [:sum :each | sum + each numberOfAnnotationInstances])]
+]
+
+{ #category : #accessing }
+FAMIXNamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXNamespace class >> annotation [
 
-	<MSEClass: #Namespace super: #FAMIXScopingEntity>
+	<FMClass: #Namespace super: #FAMIXScopingEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -37,9 +37,9 @@ FAMIXNamespace >> allParentsUpTo: aNamespace [
 FAMIXNamespace >> bunchCohesion [
 	"Computing cohesion (Bunch formula)"
 
-	<MSEProperty: #bunchCohesion type: #Number>
+	<FMProperty: #bunchCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Bunch Cohesion of a namespace. It is also considered anonymous and inner classes.'>
+	<FMComment: 'Bunch Cohesion of a namespace. It is also considered anonymous and inner classes.'>
 	| myClasses intraConnectivities |
 	(myClasses := self classes) union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
 	myClasses size == 0
@@ -115,9 +115,9 @@ FAMIXNamespace >> containedEntities: collection [
 { #category : #'Famix-Extensions-metrics' }
 FAMIXNamespace >> distance [
 	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
-	<MSEProperty: #distance type: #Number>
+	<FMProperty: #distance type: #Number>
 	<derived>
-	<MSEComment: 'Distance of a namespace'>
+	<FMComment: 'Distance of a namespace'>
 
 	| abstractness instability |
 	abstractness := self abstractness.
@@ -175,9 +175,9 @@ FAMIXNamespace >> numberOfAttributes [
 "	<property: #NOA longName: 'Number of attributes' description:
 			'The number of attributes in a namespace'>"
 
-	<MSEProperty: #numberOfAttributes type: #Number>
+	<FMProperty: #numberOfAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of attributes in a namespace'>
+	<FMComment: 'The number of attributes in a namespace'>
 	
 	^ self
 		lookUpPropertyNamed: #numberOfAttributes
@@ -192,9 +192,9 @@ FAMIXNamespace >> numberOfAttributes: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXNamespace >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
+	<FMProperty: #numberOfClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes in a namespace'>
+	<FMComment: 'The number of classes in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfClasses
@@ -209,9 +209,9 @@ FAMIXNamespace >> numberOfClasses: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXNamespace >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines of code in a namespace'>
+	<FMComment: 'The number of lines of code in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfLinesOfCode
@@ -228,9 +228,9 @@ FAMIXNamespace >> numberOfLinesOfCode: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXNamespace >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
+	<FMProperty: #numberOfMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a namespace'>
+	<FMComment: 'The number of methods in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfMethods
@@ -245,9 +245,9 @@ FAMIXNamespace >> numberOfMethods: aNumber [
 
 { #category : #'Famix-Extensions-metrics' }
 FAMIXNamespace >> numberOfNonInterfacesClasses [
-	<MSEProperty: #numberOfNonInterfacesClasses type: #Number>
+	<FMProperty: #numberOfNonInterfacesClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of non interfaces classes in a namespace'>
+	<FMComment: 'The number of non interfaces classes in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfNonInterfacesClasses

--- a/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPackage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXPackage class >> annotation [
 
-	<MSEClass: #Package super: #FAMIXScopingEntity>
+	<FMClass: #Package super: #FAMIXScopingEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -24,9 +24,9 @@ FAMIXPackage >> abstractClasses [
 { #category : #'Famix-Extensions-metrics' }
 FAMIXPackage >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness of a package'>
+	<FMComment: 'Abstractness of a package'>
 
 	| nsClasses |
 	nsClasses := self allClasses select: [:c | c isInstanceSide].
@@ -44,9 +44,9 @@ FAMIXPackage >> addChildNamedEntity: aNamedEntity [
 FAMIXPackage >> afferentCoupling [
 	"Afferent coupling for a package is the number of classes that depend upon this package"
 
-	<MSEProperty: #afferentCoupling type: #Number>
+	<FMProperty: #afferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Afferent Coupling of a package'>
+	<FMComment: 'Afferent Coupling of a package'>
 	^ (((self queryIncomingDependencies atScope: FamixTType) outOfParentUsing: FamixTPackage)
 		select: [ :c | c isInstanceSide ]) size
 ]
@@ -60,9 +60,9 @@ FAMIXPackage >> allClasses [
 FAMIXPackage >> bunchCohesion [
 	"Computing cohesion (Bunch formula)"
 
-	<MSEProperty: #bunchCohesion type: #Number>
+	<FMProperty: #bunchCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Bunch Cohesion of a package. It is also considered anonymous and inner classes (in Java).'>
+	<FMComment: 'Bunch Cohesion of a package. It is also considered anonymous and inner classes (in Java).'>
 	| myClasses intraConnectivities |
 	myClasses := self classes.
 	myClasses := myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
@@ -173,13 +173,29 @@ FAMIXPackage >> definedMethods [
 	^ self localMethods
 ]
 
+{ #category : #metrics }
+FAMIXPackage >> distance [
+	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
+	<FMProperty: #distance type: #Number>
+	<derived>
+	<FMComment: 'Distance of a package'>
+
+	
+	| abstractness instability |
+	abstractness := self abstractness.
+	instability := self instability.
+	
+	(abstractness isNil or: [instability isNil]) ifTrue: [^ nil].
+	^ abstractness + instability - 1
+]
+
 { #category : #'Famix-Extensions-metrics' }
 FAMIXPackage >> efferentCoupling [
 	"Efferent coupling for a package is the number of classes it depends upon"
 
-	<MSEProperty: #efferentCoupling type: #Number>
+	<FMProperty: #efferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Efferent Coupling of a package'>
+	<FMComment: 'Efferent Coupling of a package'>
 	^ (((self queryAllOutgoing outOfParentUsing: FamixTPackage) atScope: FamixTType) select: [ :c | c isInstanceSide ]) size
 ]
 
@@ -235,6 +251,22 @@ FAMIXPackage >> historicalUniqueName [
 		ifFalse: [ self parentPackage historicalUniqueName , '.' , self name ]) asSymbol
 ]
 
+{ #category : #metrics }
+FAMIXPackage >> instability [
+	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
+
+	<FMProperty: #instability type: #Number>
+	<derived>
+	<FMComment: 'Instability of a package'>
+
+	| efferentCoupling afferentCoupling |
+	
+	efferentCoupling := self efferentCoupling.
+	afferentCoupling := self afferentCoupling.
+	(efferentCoupling + afferentCoupling) == 0 ifTrue: [^ nil].
+	^ efferentCoupling / (efferentCoupling + afferentCoupling)
+]
+
 { #category : #'Famix-Smalltalk' }
 FAMIXPackage >> localClasses [
 	"select all local classes. Just an alias"
@@ -264,9 +296,9 @@ FAMIXPackage >> localMethods [
 FAMIXPackage >> martinCohesion [
 	"Computing cohesion as described by Robert C. Martin"
 
-	<MSEProperty: #martinCohesion type: #Number>
+	<FMProperty: #martinCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Cohesion as defined by Robert C. Martin.'>
+	<FMComment: 'Cohesion as defined by Robert C. Martin.'>
 	| intraConnectivities myClasses |
 	myClasses := self classes.
 	myClasses := (myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ])) select: [ :c | c isInstanceSide ].
@@ -285,17 +317,17 @@ FAMIXPackage >> methods [
 
 { #category : #'Famix-Extensions-metrics' }
 FAMIXPackage >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
+	<FMProperty: #numberOfClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes in a package'>
+	<FMComment: 'The number of classes in a package'>
 	
 	^ self classes size
 ]
 
 { #category : #'Famix-Extensions' }
 FAMIXPackage >> numberOfClientPackages [
-	<MSEProperty: #numberOfClientPackages type: #Number>
-	<MSEComment: 'The number of packages which depend on this package'>
+	<FMProperty: #numberOfClientPackages type: #Number>
+	<FMComment: 'The number of packages which depend on this package'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfClientPackages computedAs: [ self allClients size ]
 ]
@@ -308,9 +340,9 @@ FAMIXPackage >> numberOfClientPackages: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXPackage >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines of code in a namespace'>
+	<FMComment: 'The number of lines of code in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfLinesOfCode
@@ -326,8 +358,8 @@ FAMIXPackage >> numberOfLinesOfCode: aNumber [
 
 { #category : #'Famix-Extensions' }
 FAMIXPackage >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
-	<MSEComment: 'The number of methods in a package'>
+	<FMProperty: #numberOfMethods type: #Number>
+	<FMComment: 'The number of methods in a package'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #numberOfMethods
@@ -354,9 +386,9 @@ FAMIXPackage >> printOn: aStream [
 
 { #category : #'Famix-Extensions-metrics' }
 FAMIXPackage >> relativeImportanceForSystem [
-	<MSEProperty: #relativeImportanceForSystem type: #Number>
+	<FMProperty: #relativeImportanceForSystem type: #Number>
 	<derived>
-	<MSEComment: 'The number of client packages normalized by the total number of packages'>
+	<FMComment: 'The number of client packages normalized by the total number of packages'>
 	
 	^ self lookUpPropertyNamed: #relativeImportanceForSystem
 				 computedAs: [
@@ -366,4 +398,12 @@ FAMIXPackage >> relativeImportanceForSystem [
 							]
 						ifFalse: [0]
 						]
+]
+
+{ #category : #metrics }
+FAMIXPackage >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<FMComment: 'The sum of the complexity in a package'>
+	<derived>
+	^ self lookUpPropertyNamed: #WMC computedAs: [ (self toScope: FamixTWithMethods) detectSum: #weightedMethodCount ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXParameter class >> annotation [
 
-	<MSEClass: #Parameter super: #FAMIXStructuralEntity>
+	<FMClass: #Parameter super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -22,6 +22,14 @@ FAMIXParameter class >> requirements [
 	^ { FAMIXBehaviouralEntity }
 ]
 
+{ #category : #accessing }
+FAMIXParameter >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
 { #category : #'Famix-Implementation' }
 FAMIXParameter >> mooseNameOn: stream [ 
 	| parent |
@@ -30,6 +38,61 @@ FAMIXParameter >> mooseNameOn: stream [
 		[ parent mooseNameOn: stream.
 		stream nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
+]
+
+{ #category : #accessing }
+FAMIXParameter >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXParameter >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FAMIXParameter >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FAMIXParameter >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXParameter >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Entities/FAMIXParameterType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXParameterType class >> annotation [
 
-	<MSEClass: #ParameterType super: #FAMIXType>
+	<FMClass: #ParameterType super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizableClass.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizableClass.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXParameterizableClass class >> annotation [
 
-	<MSEClass: #ParameterizableClass super: #FAMIXClass>
+	<FMClass: #ParameterizableClass super: #FAMIXClass>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -17,8 +17,8 @@ FAMIXParameterizableClass class >> annotation [
 
 { #category : #generated }
 FAMIXParameterizableClass >> parameters [
-	<MSEProperty: #parameters type: #FAMIXParameterType> <multivalued> <derived>
-	<MSEComment: 'Parameter types of this class.'>
+	<FMProperty: #parameters type: #FAMIXParameterType> <multivalued> <derived>
+	<FMComment: 'Parameter types of this class.'>
 	
 	^self types select: [:each | each isParameterType]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXParameterizedType class >> annotation [
 
-	<MSEClass: #ParameterizedType super: #FAMIXType>
+	<FMClass: #ParameterizedType super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXPharoAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPharoAnchor.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #meta }
 FAMIXPharoAnchor class >> annotation [
 
-	<MSEClass: #PharoAnchor super: #FAMIXSourceAnchor>
+	<FMClass: #PharoAnchor super: #FAMIXSourceAnchor>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorDefine.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorDefine.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FAMIXPreprocessorDefine class >> annotation [
 
-	<MSEClass: #PreprocessorDefine super: #FAMIXPreprocessorStatement>
+	<FMClass: #PreprocessorDefine super: #FAMIXPreprocessorStatement>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -20,8 +20,8 @@ FAMIXPreprocessorDefine class >> annotation [
 
 { #category : #accessing }
 FAMIXPreprocessorDefine >> macro [
-	<MSEProperty: #macro type: #String>
-	<MSEComment: 'The name of the macro being defined'>
+	<FMProperty: #macro type: #String>
+	<FMComment: 'The name of the macro being defined'>
 	^ macro
 ]
 

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorIfdef.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorIfdef.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #meta }
 FAMIXPreprocessorIfdef class >> annotation [
 
-	<MSEClass: #PreprocessorIfdef super: #FAMIXPreprocessorStatement>
+	<FMClass: #PreprocessorIfdef super: #FAMIXPreprocessorStatement>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -19,8 +19,8 @@ FAMIXPreprocessorIfdef class >> annotation [
 
 { #category : #accessing }
 FAMIXPreprocessorIfdef >> isNegated [
-	<MSEProperty: #negated type: #Boolean>
-	<MSEComment: 'Whether it is an #ifdef (false) or #ifndef (true)'>
+	<FMProperty: #negated type: #Boolean>
+	<FMComment: 'Whether it is an #ifdef (false) or #ifndef (true)'>
 	^ negated
 ]
 
@@ -31,8 +31,8 @@ FAMIXPreprocessorIfdef >> isNegated: aBoolean [
 
 { #category : #accessing }
 FAMIXPreprocessorIfdef >> macro [
-	<MSEProperty: #macro type: #String>
-	<MSEComment: 'The name of the macro being tested'>
+	<FMProperty: #macro type: #String>
+	<FMComment: 'The name of the macro being tested'>
 	^ macro
 ]
 

--- a/src/Famix-Compatibility-Entities/FAMIXPreprocessorStatement.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPreprocessorStatement.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXPreprocessorStatement class >> annotation [
 
-	<MSEClass: #PreprocessorStatement super: #FAMIXSourcedEntity>
+	<FMClass: #PreprocessorStatement super: #FAMIXSourcedEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXPrimitiveType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXPrimitiveType.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXPrimitiveType class >> annotation [
 
-	<MSEClass: #PrimitiveType super: #FAMIXType>
+	<FMClass: #PrimitiveType super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXReference class >> annotation [
 
-	<MSEClass: #Reference super: #FAMIXAssociation>
+	<FMClass: #Reference super: #FAMIXAssociation>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXScopingEntity class >> annotation [
 
-	<MSEClass: #ScopingEntity super: #FAMIXContainerEntity>
+	<FMClass: #ScopingEntity super: #FAMIXContainerEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXSmalltalkSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSmalltalkSourceLanguage.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXSmalltalkSourceLanguage class >> annotation [
 
-	<MSEClass: #SmalltalkSourceLanguage super: #FAMIXSourceLanguage>
+	<FMClass: #SmalltalkSourceLanguage super: #FAMIXSourceLanguage>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXSourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FAMIXEntity>
+	<FMClass: #SourceAnchor super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -47,9 +47,9 @@ FAMIXSourceAnchor >> isFile [
 FAMIXSourceAnchor >> lineCount [
 	"I should return the number of line in the source text of the entity."
 
-	<MSEProperty: #lineCount type: #Number>
+	<FMProperty: #lineCount type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines in the source text'>
+	<FMComment: 'The number of lines in the source text'>
 	^ self subclassResponsibility
 ]
 

--- a/src/Famix-Compatibility-Entities/FAMIXSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXSourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FAMIXEntity>
+	<FMClass: #SourceLanguage super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -24,8 +24,8 @@ FAMIXSourceLanguage >> isC [
 FAMIXSourceLanguage >> name [
 	"The name of the language that is not modeled explicitly"
 	
-	<MSEProperty: #name type: #String> <derived>
-	<MSEComment: 'The name of the language that is not modeled explicitly.'>
+	<FMProperty: #name type: #String> <derived>
+	<FMComment: 'The name of the language that is not modeled explicitly.'>
 	
 	^ (self class name removePrefix: 'FAMIX') removeSuffix: 'SourceLanguage'
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXSourceTextAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXSourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FAMIXSourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FAMIXSourceAnchor>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXSourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FAMIXEntity>
+	<FMClass: #SourcedEntity super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -63,15 +63,49 @@ FAMIXSourcedEntity >> fileAnchorPath: aString startPos: anInteger endPos: anothe
 				model: self mooseModel)
 ]
 
+{ #category : #accessing }
+FAMIXSourcedEntity >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
 { #category : #'Famix-Extensions' }
 FAMIXSourcedEntity >> numberOfJavaNullChecks [
-	<MSEProperty: #numberOfJavaNullChecks type: #Number> <derived>
+	<FMProperty: #numberOfJavaNullChecks type: #Number> <derived>
 	^self
 		lookUpPropertyNamed: #numberOfJavaNullChecks
 		computedAs: [
 			| nullCheckTextPatterns |
 			nullCheckTextPatterns := #('== null' '!= null' 'null ==' 'null !=').
 			(self sourceText allRegexMatches: ( '|' join: nullCheckTextPatterns)) size ]
+]
+
+{ #category : #'Famix-Implementation' }
+FAMIXSourcedEntity >> numberOfLinesOfCode [
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
+	^ self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [ self computeNumberOfLinesOfCode ]
+]
+
+{ #category : #metrics }
+FAMIXSourcedEntity >> numberOfLinesOfCodeWithMoreThanOneCharacter [
+	<FMProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number> <derived>
+	<FMComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
+	the difference being that it only counts the lines with more than one non-whitespace characters.
+	This metric is particularly useful for comparing the density of other metrics on a line of code.
+	For example, depending on the formatting style chosen a Java curly brace, or a Smalltalk block 
+	can appear inline or on a separate line. For normalization purposes, these commonly appearing 
+	cases can be ruled out through the present metric.'>
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCodeWithMoreThanOneCharacter
+		computedAs: [			
+			(self sourceText lines select: [ :line |
+				line trimBoth size > 1 ]) size ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXStructuralEntity.class.st
@@ -9,14 +9,77 @@ Class {
 { #category : #meta }
 FAMIXStructuralEntity class >> annotation [
 
-	<MSEClass: #StructuralEntity super: #FAMIXLeafEntity>
+	<FMClass: #StructuralEntity super: #FAMIXLeafEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FAMIXStructuralEntity >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #'Famix-Extensions' }
 FAMIXStructuralEntity >> isSharedVariable [
 
 	^ false
+]
+
+{ #category : #accessing }
+FAMIXStructuralEntity >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXStructuralEntity >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FAMIXStructuralEntity >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FAMIXStructuralEntity >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FAMIXStructuralEntity >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXThrownException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXThrownException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXThrownException class >> annotation [
 
-	<MSEClass: #ThrownException super: #FAMIXException>
+	<FMClass: #ThrownException super: #FAMIXException>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXTrait.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTrait.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXTrait class >> annotation [
 
-	<MSEClass: #Trait super: #FAMIXType>
+	<FMClass: #Trait super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXTraitUsage class >> annotation [
 
-	<MSEClass: #TraitUsage super: #FAMIXAssociation>
+	<FMClass: #TraitUsage super: #FAMIXAssociation>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXType class >> annotation [
 
-	<MSEClass: #Type super: #FAMIXContainerEntity>
+	<FMClass: #Type super: #FAMIXContainerEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -68,8 +68,8 @@ FAMIXType >> classSide [
 
 { #category : #accessing }
 FAMIXType >> container [
-	<MSEProperty: #container type: #FAMIXContainerEntity>
-	<MSEComment: 'Deprected, use typeContainer'>
+	<FMProperty: #container type: #FAMIXContainerEntity>
+	<FMComment: 'Deprected, use typeContainer'>
 	<derived>
 	^ self typeContainer
 ]
@@ -93,6 +93,14 @@ FAMIXType >> extendedMethods [
 							ifAbsentPut: [ self methods select: [ :m| m isExtension ] ]
 ]
 
+{ #category : #metrics }
+FAMIXType >> fanIn [
+	<FMProperty: #fanIn type: #Number>
+	<derived>
+	<FMComment: 'Number of client classes'>
+	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
+]
+
 { #category : #'Famix-Extensions' }
 FAMIXType >> hasMethodWithSignature: aStringOrSymbol [
 	| symbol |
@@ -103,6 +111,26 @@ FAMIXType >> hasMethodWithSignature: aStringOrSymbol [
 { #category : #'Famix-Extensions' }
 FAMIXType >> hasMethodsAnnotatedWith: aString [
 	^ self methods anySatisfy: [ :each | each isAnnotatedWith: aString ]
+]
+
+{ #category : #metrics }
+FAMIXType >> hierarchyNestingLevel [
+	<FMProperty: #hierarchyNestingLevel type: #Number>
+	<derived>
+	<FMComment: 'The nesting of a class inside the hierarchy'>
+
+	^self
+		lookUpPropertyNamed: #hierarchyNestingLevel
+		computedAs:
+			[| currentMaxDepth |
+			(self directSuperclasses isEmpty or: [self isStub])
+				ifTrue: [0]
+				ifFalse:
+					[currentMaxDepth := 0.
+					self
+						allSuperclassesDo:
+							[:aClass | currentMaxDepth := currentMaxDepth max: aClass hierarchyNestingLevel].
+					currentMaxDepth + 1]]
 ]
 
 { #category : #'Famix-Implementation' }
@@ -156,8 +184,8 @@ FAMIXType >> instanceSide [
 
 { #category : #'Famix-Extensions' }
 FAMIXType >> isAbstract [
-	<MSEProperty: #isAbstract type: #Boolean> <derived>
-	<MSEComment: 'Flag true for abstract classes.'>
+	<FMProperty: #isAbstract type: #Boolean> <derived>
+	<FMComment: 'Flag true for abstract classes.'>
 	
 	^super isAbstract
 ]
@@ -201,9 +229,9 @@ FAMIXType >> isGodClass [
 
 { #category : #'Famix-Java' }
 FAMIXType >> isInnerClass [
-	<MSEProperty: #isInnerClass type: #Boolean>
+	<FMProperty: #isInnerClass type: #Boolean>
 	<derived>
-	<MSEComment:
+	<FMComment:
 		'True if the method is considered as an innerclass (i.e. is contained elsewhere than a java package: class, method, enum,...)'>
 	^ self container ifNotNil: [ :c | c isNamespace not ] ifNil: [ false ]
 ]
@@ -225,9 +253,9 @@ FAMIXType >> isJUnit3TestCase [
 
 { #category : #'Famix-Java' }
 FAMIXType >> isJUnit4TestCase [
-	<MSEProperty: #isJUnit4TestCase type: #Boolean>
+	<FMProperty: #isJUnit4TestCase type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Junit 4 Java test'>
+	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
 	^ self methods anySatisfy: [ :m | m isJUnit4Test ]
 ]
 
@@ -255,9 +283,9 @@ FAMIXType >> isSUnitTestCase [
 
 { #category : #'Famix-Java' }
 FAMIXType >> isTestCase [
-	<MSEProperty: #isTestCase type: #Boolean>
+	<FMProperty: #isTestCase type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Java test'>
+	<FMComment: 'True if the method is considered as a Java test'>
 	^ self isJUnit3TestCase or: [ self isJUnit4TestCase ] 
 ]
 
@@ -290,6 +318,293 @@ FAMIXType >> lookUp: aMethodSignature [
 	^searchedM
 ]
 
+{ #category : #metrics }
+FAMIXType >> numberOfAbstractMethods [
+	<FMProperty: #numberOfAbstractMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of abstract methods in the class'>
+	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfAccessesToForeignData [
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
+	<derived>
+	<FMComment: 'Number of accesses to foreign data'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessesToForeignData
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfAccessorMethods [
+	<FMProperty: #numberOfAccessorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of accessor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfAccessorMethods
+		computedAs: [ 
+			| noa |
+			noa := 0.
+			self methods
+				do: [ :method | 
+					method isPureAccessor
+						ifNotNil: [ 
+							(method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNil not ])
+								ifTrue: [ noa := noa + 1 ] ] ].
+			noa ]
+]
+
+{ #category : #'Famix-Extensions' }
+FAMIXType >> numberOfAttributes [
+	<FMProperty: #numberOfAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in the class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributes
+		computedAs: [self attributes size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfAttributesInherited [
+	<FMProperty: #numberOfAttributesInherited type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in a class inherited from super classes'>	
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributesInherited
+		computedAs: [self inheritedAttributes size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfDirectSubclasses [
+	<FMProperty: #numberOfDirectSubclasses type: #Number>
+	<FMComment: 'The number of direct subclasses'>
+	<derived>
+
+	^ self privateState propertyAt: #numberOfDirectSubclasses ifAbsentPut: [self directSubclasses size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfDuplicatedLinesOfCodeInternally [
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<derived>
+	<FMComment: 'The number of duplicated lines of code internally'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfLinesOfCode [
+
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<derived>
+	<FMComment: 'The number of lines of code in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [self methodsGroup sumNumbers: #numberOfLinesOfCode]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message sends from a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfMethodProtocols [
+	<FMProperty: #numberOfMethodProtocols type: #Number>
+	<derived>
+	<FMComment: 'The number of method protocols in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodProtocols
+		computedAs: [((self methods collect: [:each | each protocol]) reject: #isNil) asSet size]
+]
+
+{ #category : #accessing }
+FAMIXType >> numberOfMethods [
+	<FMProperty: #numberOfMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfMethods
+		computedAs: [self methods size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfMethodsAdded [
+	<FMProperty: #numberOfMethodsAdded type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class added with respect to super classes'>	
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodsAdded
+		computedAs: [self addedMethods size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfMethodsInHierarchy [
+	<FMProperty: #numberOfMethodsInHierarchy type: #Number>
+	<derived>
+	<FMComment: 'The number of methods of a class included the inherited ones'>	
+	
+	| totNom |
+	totNom := self methods size.
+	self superclassHierarchyGroup
+		do: [:aClass | totNom := totNom + aClass methods size].
+	^totNom
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfMethodsInherited [
+	<FMProperty: #numberOfMethodsInherited type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class inherited from super classes'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfMethodsInherited
+		computedAs: [self inheritedMethods size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfMethodsOverriden [
+	<FMProperty: #numberOfMethodsOverriden type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class overriden with respect to super classes'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfMethodsOverriden
+		computedAs: [self numberOfMethods - self numberOfMethodsAdded]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfParents [
+	<FMProperty: #numberOfParents type: #Number>
+	<derived>
+	<FMComment: 'The number of superclasses'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfParents
+		computedAs: [self directSuperclasses size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfPrivateAttributes [
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of private attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPrivateAttributes
+		computedAs: [(self attributes select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfPrivateMethods [
+	<FMProperty: #numberOfPrivateMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of private methods in a class'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfPrivateMethods
+		computedAs: [(self methods select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfProtectedAttributes [
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of protected attributes in a class'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedAttributes
+		computedAs: [(self attributes select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfProtectedMethods [
+	<FMProperty: #numberOfProtectedMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of protected methods in a class'>		
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedMethods
+		computedAs: [(self methods select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfPublicAttributes [
+	<FMProperty: #numberOfPublicAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPublicAttributes
+		computedAs: [(self attributes select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfPublicMethods [
+	<FMProperty: #numberOfPublicMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of public methods in a class'>		
+		
+	^self
+		lookUpPropertyNamed: #numberOfPublicMethods
+		computedAs: [(self methods select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfRevealedAttributes [
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfRevealedAttributes
+		computedAs:
+			[self numberOfPublicAttributes + self numberOfAccessorMethods]
+]
+
+{ #category : #metrics }
+FAMIXType >> numberOfSubclasses [
+	<FMProperty: #numberOfSubclasses type: #Number>
+	<derived>
+	<FMComment: 'The number of subclasses of a class'>
+	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
+]
+
 { #category : #'Famix-Implementation' }
 FAMIXType >> parentScope [
 	"Polymorphic alias to mimic GlobalVariable#parentScope and similar"
@@ -312,6 +627,73 @@ FAMIXType >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
+{ #category : #metrics }
+FAMIXType >> subclassHierarchyDepth [ 
+	<FMProperty: #subclassHierarchyDepth type: #Number>
+	<derived>
+	<FMComment: 'The depth of the class hierarchy for which I am the root'>
+		
+	^ self directSubclasses isEmpty 
+		ifTrue: [ 0 ] 
+		ifFalse: 
+			[ | currentMaxDepth| 
+				currentMaxDepth := 0. 
+				self allSubclassesDo: 
+					[ :aClass | currentMaxDepth := currentMaxDepth max: aClass subclassHierarchyDepth ]. 
+            1 + currentMaxDepth ] 
+]
+
+{ #category : #metrics }
+FAMIXType >> tightClassCohesion [
+	<FMProperty: #tightClassCohesion type: #Number>
+	<derived>
+	<FMComment: 'Tight class cohesion of a class'>
+	self flag: #TODO.
+	^ self
+		lookUpPropertyNamed: #tightClassCohesion
+		computedAs: [ 
+			| tcc accessDictionary nom |
+			tcc := 0.
+			accessDictionary := Dictionary new.
+			self
+				methods do: [ :eachMethod | 
+					eachMethod accesses
+						do: [ :eachAccess | 
+							| var |
+							var := eachAccess variable.
+							var isAttribute
+								ifTrue: [ 
+									| varName accessedFrom |
+									varName := var name.
+									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
+									accessedFrom isNil
+										ifTrue: [ 
+											accessedFrom := Set new.
+											accessDictionary at: varName put: accessedFrom ].
+									accessedFrom add: eachMethod name ] ] ].
+			accessDictionary values
+				do: [ :each | 
+					| size |
+					size := each size.
+					tcc := tcc + (size * (size - 1) / 2) ].
+			nom := self numberOfMethods.
+			tcc := (nom = 0 or: [ nom = 1 ])
+				ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				ifTrue: [ 0 ].
+			tcc asFloat ]
+]
+
+{ #category : #metrics }
+FAMIXType >> totalNumberOfChildren [
+	<FMProperty: #totalNumberOfChildren type: #Number>
+	<derived>	
+	<FMComment: 'The total number of subclasses of a class'>
+	
+	^self
+		lookUpPropertyNamed: #totalNumberOfChildren
+		computedAs: [self subclassHierarchyGroup size]
+]
+
 { #category : #'Famix-Implementation' }
 FAMIXType >> understands: signature [
 	"returns true if a class is able to respond to an invocation to aSignature on itself; false otherwise"
@@ -319,6 +701,17 @@ FAMIXType >> understands: signature [
 	self withSuperclassesDo: [:each | 
 		(each implements: signature) ifTrue: [^true]].
 	^false
+]
+
+{ #category : #metrics }
+FAMIXType >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<derived>
+	<FMComment: 'The sum of the complexity in a class'>
+			
+	^self
+		lookUpPropertyNamed: #weightedMethodCount
+		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXTypeAlias.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTypeAlias.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXTypeAlias class >> annotation [
 
-	<MSEClass: #TypeAlias super: #FAMIXType>
+	<FMClass: #TypeAlias super: #FAMIXType>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownSourceLanguage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXUnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FAMIXSourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FAMIXSourceLanguage>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXUnknownVariable.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FAMIXUnknownVariable class >> annotation [
 
-	<MSEClass: #UnknownVariable super: #FAMIXStructuralEntity>
+	<FMClass: #UnknownVariable super: #FAMIXStructuralEntity>
 	<package: #FAMIX>
 	<generated>
 	^self

--- a/src/Famix-Deprecated/FAMIXMethod.extension.st
+++ b/src/Famix-Deprecated/FAMIXMethod.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #FAMIXMethod }
+
+{ #category : #'*Famix-Deprecated' }
+FAMIXMethod >> hasClassScope [
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
+	^ self isClassSide
+]

--- a/src/Famix-Deprecated/FM3Class.extension.st
+++ b/src/Famix-Deprecated/FM3Class.extension.st
@@ -50,7 +50,7 @@ FM3Class >> attributeNamed: arg1 ifAbsent: arg2 [
 
 { #category : #'*Famix-Deprecated' }
 FM3Class >> attributes [
-	<MSEProperty: #attributes type: 'FM3.Property'>
+	<FMProperty: #attributes type: 'FM3.Property'>
 	<multivalued>
 	self deprecated: 'Use #properties instead.' transformWith: '``@object attributes' -> '``@object properties'.
 	^ self properties

--- a/src/Famix-Deprecated/FamixJavaMethod.extension.st
+++ b/src/Famix-Deprecated/FamixJavaMethod.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #FamixJavaMethod }
+
+{ #category : #'*Famix-Deprecated' }
+FamixJavaMethod >> hasClassScope [
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
+	^ self isClassSide
+]

--- a/src/Famix-Deprecated/FamixJavaType.extension.st
+++ b/src/Famix-Deprecated/FamixJavaType.extension.st
@@ -2,8 +2,8 @@ Extension { #name : #FamixJavaType }
 
 { #category : #'*Famix-Deprecated' }
 FamixJavaType >> container [
-	<MSEProperty: #container type: #FamixJavaContainerEntity>
-	<MSEComment: 'Deprected, use typeContainer'>
+	<FMProperty: #container type: #FamixJavaContainerEntity>
+	<FMComment: 'Deprected, use typeContainer'>
 	self deprecated: 'Use #typeContainer instead.' transformWith: '`@receiver container' -> '`@receiver typeContainer'.
 	^ self typeContainer
 ]

--- a/src/Famix-Deprecated/FamixStMethod.extension.st
+++ b/src/Famix-Deprecated/FamixStMethod.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #FamixStMethod }
+
+{ #category : #'*Famix-Deprecated' }
+FamixStMethod >> hasClassScope [
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
+	^ self isClassSide
+]

--- a/src/Famix-Deprecated/FamixTMethod.extension.st
+++ b/src/Famix-Deprecated/FamixTMethod.extension.st
@@ -2,8 +2,8 @@ Extension { #name : #FamixTMethod }
 
 { #category : #'*Famix-Deprecated' }
 FamixTMethod >> hasClassScope [
-	<MSEProperty: #hasClassScope type: #Boolean>
-	<MSEComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
 	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
 	^ self isClassSide
 ]

--- a/src/Famix-Groups/FAMIXAnnotationInstanceGroup.class.st
+++ b/src/Famix-Groups/FAMIXAnnotationInstanceGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXAnnotationInstanceGroup class >> annotation [
-	<MSEClass: #AnnotationInstanceGroup super: #MooseGroup>
+	<FMClass: #AnnotationInstanceGroup super: #MooseGroup>
 	<package: #FAMIX>
 
 ]

--- a/src/Famix-Groups/FAMIXAnnotationTypeGroup.class.st
+++ b/src/Famix-Groups/FAMIXAnnotationTypeGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXAnnotationTypeGroup class >> annotation [
-	<MSEClass: #AnnotationTypeGroup super: #MooseGroup>
+	<FMClass: #AnnotationTypeGroup super: #MooseGroup>
 	<package: #FAMIX>
 
 ]

--- a/src/Famix-Groups/FAMIXClassGroup.class.st
+++ b/src/Famix-Groups/FAMIXClassGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXClassGroup class >> annotation [
-	<MSEClass: #ClassGroup super: #FAMIXTypeGroup>
+	<FMClass: #ClassGroup super: #FAMIXTypeGroup>
 	<package: #FAMIX>
 
 ]

--- a/src/Famix-Groups/FAMIXFileGroup.class.st
+++ b/src/Famix-Groups/FAMIXFileGroup.class.st
@@ -6,6 +6,6 @@ Class {
 
 { #category : #meta }
 FAMIXFileGroup class >> annotation [
-	<MSEClass: #FileGroup super: #MooseGroup>
+	<FMClass: #FileGroup super: #MooseGroup>
 	<package: #FAMIX>
 ]

--- a/src/Famix-Groups/FAMIXFolderGroup.class.st
+++ b/src/Famix-Groups/FAMIXFolderGroup.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #meta }
 FAMIXFolderGroup class >> annotation [
-	<MSEClass: #FolderGroup super: #MooseGroup>
+	<FMClass: #FolderGroup super: #MooseGroup>
 	<package: #FAMIX>
 ]
 

--- a/src/Famix-Groups/FAMIXGlobalVariableGroup.class.st
+++ b/src/Famix-Groups/FAMIXGlobalVariableGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXGlobalVariableGroup class >> annotation [
-	<MSEClass: #GlobalVariableGroup super: #MooseGroup>
+	<FMClass: #GlobalVariableGroup super: #MooseGroup>
 	<package: #FAMIX>
 ]
 

--- a/src/Famix-Groups/FAMIXInvocationGroup.class.st
+++ b/src/Famix-Groups/FAMIXInvocationGroup.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #meta }
 FAMIXInvocationGroup class >> annotation [
-	<MSEClass: #InvocationGroup super: #MooseGroup>
+	<FMClass: #InvocationGroup super: #MooseGroup>
 	<package: #FAMIX>
 
 ]

--- a/src/Famix-Groups/FAMIXMethodGroup.class.st
+++ b/src/Famix-Groups/FAMIXMethodGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXMethodGroup class >> annotation [
-	<MSEClass: #MethodGroup super: #MooseGroup>
+	<FMClass: #MethodGroup super: #MooseGroup>
 	<package: #FAMIX>
 
 ]
@@ -32,8 +32,8 @@ FAMIXMethodGroup >> allPackages [
 
 { #category : #metrics }
 FAMIXMethodGroup >> averageNumberOfInvocations [
-	<MSEProperty: #averageNumberOfInvocations type: #Number>
-	<MSEComment: 'Average number of invocations per methods'>
+	<FMProperty: #averageNumberOfInvocations type: #Number>
+	<FMComment: 'Average number of invocations per methods'>
 
 	^self
 		lookUpPropertyNamed: #averageNumberOfInvocations
@@ -42,8 +42,8 @@ FAMIXMethodGroup >> averageNumberOfInvocations [
 
 { #category : #metrics }
 FAMIXMethodGroup >> averageNumberOfLinesOfCode [
-	<MSEProperty: #averageNumberOfLinesOfCode type: #Number>
-	<MSEComment: 'Average number of lines of code per methods'>
+	<FMProperty: #averageNumberOfLinesOfCode type: #Number>
+	<FMComment: 'Average number of lines of code per methods'>
 
 	^self
 		lookUpPropertyNamed: #averageNumberOfLinesOfCode
@@ -52,8 +52,8 @@ FAMIXMethodGroup >> averageNumberOfLinesOfCode [
 
 { #category : #metrics }
 FAMIXMethodGroup >> averageNumberOfParameters [
-	<MSEProperty: #averageNumberOfParameters type: #Number>
-	<MSEComment: 'Average number of parameters per methods'>
+	<FMProperty: #averageNumberOfParameters type: #Number>
+	<FMComment: 'Average number of parameters per methods'>
 	
 	^self
 		lookUpPropertyNamed: #averageNumberOfParameters

--- a/src/Famix-Groups/FAMIXNamespaceGroup.class.st
+++ b/src/Famix-Groups/FAMIXNamespaceGroup.class.st
@@ -9,6 +9,6 @@ Class {
 
 { #category : #meta }
 FAMIXNamespaceGroup class >> annotation [
-	<MSEClass: #NamespaceGroup super: #MooseGroup>
+	<FMClass: #NamespaceGroup super: #MooseGroup>
 	<package: #FAMIX>
 ]

--- a/src/Famix-Groups/FAMIXPackageGroup.class.st
+++ b/src/Famix-Groups/FAMIXPackageGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXPackageGroup class >> annotation [
-	<MSEClass: #PackageGroup super: #MooseGroup>
+	<FMClass: #PackageGroup super: #MooseGroup>
 	<package: #FAMIX>
 
 ]

--- a/src/Famix-Groups/FAMIXTypeGroup.class.st
+++ b/src/Famix-Groups/FAMIXTypeGroup.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #meta }
 FAMIXTypeGroup class >> annotation [
-	<MSEClass: #TypeGroup super: #MooseGroup>
+	<FMClass: #TypeGroup super: #MooseGroup>
 	<package: #FAMIX>
 
 ]
@@ -18,9 +18,9 @@ FAMIXTypeGroup class >> annotation [
 FAMIXTypeGroup >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
 
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract.'>
+	<FMComment: 'Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract.'>
 	
 	| nsClasses |
 	nsClasses := self allClasses select: [:c | c isInstanceSide].
@@ -60,8 +60,8 @@ FAMIXTypeGroup >> allPackages [
 
 { #category : #metrics }
 FAMIXTypeGroup >> averageNumberOfAttributes [
-	<MSEProperty: #averageNumberOfAttributes type: #Number>
-	<MSEComment: 'Average number of attributes per class'>
+	<FMProperty: #averageNumberOfAttributes type: #Number>
+	<FMComment: 'Average number of attributes per class'>
 
 	^self
 		lookUpPropertyNamed: #averageNumberOfAttributes
@@ -70,8 +70,8 @@ FAMIXTypeGroup >> averageNumberOfAttributes [
 
 { #category : #metrics }
 FAMIXTypeGroup >> averageNumberOfLinesOfCode [
-	<MSEProperty: #averageNumberOfMethods type: #Number>
-	<MSEComment: 'Average number of methods per class'>
+	<FMProperty: #averageNumberOfMethods type: #Number>
+	<FMComment: 'Average number of methods per class'>
 	
 	^self
 		lookUpPropertyNamed: #averageNumberOfMethods
@@ -80,8 +80,8 @@ FAMIXTypeGroup >> averageNumberOfLinesOfCode [
 
 { #category : #metrics }
 FAMIXTypeGroup >> averageNumberOfMethods [
-	<MSEProperty: #averageNumberOfMethods type: #Number>
-	<MSEComment: 'Average number of methods per class'>
+	<FMProperty: #averageNumberOfMethods type: #Number>
+	<FMComment: 'Average number of methods per class'>
 
 	^self
 		lookUpPropertyNamed: #averageNumberOfMethods
@@ -90,8 +90,8 @@ FAMIXTypeGroup >> averageNumberOfMethods [
 
 { #category : #metrics }
 FAMIXTypeGroup >> averageNumberOfStatements [
-	<MSEProperty: #averageNumberOfStatements type: #Number>
-	<MSEComment: 'Average number of statements per class'>	
+	<FMProperty: #averageNumberOfStatements type: #Number>
+	<FMComment: 'Average number of statements per class'>	
 
 	^self
 		lookUpPropertyNamed: #averageNumberOfStatements
@@ -128,9 +128,9 @@ FAMIXTypeGroup >> commonExternalSuperclasses [
 { #category : #metrics }
 FAMIXTypeGroup >> distance [
 	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
-	<MSEProperty: #distance type: #Number>
+	<FMProperty: #distance type: #Number>
 	<derived>
-	<MSEComment: 'Distance of a class group'>
+	<FMComment: 'Distance of a class group'>
 	
 	| abstractness instability |
 	abstractness := self abstractness.
@@ -143,9 +143,9 @@ FAMIXTypeGroup >> distance [
 { #category : #metrics }
 FAMIXTypeGroup >> instability [
 	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
-	<MSEProperty: #instability type: #Number>
+	<FMProperty: #instability type: #Number>
 	<derived>
-	<MSEComment: 'Instability of a class group'>
+	<FMComment: 'Instability of a class group'>
 	
 	| efferentCoupling afferentCoupling |
 	

--- a/src/Famix-Java-Entities/FamixJavaAbstractFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAbstractFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAbstractFileAnchor class >> annotation [
 
-	<MSEClass: #AbstractFileAnchor super: #FamixJavaSourceAnchor>
+	<FMClass: #AbstractFileAnchor super: #FamixJavaSourceAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -18,6 +18,13 @@ FamixJavaAbstractFileAnchor class >> annotation [
 { #category : #'as yet unclassified' }
 FamixJavaAbstractFileAnchor >> <= aFileAnchor [
 	^ self fileName <= aFileAnchor fileName
+]
+
+{ #category : #accessing }
+FamixJavaAbstractFileAnchor >> encoding [
+	<FMProperty: #encoding type: #String>
+	<FMComment: 'A string representing the encoding of a file'>
+	^ encoding ifNil: [ encoding := self detectEncoding ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -9,10 +9,35 @@ Class {
 { #category : #meta }
 FamixJavaAccess class >> annotation [
 
-	<MSEClass: #Access super: #FamixJavaAssociation>
+	<FMClass: #Access super: #FamixJavaAssociation>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixJavaAccess >> isRead [
+	<FMProperty: #isRead type: #Boolean> <derived>
+	<FMComment: 'Read access'>
+	
+	^ isWrite isNil ifTrue: [ false ] ifFalse: [ isWrite not ]
+]
+
+{ #category : #accessing }
+FamixJavaAccess >> isReadWriteUnknown [
+	<FMProperty: #isReadWriteUnknown type: #Boolean> <derived>
+	<FMComment: ''>
+	
+	^ isWrite isNil
+]
+
+{ #category : #accessing }
+FamixJavaAccess >> isWrite [
+
+	<FMProperty: #isWrite type: #Boolean> 
+	<derived>
+	<FMComment: 'Write access'>
+	^ isWrite ifNil: [ false ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAnnotationInstance class >> annotation [
 
-	<MSEClass: #AnnotationInstance super: #FamixJavaSourcedEntity>
+	<FMClass: #AnnotationInstance super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -43,4 +43,12 @@ FamixJavaAnnotationInstance >> name [
 			stream << '@'
 				<< (self annotationType ifNil: [ super name ] ifNotNil: [ :type | type name ])
 				<< ' on ' << (self annotatedEntity ifNotNil: #name ifNil: [ 'undefined' ]) ]
+]
+
+{ #category : #accessing }
+FamixJavaAnnotationInstance >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAnnotationInstanceAttribute class >> annotation [
 
-	<MSEClass: #AnnotationInstanceAttribute super: #FamixJavaSourcedEntity>
+	<FMClass: #AnnotationInstanceAttribute super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -27,4 +27,12 @@ FamixJavaAnnotationInstanceAttribute >> name [
 	^ self annotationTypeAttribute notNil 
 		ifTrue: [ self annotationTypeAttribute name ]
 		ifFalse: [ nil ]
+]
+
+{ #category : #accessing }
+FamixJavaAnnotationInstanceAttribute >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAnnotationType class >> annotation [
 
-	<MSEClass: #AnnotationType super: #FamixJavaType>
+	<FMClass: #AnnotationType super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAnnotationTypeAttribute class >> annotation [
 
-	<MSEClass: #AnnotationTypeAttribute super: #FamixJavaAttribute>
+	<FMClass: #AnnotationTypeAttribute super: #FamixJavaAttribute>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -17,9 +17,9 @@ FamixJavaAnnotationTypeAttribute class >> annotation [
 
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationTypeAttribute >> parentAnnotationType [
-	<MSEProperty: #parentAnnotationType type: #FamixJavaAnnotationType> 
+	<FMProperty: #parentAnnotationType type: #FamixJavaAnnotationType> 
 	<derived> 
-	<MSEComment: 'This is an alias pointing to the AnnotationType that defines this attribute'>
+	<FMComment: 'This is an alias pointing to the AnnotationType that defines this attribute'>
 
 	^ self parentType
 ]

--- a/src/Famix-Java-Entities/FamixJavaAssociation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAssociation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAssociation class >> annotation [
 
-	<MSEClass: #Association super: #FamixJavaSourcedEntity>
+	<FMClass: #Association super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -28,8 +28,8 @@ FamixJavaAssociation >> from [
 	It should be refined by subclasses by delegating to a concrete property.
 	This property should always remain derived."
 	
-	<MSEProperty: #from type: #FamixJavaNamedEntity> <derived>
-	<MSEComment: 'Generic accessor to the entity originating the association. Refined by subclasses'>
+	<FMProperty: #from type: #FamixJavaNamedEntity> <derived>
+	<FMComment: 'Generic accessor to the entity originating the association. Refined by subclasses'>
 	^ self subclassResponsibility
 ]
 
@@ -50,7 +50,7 @@ FamixJavaAssociation >> to [
 	It should be refined by subclasses by delegating to a concrete property.
 	This property should always remain derived."
 
-	<MSEProperty: #to type: #FamixJavaNamedEntity> <derived>
-	<MSEComment: 'Generic accessor to the target entity of the association'>
+	<FMProperty: #to type: #FamixJavaNamedEntity> <derived>
+	<FMComment: 'Generic accessor to the target entity of the association'>
 	^ self subclassResponsibility
 ]

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -12,16 +12,24 @@ Class {
 { #category : #meta }
 FamixJavaAttribute class >> annotation [
 
-	<MSEClass: #Attribute super: #FamixJavaNamedEntity>
+	<FMClass: #Attribute super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
 ]
 
+{ #category : #accessing }
+FamixJavaAttribute >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
 { #category : #'as yet unclassified' }
 FamixJavaAttribute >> hasClassScope [
-	<MSEProperty: #hasClassScope type: #Boolean>
-	<MSEComment: 'True if class-side attribute'>
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'True if class-side attribute'>
 
 	^ hasClassScope
 ]
@@ -34,9 +42,9 @@ FamixJavaAttribute >> hasClassScope: aBoolean [
 
 { #category : #'as yet unclassified' }
 FamixJavaAttribute >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'Attribute hierarchy nesting level'>
+	<FMComment: 'Attribute hierarchy nesting level'>
 		
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -64,6 +72,61 @@ FamixJavaAttribute >> mooseNameOn: aStream [
 		[ parent mooseNameOn: aStream.
 		aStream nextPut: $. ].
 	self name ifNotNil: [ aStream nextPutAll: self name ].
+]
+
+{ #category : #accessing }
+FamixJavaAttribute >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaAttribute >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaAttribute >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaAttribute >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaAttribute >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaCaughtException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaCaughtException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaCaughtException class >> annotation [
 
-	<MSEClass: #CaughtException super: #FamixJavaException>
+	<FMClass: #CaughtException super: #FamixJavaException>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaClass class >> annotation [
 
-	<MSEClass: #Class super: #FamixJavaType>
+	<FMClass: #Class super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -23,6 +23,14 @@ FamixJavaClass >> accessedAttributes [
 	Used to support the calculation of LCOM"
 	
 	^ self methodsWithoutSutbsAndConstructors asOrderedCollection flatCollect: [ :method | method accessedAttributes ]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> fanIn [
+	<FMProperty: #fanIn type: #Number>
+	<derived>
+	<FMComment: 'Number of client classes'>
+	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
 ]
 
 { #category : #testing }
@@ -65,10 +73,10 @@ FamixJavaClass >> isAccessedBy: anAccess [
 
 { #category : #testing }
 FamixJavaClass >> isIgnored [
-	<MSEProperty: #isIgnored type: #Boolean>
+	<FMProperty: #isIgnored type: #Boolean>
 	<multivalued>
 	<derived>
-	<MSEComment:
+	<FMComment:
 		'If the class is a test class, it can be annotated with Ignore, all the tests of contained are bypassed'>
 	^ (self isAnnotatedWith: 'Ignore') 
 ]
@@ -82,8 +90,8 @@ FamixJavaClass >> isInheritedBy: anInheritance [
 { #category : #testing }
 FamixJavaClass >> isInterface [
 
-	<MSEProperty: #isInterface type: #Boolean>
-	<MSEComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces'>
+	<FMProperty: #isInterface type: #Boolean>
+	<FMComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces'>
 
 	^ self privateState attributeAt: #isInterface ifAbsent: [ false ]
 ]
@@ -106,6 +114,40 @@ FamixJavaClass >> isInvokedBy: anInvocation [
 		ifFalse: [false]
 ]
 
+{ #category : #testing }
+FamixJavaClass >> isTestCase [
+
+	<FMProperty: #isTestCase type: #Boolean>
+	<FMComment: 'True if the method is considered as a test'>
+	<derived>
+
+	^ self privateState attributeAt: #isTestCase ifAbsent: [ false ]
+]
+
+{ #category : #'Famix-Extensions-metrics-support' }
+FamixJavaClass >> lcom2 [
+
+	<FMProperty: #lcom2 type: #Number>
+	<FMComment: 'lack of cohesion in methods 2 (lcom2)'>
+	<derived>
+
+	^ self
+		lookUpPropertyNamed: #lcom2
+		computedAs: [self calculateLCOM2]
+]
+
+{ #category : #'Famix-Extensions-metrics-support' }
+FamixJavaClass >> lcom3 [
+
+	<FMProperty: #lcom3 type: #Number>
+	<FMComment: 'lack of cohesion in methods 3 (lcom3)'>
+	<derived>
+
+	^ self
+		lookUpPropertyNamed: #lcom3
+		computedAs: [self calculateLCOM3]
+]
+
 { #category : #'Famix-Extensions-metrics-support' }
 FamixJavaClass >> methodsWithoutSutbsAndConstructors [
 
@@ -115,7 +157,288 @@ FamixJavaClass >> methodsWithoutSutbsAndConstructors [
 		each isStub not and: [each isConstructor not]]) asSet
 ]
 
+{ #category : #metrics }
+FamixJavaClass >> numberOfAbstractMethods [
+	<FMProperty: #numberOfAbstractMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of abstract methods in the class'>
+	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfAccessesToForeignData [
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
+	<derived>
+	<FMComment: 'Number of accesses to foreign data'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessesToForeignData
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfAccessorMethods [
+	<FMProperty: #numberOfAccessorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of accessor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfAccessorMethods
+		computedAs: [ 
+			| noa |
+			noa := 0.
+			self methods
+				do: [ :method | 
+					method isPureAccessor
+						ifNotNil: [ 
+							(method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNil not ])
+								ifTrue: [ noa := noa + 1 ] ] ].
+			noa ]
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaClass >> numberOfAttributes [
+	<FMProperty: #numberOfAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in the class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributes
+		computedAs: [self attributes size]
+]
+
+{ #category : #accessing }
+FamixJavaClass >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfDuplicatedLinesOfCodeInternally [
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<derived>
+	<FMComment: 'The number of duplicated lines of code internally'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfLinesOfCode [
+
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<derived>
+	<FMComment: 'The number of lines of code in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [self methodsGroup sumNumbers: #numberOfLinesOfCode]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message sends from a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfMethodProtocols [
+	<FMProperty: #numberOfMethodProtocols type: #Number>
+	<derived>
+	<FMComment: 'The number of method protocols in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodProtocols
+		computedAs: [((self methods collect: [:each | each protocol]) reject: #isNil) asSet size]
+]
+
+{ #category : #accessing }
+FamixJavaClass >> numberOfMethods [
+	<FMProperty: #numberOfMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfMethods
+		computedAs: [self methods size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfPrivateAttributes [
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of private attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPrivateAttributes
+		computedAs: [(self attributes select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfPrivateMethods [
+	<FMProperty: #numberOfPrivateMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of private methods in a class'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfPrivateMethods
+		computedAs: [(self methods select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfProtectedAttributes [
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of protected attributes in a class'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedAttributes
+		computedAs: [(self attributes select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfProtectedMethods [
+	<FMProperty: #numberOfProtectedMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of protected methods in a class'>		
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedMethods
+		computedAs: [(self methods select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfPublicAttributes [
+	<FMProperty: #numberOfPublicAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPublicAttributes
+		computedAs: [(self attributes select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfPublicMethods [
+	<FMProperty: #numberOfPublicMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of public methods in a class'>		
+		
+	^self
+		lookUpPropertyNamed: #numberOfPublicMethods
+		computedAs: [(self methods select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfRevealedAttributes [
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfRevealedAttributes
+		computedAs:
+			[self numberOfPublicAttributes + self numberOfAccessorMethods]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> numberOfSubclasses [
+	<FMProperty: #numberOfSubclasses type: #Number>
+	<derived>
+	<FMComment: 'The number of subclasses of a class'>
+	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
+]
+
 { #category : #'as yet unclassified' }
 FamixJavaClass >> structuralChildren [
 	^ (OrderedCollection withAll: self methods), self attributes
+]
+
+{ #category : #metrics }
+FamixJavaClass >> tightClassCohesion [
+	<FMProperty: #tightClassCohesion type: #Number>
+	<derived>
+	<FMComment: 'Tight class cohesion of a class'>
+	self flag: #TODO.
+	^ self
+		lookUpPropertyNamed: #tightClassCohesion
+		computedAs: [ 
+			| tcc accessDictionary nom |
+			tcc := 0.
+			accessDictionary := Dictionary new.
+			self
+				methods do: [ :eachMethod | 
+					eachMethod accesses
+						do: [ :eachAccess | 
+							| var |
+							var := eachAccess variable.
+							var isAttribute
+								ifTrue: [ 
+									| varName accessedFrom |
+									varName := var name.
+									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
+									accessedFrom isNil
+										ifTrue: [ 
+											accessedFrom := Set new.
+											accessDictionary at: varName put: accessedFrom ].
+									accessedFrom add: eachMethod name ] ] ].
+			accessDictionary values
+				do: [ :each | 
+					| size |
+					size := each size.
+					tcc := tcc + (size * (size - 1) / 2) ].
+			nom := self numberOfMethods.
+			tcc := (nom = 0 or: [ nom = 1 ])
+				ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				ifTrue: [ 0 ].
+			tcc asFloat ]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> weightOfAClass [
+	<FMProperty: #weightOfAClass type: #Number>
+	<derived>
+	<FMComment: 'Weight of a class'>	
+			
+	^self
+		lookUpPropertyNamed: #weightOfAClass
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixJavaClass >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<derived>
+	<FMComment: 'The sum of the complexity in a class'>
+			
+	^self
+		lookUpPropertyNamed: #weightedMethodCount
+		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
 ]

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaComment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixJavaSourcedEntity>
+	<FMClass: #Comment super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaContainerEntity class >> annotation [
 
-	<MSEClass: #ContainerEntity super: #FamixJavaNamedEntity>
+	<FMClass: #ContainerEntity super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -19,6 +19,14 @@ FamixJavaContainerEntity class >> annotation [
 FamixJavaContainerEntity >> addClass: aClass [
 	
 	types add: aClass
+]
+
+{ #category : #metrics }
+FamixJavaContainerEntity >> fanOut [
+	<FMProperty: #fanOut type: #Number>
+	<derived>
+	<FMComment: 'Number of provider classes'>
+	^ self lookUpPropertyNamed: #fanOut computedAs: [ (self allProvidersAtScope: FamixTType) size ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaDeclaredException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaDeclaredException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaDeclaredException class >> annotation [
 
-	<MSEClass: #DeclaredException super: #FamixJavaException>
+	<FMClass: #DeclaredException super: #FamixJavaException>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -24,7 +24,7 @@ Class {
 { #category : #meta }
 FamixJavaEntity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaEnum class >> annotation [
 
-	<MSEClass: #Enum super: #FamixJavaType>
+	<FMClass: #Enum super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaEnumValue class >> annotation [
 
-	<MSEClass: #EnumValue super: #FamixJavaNamedEntity>
+	<FMClass: #EnumValue super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -20,4 +20,67 @@ FamixJavaEnumValue class >> requirements [
 
 	<generated>
 	^ { FamixJavaEnum }
+]
+
+{ #category : #accessing }
+FamixJavaEnumValue >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
+{ #category : #accessing }
+FamixJavaEnumValue >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaEnumValue >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaEnumValue >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaEnumValue >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaEnumValue >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaException class >> annotation [
 
-	<MSEClass: #Exception super: #FamixJavaEntity>
+	<FMClass: #Exception super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaFile.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFile.class.st
@@ -9,14 +9,88 @@ Class {
 { #category : #meta }
 FamixJavaFile class >> annotation [
 
-	<MSEClass: #File super: #FamixJavaNamedEntity>
+	<FMClass: #File super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixJavaFile >> averageNumberOfCharactersPerLine [
+	<FMProperty: #averageNumberOfCharactersPerLine type: #Number>
+	<FMComment: 'Average number of characters per line of text in a file.'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #averageNumberOfCharactersPerLine
+		computedAs: [ self numberOfLinesOfText isZero
+			ifFalse: [ (self numberOfCharacters / self numberOfLinesOfText) asFloat ]
+			ifTrue: [ 0 ] ]
 ]
 
 { #category : #'as yet unclassified' }
 FamixJavaFile >> isSourceCodeLoaded [
 	self propertyNamed: #sourceText ifAbsentPut: [ ^ false].
 	^ true
+]
+
+{ #category : #properties }
+FamixJavaFile >> numberOfBytes [
+	<FMProperty: #numberOfBytes type: #Number>
+	<FMComment: 'Number of bytes in a file.'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #numberOfBytes
+		computedAs: [ self fileExists
+				ifTrue: [ self fileReference size ]
+				ifFalse: [ 0 ] ]
+]
+
+{ #category : #properties }
+FamixJavaFile >> numberOfCharacters [
+	<FMProperty: #numberOfCharacters type: #Number>
+	<FMComment: 'Number of characters in a file.'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfCharacters computedAs: [ self sourceText size ]
+]
+
+{ #category : #properties }
+FamixJavaFile >> numberOfEmptyLinesOfText [
+	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
+	<FMComment: 'Number of empty lines of text'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #numberOfEmptyLinesOfText
+		computedAs: [ self fileExists
+				ifTrue: [ (self sourceText lines select: #isEmpty) size ]
+				ifFalse: [ 0 ] ]
+]
+
+{ #category : #properties }
+FamixJavaFile >> numberOfKiloBytes [
+	<FMProperty: #numberOfKiloBytes type: #Number>
+	<FMComment: 'Number of kilo bytes in a file.'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfKiloBytes computedAs: [ (self numberOfBytes / 1024) asFloat ]
+]
+
+{ #category : #accessing }
+FamixJavaFile >> numberOfLinesOfText [
+	<FMProperty: #numberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text which are not empty in a file'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
+]
+
+{ #category : #properties }
+FamixJavaFile >> totalNumberOfLinesOfText [
+	<FMProperty: #totalNumberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #totalNumberOfLinesOfText
+		computedAs: [ self sourceText isEmpty
+				ifFalse: [ self sourceText lineCount ]
+				ifTrue: [ (self name isNotNil and: [ self exists ])
+					ifTrue: [ (self sourceText select: [ :each | each = Character cr ]) size + 1 ]
+					ifFalse: [ 0 ] ] ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaFileAnchor class >> annotation [
 
-	<MSEClass: #FileAnchor super: #FamixJavaAbstractFileAnchor>
+	<FMClass: #FileAnchor super: #FamixJavaAbstractFileAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaFolder.class.st
+++ b/src/Famix-Java-Entities/FamixJavaFolder.class.st
@@ -9,8 +9,56 @@ Class {
 { #category : #meta }
 FamixJavaFolder class >> annotation [
 
-	<MSEClass: #Folder super: #FamixJavaNamedEntity>
+	<FMClass: #Folder super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #properties }
+FamixJavaFolder >> numberOfEmptyLinesOfText [
+	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
+	<FMComment: 'Number of empty lines of text'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfEmptyLinesOfText computedAs: [ 
+		self files, self folders sumNumbers: #numberOfEmptyLinesOfText
+	]
+]
+
+{ #category : #properties }
+FamixJavaFolder >> numberOfFiles [
+	<FMProperty: #numberOfFiles type: #Number>
+	<FMComment: 'The number of files in a folder'>
+	<derived>
+	^self
+		lookUpPropertyNamed: #numberOfFiles
+		computedAs: [self files size]
+]
+
+{ #category : #properties }
+FamixJavaFolder >> numberOfFolders [
+	<FMProperty: #numberOfFolders type: #Number>
+	<FMComment: 'The number of folders in a folder'>
+	<derived>
+	^self
+		lookUpPropertyNamed: #numberOfFolders
+		computedAs: [self folders size]
+]
+
+{ #category : #accessing }
+FamixJavaFolder >> numberOfLinesOfText [
+	<FMProperty: #numberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text which are not empty in a file'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
+]
+
+{ #category : #properties }
+FamixJavaFolder >> totalNumberOfLinesOfText [
+	<FMProperty: #totalNumberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text'>
+	<derived>
+	^ self
+		lookUpPropertyNamed: #totalNumberOfLinesOfText
+		computedAs: [ self files , self folders sumNumbers: #totalNumberOfLinesOfText ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaGlobalVariable class >> annotation [
 
-	<MSEClass: #GlobalVariable super: #FamixJavaNamedEntity>
+	<FMClass: #GlobalVariable super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -22,6 +22,14 @@ FamixJavaGlobalVariable class >> requirements [
 	^ { FamixJavaScopingEntity }
 ]
 
+{ #category : #accessing }
+FamixJavaGlobalVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
 { #category : #'as yet unclassified' }
 FamixJavaGlobalVariable >> isPrivate [
 	^ self isPublic not
@@ -32,6 +40,61 @@ FamixJavaGlobalVariable >> isPublic [
 	"checker whether I am called outside the module in which I am defined"
 	^ self incomingAccesses anySatisfy: [:inv |
 			inv accessor parentScope ~~ self parentScope]
+]
+
+{ #category : #accessing }
+FamixJavaGlobalVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaGlobalVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaGlobalVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaGlobalVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaGlobalVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -9,10 +9,18 @@ Class {
 { #category : #meta }
 FamixJavaImplicitVariable class >> annotation [
 
-	<MSEClass: #ImplicitVariable super: #FamixJavaNamedEntity>
+	<FMClass: #ImplicitVariable super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixJavaImplicitVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #'as yet unclassified' }
@@ -24,6 +32,61 @@ FamixJavaImplicitVariable >> mooseNameOn: stream [
 		stream nextPut: $. ].
 
 	self name ifNotNil: [ stream nextPutAll: self name ]
+]
+
+{ #category : #accessing }
+FamixJavaImplicitVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaImplicitVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaImplicitVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaImplicitVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaImplicitVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaIndexedFileAnchor class >> annotation [
 
-	<MSEClass: #IndexedFileAnchor super: #FamixJavaAbstractFileAnchor>
+	<FMClass: #IndexedFileAnchor super: #FamixJavaAbstractFileAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaInheritance class >> annotation [
 
-	<MSEClass: #Inheritance super: #FamixJavaAssociation>
+	<FMClass: #Inheritance super: #FamixJavaAssociation>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaInvocation class >> annotation [
 
-	<MSEClass: #Invocation super: #FamixJavaAssociation>
+	<FMClass: #Invocation super: #FamixJavaAssociation>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -9,10 +9,18 @@ Class {
 { #category : #meta }
 FamixJavaLocalVariable class >> annotation [
 
-	<MSEClass: #LocalVariable super: #FamixJavaNamedEntity>
+	<FMClass: #LocalVariable super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixJavaLocalVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #'as yet unclassified' }
@@ -23,6 +31,61 @@ FamixJavaLocalVariable >> mooseNameOn: stream [
 		[ parent mooseNameOn: stream.
 		stream nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
+]
+
+{ #category : #accessing }
+FamixJavaLocalVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaLocalVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaLocalVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaLocalVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaLocalVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaMethod class >> annotation [
 
-	<MSEClass: #Method super: #FamixJavaContainerEntity>
+	<FMClass: #Method super: #FamixJavaContainerEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -33,17 +33,26 @@ FamixJavaMethod >> accessedAttributes [
 
 { #category : #accessing }
 FamixJavaMethod >> category [
-	<MSEProperty: #category type: #String>
-	<MSEComment: 'Category of the method'>
+	<FMProperty: #category type: #String>
+	<FMComment: 'Category of the method'>
 	
 	^ self privateState attributeAt: #category ifAbsentPut: [ nil ]
 ]
 
 { #category : #'Famix-Extensions' }
 FamixJavaMethod >> clientBehaviours [
-	<MSEProperty: #clientBehaviours type: #FamixJavaMethod> <multivalued> <derived>
-	<MSEComment: 'All behaviours that depend on the receiver'>
+	<FMProperty: #clientBehaviours type: #FamixJavaMethod> <multivalued> <derived>
+	<FMComment: 'All behaviours that depend on the receiver'>
 	^ self invokingBehaviours 
+]
+
+{ #category : #metrics }
+FamixJavaMethod >> cyclomaticComplexity [
+	<FMProperty: #cyclomaticComplexity type: #Number>
+	<FMComment: 'The number of linear-independent paths through a method.'>
+	^ self
+		lookUpPropertyNamed:  #cyclomaticComplexity
+		computedAs: [ self notExistentMetricValue ]
 ]
 
 { #category : #testing }
@@ -66,9 +75,9 @@ FamixJavaMethod >> hasInnerClassImplementingMethods [
 
 { #category : #metrics }
 FamixJavaMethod >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'The nesting level in the hierarchy'>
+	<FMComment: 'The nesting level in the hierarchy'>
 	
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -99,8 +108,8 @@ FamixJavaMethod >> invokedBehaviours [
 
 { #category : #'Famix-Extensions' }
 FamixJavaMethod >> invokedMethods [
-	<MSEProperty: #invokedMethods type: #FamixJavaMethod> <derived> <multivalued>
-	<MSEComment: 'The methods invoked by the receiver'>
+	<FMProperty: #invokedMethods type: #FamixJavaMethod> <derived> <multivalued>
+	<FMComment: 'The methods invoked by the receiver'>
 	
 	^ self invokedBehaviours select: [ :each | each isMethod ]
 ]
@@ -112,8 +121,8 @@ FamixJavaMethod >> invokingBehaviours [
 
 { #category : #'Famix-Extensions' }
 FamixJavaMethod >> invokingMethods [
-	<MSEProperty: #invokingMethods type: #FamixJavaMethod> <derived> <multivalued>
-	<MSEComment: 'The methods invoking the receiver'>
+	<FMProperty: #invokingMethods type: #FamixJavaMethod> <derived> <multivalued>
+	<FMComment: 'The methods invoking the receiver'>
 
 	^ self invokingBehaviours select: [ :each | each isMethod ]
 ]
@@ -127,11 +136,29 @@ FamixJavaMethod >> isCalledInternally [
 
 { #category : #testing }
 FamixJavaMethod >> isClassInitializer [
-	<MSEProperty: #isClassInitializer type: #Boolean>
+	<FMProperty: #isClassInitializer type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is an initializer of the class (i.e. contains the attribute init env)'>
+	<FMComment: 'True if the method is an initializer of the class (i.e. contains the attribute init env)'>
 	^ #initializer = self kind
 		or: [ self privateState propertyAt: #isClassInitializer ifAbsent: [ false ] ]
+]
+
+{ #category : #testing }
+FamixJavaMethod >> isConstant [
+	<FMProperty: #isConstant type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method simply returns a constant'>
+	^#constant = self kind
+]
+
+{ #category : #testing }
+FamixJavaMethod >> isConstructor [
+	<FMProperty: #isConstructor type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a constructor of the class'>
+
+	^ #constructor = self kind or: [ 
+		self privateState propertyAt: #isConstructor ifAbsent: [false] ]
 ]
 
 { #category : #testing }
@@ -149,27 +176,36 @@ FamixJavaMethod >> isDetectedSetter [
 ]
 
 { #category : #testing }
-FamixJavaMethod >> isImplementing [
-	<MSEProperty: #isImplementing type: #Boolean>
+FamixJavaMethod >> isGetter [
+	<FMProperty: #isGetter type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is implementing a method defined in an interface'>
+	<FMComment: 'True if the method is a getter of an attribute'>
+	
+	^#getter = self kind
+]
+
+{ #category : #testing }
+FamixJavaMethod >> isImplementing [
+	<FMProperty: #isImplementing type: #Boolean>
+	<derived>
+	<FMComment: 'The method is implementing a method defined in an interface'>
 	^ self belongsTo directSuperclasses
 		anySatisfy: [ :each | each isInterface and: [ each understands: self signature ] ]
 ]
 
 { #category : #testing }
 FamixJavaMethod >> isJUnit4Test [
-	<MSEProperty: #isJUnit4Test type: #Boolean>
+	<FMProperty: #isJUnit4Test type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Junit 4 Java test'>
+	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
 	^ self isAnnotatedWith: 'Test'
 ]
 
 { #category : #testing }
 FamixJavaMethod >> isOverriden [
-	<MSEProperty: #isOverriden type: #Boolean>
+	<FMProperty: #isOverriden type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is overrided in a sub class'>
+	<FMComment: 'The method is overrided in a sub class'>
 	"If we have a stub and we don't have the container, we can't have the information"
 	(self belongsTo isNil and: [ self isStub ]) ifTrue: [ ^ false ].
 	
@@ -178,12 +214,21 @@ FamixJavaMethod >> isOverriden [
 
 { #category : #testing }
 FamixJavaMethod >> isOverriding [
-	<MSEProperty: #isOverriding type: #Boolean>
+	<FMProperty: #isOverriding type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is overrinding a method defined in a super class'>
+	<FMComment: 'The method is overrinding a method defined in a super class'>
 	
 	^self belongsTo directSuperclasses anySatisfy: [:each | 
 		each isInterface not and: [each understands: self signature]]
+]
+
+{ #category : #testing }
+FamixJavaMethod >> isSetter [
+	<FMProperty: #isSetter type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a setter on an attribute'>
+
+	^#setter = self kind
 ]
 
 { #category : #printing }
@@ -216,9 +261,9 @@ FamixJavaMethod >> isSurelyInvokedBy: aFAMIXMethod [
 
 { #category : #accessing }
 FamixJavaMethod >> numberOfAccesses [
-	<MSEProperty: #numberOfAccesses type: #Number>
+	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
-	<MSEComment: 'The number of accesses from a method'>
+	<FMComment: 'The number of accesses from a method'>
 	
 	^ self 
 		lookUpPropertyNamed: #numberOfAccesses
@@ -227,9 +272,9 @@ FamixJavaMethod >> numberOfAccesses [
 
 { #category : #metrics }
 FamixJavaMethod >> numberOfAnnotationInstances [
-	<MSEProperty: #numberOfAnnotationInstances type: #Number>
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
 	<derived>
-	<MSEComment: 'The number of annotation instances defined in the method'>
+	<FMComment: 'The number of annotation instances defined in the method'>
 
 	^self
 		lookUpPropertyNamed: #numberOfAnnotationInstances
@@ -238,8 +283,8 @@ FamixJavaMethod >> numberOfAnnotationInstances [
 
 { #category : #accessing }
 FamixJavaMethod >> numberOfComments [
-	<MSEProperty: #numberOfComments type: #Number>
-	<MSEComment: 'The number of comment fragments'>
+	<FMProperty: #numberOfComments type: #Number>
+	<FMComment: 'The number of comment fragments'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
 ]
@@ -252,8 +297,8 @@ FamixJavaMethod >> numberOfComments: aNumber [
 
 { #category : #'Famix-Extensions-private' }
 FamixJavaMethod >> numberOfConditionals [
-	<MSEProperty: #numberOfConditionals type: #Number>
-	<MSEComment: 'The number of conditionals in a method'>
+	<FMProperty: #numberOfConditionals type: #Number>
+	<FMComment: 'The number of conditionals in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfConditionals
 		computedAs: [ 
@@ -268,22 +313,48 @@ FamixJavaMethod >> numberOfConditionals: aNumber [
 
 { #category : #'Famix-Extensions' }
 FamixJavaMethod >> numberOfInvokedMethods [
-	<MSEProperty: #numberOfInvokedMethods type: #Number>
-	<MSEComment: 'Return a number corresponding to the number of invoked methods'>
+	<FMProperty: #numberOfInvokedMethods type: #Number>
+	<FMComment: 'Return a number corresponding to the number of invoked methods'>
 	<derived>
 	
 	^ self privateState propertyAt: #numberOfInvokedMethods ifAbsentPut: [self invokedMethods size]
 ]
 
+{ #category : #metrics }
+FamixJavaMethod >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message from a method'>
+	^ self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [ self notExistentMetricValue ]
+]
+
 { #category : #'Famix-Extensions-private' }
 FamixJavaMethod >> numberOfOutgoingInvocations [
-	<MSEProperty: #numberOfOutgoingInvocations type: #Number>
+	<FMProperty: #numberOfOutgoingInvocations type: #Number>
 	<derived>
-	<MSEComment: 'The number of invocations in a method'>
+	<FMComment: 'The number of invocations in a method'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfOutgoingInvocations
 		computedAs: [self outgoingInvocations size]
+]
+
+{ #category : #accessing }
+FamixJavaMethod >> numberOfParameters [
+	<FMProperty: #numberOfParameters type: #Number>
+	<FMComment: 'The number of parameters in a method'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
+]
+
+{ #category : #metrics }
+FamixJavaMethod >> numberOfStatements [
+	<FMProperty: #numberOfStatements type: #Number>
+	<derived>
+	<FMComment: 'The number of statements in a class'>
+	^ self lookUpPropertyNamed: #numberOfStatements computedAs: [ (self toScope: FamixTWithStatements) detectSum: #numberOfStatements ]
 ]
 
 { #category : #'Famix-Implementation' }
@@ -308,8 +379,8 @@ FamixJavaMethod >> printOn: aStream [
 
 { #category : #'Famix-Extensions' }
 FamixJavaMethod >> providerBehaviours [
-	<MSEProperty: #providerBehaviours type: #FamixJavaMethod> <derived> <multivalued>
-	<MSEComment: 'All behaviours that the receiver depends on'>
+	<FMProperty: #providerBehaviours type: #FamixJavaMethod> <derived> <multivalued>
+	<FMComment: 'All behaviours that the receiver depends on'>
 
 	^ self invokedBehaviours 
 ]

--- a/src/Famix-Java-Entities/FamixJavaModel.class.st
+++ b/src/Famix-Java-Entities/FamixJavaModel.class.st
@@ -12,7 +12,7 @@ FamixJavaModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixJavaModel class >> annotation [
-	<MSEClass: #FamixJavaModel super: #MooseModel>
+	<FMClass: #FamixJavaModel super: #MooseModel>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 ]

--- a/src/Famix-Java-Entities/FamixJavaMultipleFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMultipleFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaMultipleFileAnchor class >> annotation [
 
-	<MSEClass: #MultipleFileAnchor super: #FamixJavaSourceAnchor>
+	<FMClass: #MultipleFileAnchor super: #FamixJavaSourceAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -18,6 +18,15 @@ FamixJavaMultipleFileAnchor class >> annotation [
 { #category : #'as yet unclassified' }
 FamixJavaMultipleFileAnchor >> addFileAnchorWithPath: aPath [
 	self allFiles detect: [ :each | each fileName = aPath ] ifNone: [ self createAnchorWithPath: aPath ]
+]
+
+{ #category : #accessing }
+FamixJavaMultipleFileAnchor >> allFiles [
+
+	<FMProperty: #allFiles type: #FamixTFileAnchor>
+	<multivalued>
+	<FMComment: 'All source code definition files'>
+	^ allFiles ifNil: [ allFiles := OrderedCollection new. ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaNamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixJavaSourcedEntity>
+	<FMClass: #NamedEntity super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -20,6 +20,91 @@ FamixJavaNamedEntity class >> requirements [
 
 	<generated>
 	^ { FamixJavaPackage }
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaNamedEntity >> isAbstract [
+	<FMProperty: #isAbstract type: #Boolean> <derived>
+	<FMComment: 'Flag true for abstract entities. Language dependent.'>
+	
+	^ self modifiers includes: #abstract
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaNamedEntity >> isFinal [
+	<FMProperty: #isFinal type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities defined as being final. Language dependent.'>	
+
+	^ self modifiers includes: #final
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaNamedEntity >> isPackage [
+	<FMProperty: #isPackage type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities that have a package visibility. Language dependent.'>
+	
+	^ self modifiers includes: #package
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaNamedEntity >> isPrivate [
+	<FMProperty: #isPrivate type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities invisible out of their owner scope. Language dependent.'>
+	
+	^ self modifiers includes: #private
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaNamedEntity >> isProtected [
+	<FMProperty: #isProtected type: #Boolean> <derived>
+	<FMComment: 'Flag true for protected entities, depending on language semantics.'>
+	
+	^ self modifiers includes: #protected
+]
+
+{ #category : #'Famix-Extensions' }
+FamixJavaNamedEntity >> isPublic [
+	<FMProperty: #isPublic type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities accessible from anywhere. Language dependent.'>	
+
+	^ self modifiers includes: #public
+]
+
+{ #category : #accessing }
+FamixJavaNamedEntity >> isStub [
+
+	<FMProperty: #isStub type: #Boolean>
+	<FMComment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'>
+	^ isStub ifNil: [ false ]
+]
+
+{ #category : #accessing }
+FamixJavaNamedEntity >> modifiers [
+
+	<FMProperty: #modifiers type: #String>
+	<multivalued>
+	<FMComment: 'Generic container for language dependent modifiers.'>
+	^ modifiers ifNil: [ modifiers := Set new ]
+]
+
+{ #category : #metrics }
+FamixJavaNamedEntity >> numberOfAnnotationInstances [
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
+	<derived>
+	<FMComment: 'The number of annotation instances defined in the class or in any of its methods'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAnnotationInstances
+		computedAs: [
+			self annotationInstances size + (self methods inject: 0 into: [:sum :each | sum + each numberOfAnnotationInstances])]
+]
+
+{ #category : #accessing }
+FamixJavaNamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaNamespace class >> annotation [
 
-	<MSEClass: #Namespace super: #FamixJavaScopingEntity>
+	<FMClass: #Namespace super: #FamixJavaScopingEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -19,9 +19,9 @@ FamixJavaNamespace class >> annotation [
 FamixJavaNamespace >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
 
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness of a namespace'>
+	<FMComment: 'Abstractness of a namespace'>
 	| nsClasses |
 	nsClasses := self allClasses.
 	nsClasses size == 0 ifTrue: [ ^ nil ].
@@ -37,9 +37,9 @@ FamixJavaNamespace >> abstractness: aNumber [
 
 { #category : #'as yet unclassified' }
 FamixJavaNamespace >> afferentCoupling [
-	<MSEProperty: #afferentCoupling type: #Number>
+	<FMProperty: #afferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Afferent Coupling of a namespace Afferent is the number of classes that depend upon this namespace'>
+	<FMComment: 'Afferent Coupling of a namespace Afferent is the number of classes that depend upon this namespace'>
 	^ ((self queryAllIncoming atScope: FamixTType) outOfParentUsing: FamixTNamespace) size
 ]
 
@@ -59,9 +59,9 @@ FamixJavaNamespace >> allParentsUpTo: aNamespace [
 FamixJavaNamespace >> bunchCohesion [
 	"Computing cohesion (Bunch formula)"
 
-	<MSEProperty: #bunchCohesion type: #Number>
+	<FMProperty: #bunchCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Bunch Cohesion of a namespace. It is also considered anonymous and inner classes.'>
+	<FMComment: 'Bunch Cohesion of a namespace. It is also considered anonymous and inner classes.'>
 	| myClasses intraConnectivities |
 	(myClasses := self classes) union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
 	myClasses size == 0
@@ -135,9 +135,9 @@ FamixJavaNamespace >> containedEntities: collection [
 { #category : #'as yet unclassified' }
 FamixJavaNamespace >> distance [
 	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
-	<MSEProperty: #distance type: #Number>
+	<FMProperty: #distance type: #Number>
 	<derived>
-	<MSEComment: 'Distance of a namespace'>
+	<FMComment: 'Distance of a namespace'>
 
 	| abstractness instability |
 	abstractness := self abstractness.
@@ -157,9 +157,9 @@ FamixJavaNamespace >> distance: aNumber [
 FamixJavaNamespace >> efferentCoupling [
 	"Efferent coupling for a module is the number of classes it depends upon"
 
-	<MSEProperty: #efferentCoupling type: #Number>
+	<FMProperty: #efferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Efferent coupling for a module is the number of classes it depends upon'>
+	<FMComment: 'Efferent coupling for a module is the number of classes it depends upon'>
 	^ ((self queryOutgoingDependencies outOfParentUsing: FamixTNamespace) atScope: FamixTType) size
 ]
 
@@ -172,9 +172,9 @@ FamixJavaNamespace >> efferentCoupling: aNumber [
 { #category : #'as yet unclassified' }
 FamixJavaNamespace >> instability [
 	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
-	<MSEProperty: #instability type: #Number>
+	<FMProperty: #instability type: #Number>
 	<derived>
-	<MSEComment: 'Instability of a namespace'>
+	<FMComment: 'Instability of a namespace'>
 	
 	| efferentCoupling afferentCoupling |
 	
@@ -199,9 +199,9 @@ FamixJavaNamespace >> isNamespace [
 FamixJavaNamespace >> martinCohesion [
 	"Computing cohesion as described by Robert C. Martin"
 
-	<MSEProperty: #martinCohesion type: #Number>
+	<FMProperty: #martinCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Cohesion as defined by Robert C. Martin.'>
+	<FMComment: 'Cohesion as defined by Robert C. Martin.'>
 	| intraConnectivities myClasses |
 	myClasses := self classes.
 	myClasses := myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
@@ -227,9 +227,9 @@ FamixJavaNamespace >> numberOfAttributes [
 "	<property: #NOA longName: 'Number of attributes' description:
 			'The number of attributes in a namespace'>"
 
-	<MSEProperty: #numberOfAttributes type: #Number>
+	<FMProperty: #numberOfAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of attributes in a namespace'>
+	<FMComment: 'The number of attributes in a namespace'>
 	
 	^ self
 		lookUpPropertyNamed: #numberOfAttributes
@@ -244,9 +244,9 @@ FamixJavaNamespace >> numberOfAttributes: aNumber [
 
 { #category : #'Famix-Extensions' }
 FamixJavaNamespace >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
+	<FMProperty: #numberOfClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes in a namespace'>
+	<FMComment: 'The number of classes in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfClasses
@@ -261,9 +261,9 @@ FamixJavaNamespace >> numberOfClasses: aNumber [
 
 { #category : #'Famix-Implementation' }
 FamixJavaNamespace >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines of code in a namespace'>
+	<FMComment: 'The number of lines of code in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfLinesOfCode
@@ -280,9 +280,9 @@ FamixJavaNamespace >> numberOfLinesOfCode: aNumber [
 
 { #category : #accessing }
 FamixJavaNamespace >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
+	<FMProperty: #numberOfMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a namespace'>
+	<FMComment: 'The number of methods in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfMethods
@@ -297,9 +297,9 @@ FamixJavaNamespace >> numberOfMethods: aNumber [
 
 { #category : #'Famix-Extensions-metrics' }
 FamixJavaNamespace >> numberOfNonInterfacesClasses [
-	<MSEProperty: #numberOfNonInterfacesClasses type: #Number>
+	<FMProperty: #numberOfNonInterfacesClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of non interfaces classes in a namespace'>
+	<FMComment: 'The number of non interfaces classes in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfNonInterfacesClasses

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaPackage class >> annotation [
 
-	<MSEClass: #Package super: #FamixJavaScopingEntity>
+	<FMClass: #Package super: #FamixJavaScopingEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -25,9 +25,9 @@ FamixJavaPackage >> abstractClasses [
 FamixJavaPackage >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
 
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness of a package'>
+	<FMComment: 'Abstractness of a package'>
 	| nsClasses |
 	nsClasses := self allClasses.
 	nsClasses size == 0 ifTrue: [ ^ nil ].
@@ -44,9 +44,9 @@ FamixJavaPackage >> addChildNamedEntity: aNamedEntity [
 FamixJavaPackage >> afferentCoupling [
 	"Afferent coupling for a package is the number of classes that depend upon this package"
 
-	<MSEProperty: #afferentCoupling type: #Number>
+	<FMProperty: #afferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Afferent Coupling of a package'>
+	<FMComment: 'Afferent Coupling of a package'>
 	^ ((self queryIncomingDependencies atScope: FamixTType) outOfParentUsing: FamixTPackage) size
 ]
 
@@ -60,9 +60,9 @@ FamixJavaPackage >> allClasses [
 FamixJavaPackage >> bunchCohesion [
 	"Computing cohesion (Bunch formula)"
 
-	<MSEProperty: #bunchCohesion type: #Number>
+	<FMProperty: #bunchCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Bunch Cohesion of a package. It is also considered anonymous and inner classes (in Java).'>
+	<FMComment: 'Bunch Cohesion of a package. It is also considered anonymous and inner classes (in Java).'>
 	| myClasses intraConnectivities |
 	myClasses := self classes.
 	myClasses := myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
@@ -133,9 +133,9 @@ FamixJavaPackage >> containedEntities: collection [
 { #category : #'as yet unclassified' }
 FamixJavaPackage >> distance [
 	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
-	<MSEProperty: #distance type: #Number>
+	<FMProperty: #distance type: #Number>
 	<derived>
-	<MSEComment: 'Distance of a package'>
+	<FMComment: 'Distance of a package'>
 
 	
 	| abstractness instability |
@@ -151,9 +151,9 @@ FamixJavaPackage >> distance [
 FamixJavaPackage >> efferentCoupling [
 	"Efferent coupling for a package is the number of classes it depends upon"
 
-	<MSEProperty: #efferentCoupling type: #Number>
+	<FMProperty: #efferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Efferent Coupling of a package'>
+	<FMComment: 'Efferent Coupling of a package'>
 	^ ((self queryAllOutgoing outOfParentUsing: FamixTPackage) atScope: FamixTType) size
 ]
 
@@ -161,9 +161,9 @@ FamixJavaPackage >> efferentCoupling [
 FamixJavaPackage >> instability [
 	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
 
-	<MSEProperty: #instability type: #Number>
+	<FMProperty: #instability type: #Number>
 	<derived>
-	<MSEComment: 'Instability of a package'>
+	<FMComment: 'Instability of a package'>
 
 	| efferentCoupling afferentCoupling |
 	
@@ -177,9 +177,9 @@ FamixJavaPackage >> instability [
 FamixJavaPackage >> martinCohesion [
 	"Computing cohesion as described by Robert C. Martin"
 
-	<MSEProperty: #martinCohesion type: #Number>
+	<FMProperty: #martinCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Cohesion as defined by Robert C. Martin.'>
+	<FMComment: 'Cohesion as defined by Robert C. Martin.'>
 	| intraConnectivities myClasses |
 	myClasses := self classes.
 	myClasses := myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ]).
@@ -195,17 +195,17 @@ FamixJavaPackage >> methods [
 
 { #category : #'Famix-Extensions' }
 FamixJavaPackage >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
+	<FMProperty: #numberOfClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes in a package'>
+	<FMComment: 'The number of classes in a package'>
 	
 	^ self classes size
 ]
 
 { #category : #accessing }
 FamixJavaPackage >> numberOfClientPackages [
-	<MSEProperty: #numberOfClientPackages type: #Number>
-	<MSEComment: 'The number of packages which depend on this package'>
+	<FMProperty: #numberOfClientPackages type: #Number>
+	<FMComment: 'The number of packages which depend on this package'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfClientPackages computedAs: [ self allClients size ]
 ]
@@ -218,9 +218,9 @@ FamixJavaPackage >> numberOfClientPackages: aNumber [
 
 { #category : #'Famix-Implementation' }
 FamixJavaPackage >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines of code in a namespace'>
+	<FMComment: 'The number of lines of code in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfLinesOfCode
@@ -236,8 +236,8 @@ FamixJavaPackage >> numberOfLinesOfCode: aNumber [
 
 { #category : #accessing }
 FamixJavaPackage >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
-	<MSEComment: 'The number of methods in a package'>
+	<FMProperty: #numberOfMethods type: #Number>
+	<FMComment: 'The number of methods in a package'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #numberOfMethods
@@ -264,9 +264,9 @@ FamixJavaPackage >> printOn: aStream [
 
 { #category : #'Famix-Extensions-metrics' }
 FamixJavaPackage >> relativeImportanceForSystem [
-	<MSEProperty: #relativeImportanceForSystem type: #Number>
+	<FMProperty: #relativeImportanceForSystem type: #Number>
 	<derived>
-	<MSEComment: 'The number of client packages normalized by the total number of packages'>
+	<FMComment: 'The number of client packages normalized by the total number of packages'>
 	
 	^ self lookUpPropertyNamed: #relativeImportanceForSystem
 				 computedAs: [
@@ -276,4 +276,12 @@ FamixJavaPackage >> relativeImportanceForSystem [
 							]
 						ifFalse: [0]
 						]
+]
+
+{ #category : #metrics }
+FamixJavaPackage >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<FMComment: 'The sum of the complexity in a package'>
+	<derived>
+	^ self lookUpPropertyNamed: #WMC computedAs: [ (self toScope: FamixTWithMethods) detectSum: #weightedMethodCount ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -9,10 +9,18 @@ Class {
 { #category : #meta }
 FamixJavaParameter class >> annotation [
 
-	<MSEClass: #Parameter super: #FamixJavaNamedEntity>
+	<FMClass: #Parameter super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixJavaParameter >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #'as yet unclassified' }
@@ -23,6 +31,61 @@ FamixJavaParameter >> mooseNameOn: stream [
 		[ parent mooseNameOn: stream.
 		stream nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
+]
+
+{ #category : #accessing }
+FamixJavaParameter >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaParameter >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaParameter >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaParameter >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaParameter >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaParameterType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaParameterType class >> annotation [
 
-	<MSEClass: #ParameterType super: #FamixJavaType>
+	<FMClass: #ParameterType super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaParameterizableClass class >> annotation [
 
-	<MSEClass: #ParameterizableClass super: #FamixJavaClass>
+	<FMClass: #ParameterizableClass super: #FamixJavaClass>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -17,8 +17,8 @@ FamixJavaParameterizableClass class >> annotation [
 
 { #category : #'as yet unclassified' }
 FamixJavaParameterizableClass >> parameters [
-	<MSEProperty: #parameters type: #FamixJavaParameterType> <multivalued> <derived>
-	<MSEComment: 'Parameter types of this class.'>
+	<FMProperty: #parameters type: #FamixJavaParameterType> <multivalued> <derived>
+	<FMComment: 'Parameter types of this class.'>
 	
 	^self types select: [:each | each isParameterType]
 ]

--- a/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaParameterizedType class >> annotation [
 
-	<MSEClass: #ParameterizedType super: #FamixJavaType>
+	<FMClass: #ParameterizedType super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixJavaPrimitiveType class >> annotation [
 
-	<MSEClass: #PrimitiveType super: #FamixJavaType>
+	<FMClass: #PrimitiveType super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaReference class >> annotation [
 
-	<MSEClass: #Reference super: #FamixJavaAssociation>
+	<FMClass: #Reference super: #FamixJavaAssociation>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaScopingEntity class >> annotation [
 
-	<MSEClass: #ScopingEntity super: #FamixJavaContainerEntity>
+	<FMClass: #ScopingEntity super: #FamixJavaContainerEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaSourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixJavaEntity>
+	<FMClass: #SourceAnchor super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -40,9 +40,9 @@ FamixJavaSourceAnchor >> isFile [
 FamixJavaSourceAnchor >> lineCount [
 	"I should return the number of line in the source text of the entity."
 
-	<MSEProperty: #lineCount type: #Number>
+	<FMProperty: #lineCount type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines in the source text'>
+	<FMComment: 'The number of lines in the source text'>
 	^ self subclassResponsibility
 ]
 

--- a/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaSourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixJavaEntity>
+	<FMClass: #SourceLanguage super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -28,9 +28,9 @@ FamixJavaSourceLanguage >> isJava [
 { #category : #'as yet unclassified' }
 FamixJavaSourceLanguage >> name [
 	
-	<MSEProperty: #name type: #String> 
+	<FMProperty: #name type: #String> 
 	<derived>
-	<MSEComment: 'The name of the language'>
+	<FMComment: 'The name of the language'>
 	
 	^ 'Java'
 ]

--- a/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaSourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixJavaSourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixJavaSourceAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaSourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixJavaEntity>
+	<FMClass: #SourcedEntity super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -63,15 +63,49 @@ FamixJavaSourcedEntity >> fileAnchorPath: aString startPos: anInteger endPos: an
 				model: self mooseModel)
 ]
 
+{ #category : #accessing }
+FamixJavaSourcedEntity >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
 { #category : #'as yet unclassified' }
 FamixJavaSourcedEntity >> numberOfJavaNullChecks [
-	<MSEProperty: #numberOfJavaNullChecks type: #Number> <derived>
+	<FMProperty: #numberOfJavaNullChecks type: #Number> <derived>
 	^self
 		lookUpPropertyNamed: #numberOfJavaNullChecks
 		computedAs: [
 			| nullCheckTextPatterns |
 			nullCheckTextPatterns := #('== null' '!= null' 'null ==' 'null !=').
 			(self sourceText allRegexMatches: ( '|' join: nullCheckTextPatterns)) size ]
+]
+
+{ #category : #'Famix-Implementation' }
+FamixJavaSourcedEntity >> numberOfLinesOfCode [
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
+	^ self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [ self computeNumberOfLinesOfCode ]
+]
+
+{ #category : #metrics }
+FamixJavaSourcedEntity >> numberOfLinesOfCodeWithMoreThanOneCharacter [
+	<FMProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number> <derived>
+	<FMComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
+	the difference being that it only counts the lines with more than one non-whitespace characters.
+	This metric is particularly useful for comparing the density of other metrics on a line of code.
+	For example, depending on the formatting style chosen a Java curly brace, or a Smalltalk block 
+	can appear inline or on a separate line. For normalization purposes, these commonly appearing 
+	cases can be ruled out through the present metric.'>
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCodeWithMoreThanOneCharacter
+		computedAs: [			
+			(self sourceText lines select: [ :line |
+				line trimBoth size > 1 ]) size ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-Java-Entities/FamixJavaTStructuralEntity.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTStructuralEntity.trait.st
@@ -8,8 +8,71 @@ Trait {
 { #category : #meta }
 FamixJavaTStructuralEntity classSide >> annotation [
 
-	<MSEClass: #TStructuralEntity super: #Object>
+	<FMClass: #TStructuralEntity super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixJavaTStructuralEntity >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
+{ #category : #accessing }
+FamixJavaTStructuralEntity >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaTStructuralEntity >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixJavaTStructuralEntity >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixJavaTStructuralEntity >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixJavaTStructuralEntity >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-Java-Entities/FamixJavaThrownException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaThrownException.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaThrownException class >> annotation [
 
-	<MSEClass: #ThrownException super: #FamixJavaException>
+	<FMClass: #ThrownException super: #FamixJavaException>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaType class >> annotation [
 
-	<MSEClass: #Type super: #FamixJavaContainerEntity>
+	<FMClass: #Type super: #FamixJavaContainerEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -48,6 +48,14 @@ FamixJavaType >> anySuperclass [
 	^ nil
 ]
 
+{ #category : #metrics }
+FamixJavaType >> fanIn [
+	<FMProperty: #fanIn type: #Number>
+	<derived>
+	<FMComment: 'Number of client classes'>
+	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
+]
+
 { #category : #testing }
 FamixJavaType >> hasMethodWithSignature: aStringOrSymbol [
 	| symbol |
@@ -58,6 +66,26 @@ FamixJavaType >> hasMethodWithSignature: aStringOrSymbol [
 { #category : #testing }
 FamixJavaType >> hasMethodsAnnotatedWith: aString [
 	^ self methods anySatisfy: [ :each | each isAnnotatedWith: aString ]
+]
+
+{ #category : #metrics }
+FamixJavaType >> hierarchyNestingLevel [
+	<FMProperty: #hierarchyNestingLevel type: #Number>
+	<derived>
+	<FMComment: 'The nesting of a class inside the hierarchy'>
+
+	^self
+		lookUpPropertyNamed: #hierarchyNestingLevel
+		computedAs:
+			[| currentMaxDepth |
+			(self directSuperclasses isEmpty or: [self isStub])
+				ifTrue: [0]
+				ifFalse:
+					[currentMaxDepth := 0.
+					self
+						allSuperclassesDo:
+							[:aClass | currentMaxDepth := currentMaxDepth max: aClass hierarchyNestingLevel].
+					currentMaxDepth + 1]]
 ]
 
 { #category : #'Famix-Implementation' }
@@ -91,8 +119,8 @@ FamixJavaType >> incomingAccesses [
 
 { #category : #'Famix-Extensions' }
 FamixJavaType >> isAbstract [
-	<MSEProperty: #isAbstract type: #Boolean> <derived>
-	<MSEComment: 'Flag true for abstract classes.'>
+	<FMProperty: #isAbstract type: #Boolean> <derived>
+	<FMComment: 'Flag true for abstract classes.'>
 	
 	^super isAbstract
 ]
@@ -107,9 +135,9 @@ FamixJavaType >> isAnonymousClass [
 
 { #category : #testing }
 FamixJavaType >> isInnerClass [
-	<MSEProperty: #isInnerClass type: #Boolean>
+	<FMProperty: #isInnerClass type: #Boolean>
 	<derived>
-	<MSEComment:
+	<FMComment:
 		'True if the method is considered as an innerclass (i.e. is contained elsewhere than a java package: class, method, enum,...)'>
 	^ self container ifNotNil: [ :c | c isNamespace not ] ifNil: [ false ]
 ]
@@ -126,9 +154,9 @@ FamixJavaType >> isJUnit3TestCase [
 
 { #category : #testing }
 FamixJavaType >> isJUnit4TestCase [
-	<MSEProperty: #isJUnit4TestCase type: #Boolean>
+	<FMProperty: #isJUnit4TestCase type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Junit 4 Java test'>
+	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
 	^ self methods anySatisfy: [ :m | m isJUnit4Test ]
 ]
 
@@ -150,9 +178,9 @@ FamixJavaType >> isParameterizedType [
 
 { #category : #testing }
 FamixJavaType >> isTestCase [
-	<MSEProperty: #isTestCase type: #Boolean>
+	<FMProperty: #isTestCase type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Java test'>
+	<FMComment: 'True if the method is considered as a Java test'>
 	^ self isJUnit3TestCase or: [ self isJUnit4TestCase ] 
 ]
 
@@ -177,6 +205,229 @@ FamixJavaType >> lookUp: aMethodSignature [
 	^searchedM
 ]
 
+{ #category : #metrics }
+FamixJavaType >> numberOfAbstractMethods [
+	<FMProperty: #numberOfAbstractMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of abstract methods in the class'>
+	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfAccessesToForeignData [
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
+	<derived>
+	<FMComment: 'Number of accesses to foreign data'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessesToForeignData
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfAccessorMethods [
+	<FMProperty: #numberOfAccessorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of accessor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfAccessorMethods
+		computedAs: [ 
+			| noa |
+			noa := 0.
+			self methods
+				do: [ :method | 
+					method isPureAccessor
+						ifNotNil: [ 
+							(method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNil not ])
+								ifTrue: [ noa := noa + 1 ] ] ].
+			noa ]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfAttributesInherited [
+	<FMProperty: #numberOfAttributesInherited type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in a class inherited from super classes'>	
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributesInherited
+		computedAs: [self inheritedAttributes size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfDirectSubclasses [
+	<FMProperty: #numberOfDirectSubclasses type: #Number>
+	<FMComment: 'The number of direct subclasses'>
+	<derived>
+
+	^ self privateState propertyAt: #numberOfDirectSubclasses ifAbsentPut: [self directSubclasses size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfDuplicatedLinesOfCodeInternally [
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<derived>
+	<FMComment: 'The number of duplicated lines of code internally'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfLinesOfCode [
+
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<derived>
+	<FMComment: 'The number of lines of code in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [self methodsGroup sumNumbers: #numberOfLinesOfCode]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message sends from a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfMethodProtocols [
+	<FMProperty: #numberOfMethodProtocols type: #Number>
+	<derived>
+	<FMComment: 'The number of method protocols in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodProtocols
+		computedAs: [((self methods collect: [:each | each protocol]) reject: #isNil) asSet size]
+]
+
+{ #category : #accessing }
+FamixJavaType >> numberOfMethods [
+	<FMProperty: #numberOfMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfMethods
+		computedAs: [self methods size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfMethodsAdded [
+	<FMProperty: #numberOfMethodsAdded type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class added with respect to super classes'>	
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodsAdded
+		computedAs: [self addedMethods size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfMethodsInHierarchy [
+	<FMProperty: #numberOfMethodsInHierarchy type: #Number>
+	<derived>
+	<FMComment: 'The number of methods of a class included the inherited ones'>	
+	
+	| totNom |
+	totNom := self methods size.
+	self superclassHierarchyGroup
+		do: [:aClass | totNom := totNom + aClass methods size].
+	^totNom
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfMethodsInherited [
+	<FMProperty: #numberOfMethodsInherited type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class inherited from super classes'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfMethodsInherited
+		computedAs: [self inheritedMethods size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfMethodsOverriden [
+	<FMProperty: #numberOfMethodsOverriden type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class overriden with respect to super classes'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfMethodsOverriden
+		computedAs: [self numberOfMethods - self numberOfMethodsAdded]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfParents [
+	<FMProperty: #numberOfParents type: #Number>
+	<derived>
+	<FMComment: 'The number of superclasses'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfParents
+		computedAs: [self directSuperclasses size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfPrivateMethods [
+	<FMProperty: #numberOfPrivateMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of private methods in a class'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfPrivateMethods
+		computedAs: [(self methods select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfProtectedMethods [
+	<FMProperty: #numberOfProtectedMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of protected methods in a class'>		
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedMethods
+		computedAs: [(self methods select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixJavaType >> numberOfPublicMethods [
+	<FMProperty: #numberOfPublicMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of public methods in a class'>		
+		
+	^self
+		lookUpPropertyNamed: #numberOfPublicMethods
+		computedAs: [(self methods select: [:each | each isPublic]) size]
+]
+
 { #category : #accessing }
 FamixJavaType >> parentScope [
 	"Polymorphic alias to mimic GlobalVariable#parentScope and similar"
@@ -197,6 +448,73 @@ FamixJavaType >> printOn: aStream [
 		nextPut: $)
 ]
 
+{ #category : #metrics }
+FamixJavaType >> subclassHierarchyDepth [ 
+	<FMProperty: #subclassHierarchyDepth type: #Number>
+	<derived>
+	<FMComment: 'The depth of the class hierarchy for which I am the root'>
+		
+	^ self directSubclasses isEmpty 
+		ifTrue: [ 0 ] 
+		ifFalse: 
+			[ | currentMaxDepth| 
+				currentMaxDepth := 0. 
+				self allSubclassesDo: 
+					[ :aClass | currentMaxDepth := currentMaxDepth max: aClass subclassHierarchyDepth ]. 
+            1 + currentMaxDepth ] 
+]
+
+{ #category : #metrics }
+FamixJavaType >> tightClassCohesion [
+	<FMProperty: #tightClassCohesion type: #Number>
+	<derived>
+	<FMComment: 'Tight class cohesion of a class'>
+	self flag: #TODO.
+	^ self
+		lookUpPropertyNamed: #tightClassCohesion
+		computedAs: [ 
+			| tcc accessDictionary nom |
+			tcc := 0.
+			accessDictionary := Dictionary new.
+			self
+				methods do: [ :eachMethod | 
+					eachMethod accesses
+						do: [ :eachAccess | 
+							| var |
+							var := eachAccess variable.
+							var isAttribute
+								ifTrue: [ 
+									| varName accessedFrom |
+									varName := var name.
+									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
+									accessedFrom isNil
+										ifTrue: [ 
+											accessedFrom := Set new.
+											accessDictionary at: varName put: accessedFrom ].
+									accessedFrom add: eachMethod name ] ] ].
+			accessDictionary values
+				do: [ :each | 
+					| size |
+					size := each size.
+					tcc := tcc + (size * (size - 1) / 2) ].
+			nom := self numberOfMethods.
+			tcc := (nom = 0 or: [ nom = 1 ])
+				ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				ifTrue: [ 0 ].
+			tcc asFloat ]
+]
+
+{ #category : #metrics }
+FamixJavaType >> totalNumberOfChildren [
+	<FMProperty: #totalNumberOfChildren type: #Number>
+	<derived>	
+	<FMComment: 'The total number of subclasses of a class'>
+	
+	^self
+		lookUpPropertyNamed: #totalNumberOfChildren
+		computedAs: [self subclassHierarchyGroup size]
+]
+
 { #category : #'Famix-Implementation' }
 FamixJavaType >> understands: signature [
 	"returns true if a class is able to respond to an invocation to aSignature on itself; false otherwise"
@@ -204,6 +522,17 @@ FamixJavaType >> understands: signature [
 	self withSuperclassesDo: [:each | 
 		(each implements: signature) ifTrue: [^true]].
 	^false
+]
+
+{ #category : #metrics }
+FamixJavaType >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<derived>
+	<FMComment: 'The sum of the complexity in a class'>
+			
+	^self
+		lookUpPropertyNamed: #weightedMethodCount
+		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaUnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixJavaSourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixJavaSourceLanguage>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
@@ -18,9 +18,9 @@ FamixJavaUnknownSourceLanguage class >> annotation [
 { #category : #'as yet unclassified' }
 FamixJavaUnknownSourceLanguage >> name [
 	
-	<MSEProperty: #name type: #String> 
+	<FMProperty: #name type: #String> 
 	<derived>
-	<MSEComment: 'The name of the language'>
+	<FMComment: 'The name of the language'>
 	
 	^ 'Unknown'
 ]

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaUnknownVariable class >> annotation [
 
-	<MSEClass: #UnknownVariable super: #FamixJavaNamedEntity>
+	<FMClass: #UnknownVariable super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -248,7 +248,7 @@ FamixMetamodelBuilder >> generateMooseModel [
 			model classSide
 				compile:
 					('annotation
-	<MSEClass: #{1} super: #MooseModel>
+	<FMClass: #{1} super: #MooseModel>
 	<package: {2}>
 	<generated>' format: {mooseModelName . self safeAnnotationPackageName})
 				classified: 'meta'.

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -186,7 +186,7 @@ FmxMBBehavior >> generateAnnotationIn: aRealClass as: aName superclass: aSupercl
 		compile:
 			('annotation
 
-	<MSEClass: #{1} super: #{2}>
+	<FMClass: #{1} super: #{2}>
 	<package: {3}>
 	<generated>
 	^self' format: {aName . aSuperclassName . self builder safeAnnotationPackageName})

--- a/src/Famix-MetamodelBuilder-Core/FmxMBNonremoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBNonremoteRelationSideGenerationStrategy.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #printing }
 FmxMBNonRemoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
 
-	 aStream tab; nextPutAll: ('<MSEProperty: #{1} type: #{2} opposite: #{3}>' format: {aRelationSide name. aRelationSide oppositeType. aRelationSide oppositeName}).
+	 aStream tab; nextPutAll: ('<FMProperty: #{1} type: #{2} opposite: #{3}>' format: {aRelationSide name. aRelationSide oppositeType. aRelationSide oppositeName}).
     aStream cr.
 	
 	aRelationSide remoteBuilderDo: [ :aRemoteBuilder |

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideGenerationStrategy.class.st
@@ -35,7 +35,7 @@ FmxMBRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: a
 { #category : #generation }
 FmxMBRelationSideGenerationStrategy >> generateGetterIn: aClassOrTrait for: aRelationSide [
 	| methodSource commentDefinition |
-	commentDefinition := aRelationSide comment ifNotEmpty: [ :comment | '<MSEComment: {1}>' format: {comment printString} ].
+	commentDefinition := aRelationSide comment ifNotEmpty: [ :comment | '<FMComment: {1}>' format: {comment printString} ].
 
 	methodSource := String
 		streamContents: [ :s | 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
@@ -26,11 +26,11 @@ FmxMBTypedProperty >> generateGetterIn: aClassOrTrait [
 
 	| methodSource propertyDefinition commentDefinition |
 
-	propertyDefinition := '<MSEProperty: #{1} type: #{2}>' 
+	propertyDefinition := '<FMProperty: #{1} type: #{2}>' 
 		format: { self name. self propertyType }.
 
 	commentDefinition := self comment
-		ifNotEmpty: [ '<MSEComment: {1}>' format: { self comment printString } ].
+		ifNotEmpty: [ '<FMComment: {1}>' format: { self comment printString } ].
 
 	methodSource := String streamContents: [ :s |
 		s nextPutAll: self name; cr; cr.

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorAliasTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorAliasTest.class.st
@@ -31,7 +31,7 @@ FmxMBBehaviorAliasTest >> testClassPropertyWithType [
 	
 	generated := builder testingEnvironment ask classNamed: 'TstNamed'.
 	method := generated instanceSide methodNamed: #name.
-	self assert: (method sourceCode includesSubstring: '<MSEProperty: #name type: #String>').
+	self assert: (method sourceCode includesSubstring: '<FMProperty: #name type: #String>').
 	self assert: (method sourceCode includesSubstring: '<generated>').
 	method := generated instanceSide methodNamed: #name:.
 	self assert: (method sourceCode includesSubstring: 'name := ').
@@ -63,7 +63,7 @@ FmxMBBehaviorAliasTest >> testTraitPropertyWithType [
 	
 	generated := builder testingEnvironment ask classNamed: 'TstTNamed'.
 	method := generated instanceSide methodNamed: #name.
-	self assert: (method sourceCode includesSubstring: '<MSEProperty: #name type: #String>').
+	self assert: (method sourceCode includesSubstring: '<FMProperty: #name type: #String>').
 	self assert: (method sourceCode includesSubstring: '<generated>').
 	method := generated instanceSide methodNamed: #name:.
 	self assert: (method sourceCode includesSubstring: 'name := ').

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassGeneralizationsTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassGeneralizationsTest.class.st
@@ -23,7 +23,7 @@ FmxMBClassGeneralizationsTest >> checkGeneralizationWithAnnotations [
 	
 	self assert: generatedClass superclass equals: generatedBehavior.
 	annotation := generatedClass classSide methodNamed: #annotation.
-	self assert: (annotation sourceCode includesSubstring: '<MSEClass: #Class super: #TstBehavior>').
+	self assert: (annotation sourceCode includesSubstring: '<FMClass: #Class super: #TstBehavior>').
 	self assert: (annotation sourceCode includesSubstring: '<generated>').
 	
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
@@ -21,7 +21,7 @@ FmxMBClassTest >> checkGeneralizationWithAnnotations [
 	
 	self assert: generatedClass superclass equals: generatedBehavior.
 	annotation := generatedClass classSide methodNamed: #annotation.
-	self assert: (annotation sourceCode includesSubstring: '<MSEClass: #Class super: #TstBehavior>').
+	self assert: (annotation sourceCode includesSubstring: '<FMClass: #Class super: #TstBehavior>').
 	self assert: (annotation sourceCode includesSubstring: '<generated>').
 	
 
@@ -72,11 +72,11 @@ FmxMBClassTest >> testAsPropertyComment [
 	self assertCollection: (generatedTrait slots collect: #name) hasSameElements: #(from to).
 
 	method := generatedTrait methodNamed: #from.
-	self assert: (method sourceCode includesSubstring: '<MSEComment: ''comment from''>').
+	self assert: (method sourceCode includesSubstring: '<FMComment: ''comment from''>').
 	self assert: (method sourceCode includesSubstring: '<generated>').
 
 	method := generatedTrait methodNamed: #to.
-	self assert: (method sourceCode includesSubstring: '<MSEComment: ''comment to''>').
+	self assert: (method sourceCode includesSubstring: '<FMComment: ''comment to''>').
 	self assert: (method sourceCode includesSubstring: '<generated>').
 
 
@@ -423,7 +423,7 @@ FmxMBClassTest >> testSimpleClassAnnotation [
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
 	method := generated classSide methodNamed: #annotation.
-	self assert: (method sourceCode includesSubstring: '<MSEClass: #Comment super: #MooseEntity>').
+	self assert: (method sourceCode includesSubstring: '<FMClass: #Comment super: #MooseEntity>').
 	self assert: (method sourceCode includesSubstring: '<generated>').
 	self assert: (method sourceCode includesSubstring: '<package: #Tst>').
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -61,7 +61,7 @@ FmxMBGeneratorCleaningStrategyTest >> generateClasses [
 		compile:
 			'annotation
 
-	<MSEClass: #AddedClassFromFamix super: #MooseEntity>
+	<FMClass: #AddedClassFromFamix super: #MooseEntity>
 	<package: #'',  self packageName , ''>
 	<generated>
 	^self'.
@@ -76,7 +76,7 @@ FmxMBGeneratorCleaningStrategyTest >> generateClasses [
 		compile:
 			'annotation
 
-	<MSEClass: #TAddedClassFromFamix super: #Trait>
+	<FMClass: #TAddedClassFromFamix super: #Trait>
 	<package: #'',  self packageName , ''>
 	<generated>
 	^self'.

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
@@ -304,7 +304,7 @@ FmxMBTraitTest >> testSimpleClassAnnotation [
 	generated := builder testingEnvironment ask classNamed: 'TstTComment'.
 
 	method := generated classSide methodNamed: #annotation.
-	self assert: (method sourceCode includesSubstring: '<MSEClass: #TComment super: #Object>').
+	self assert: (method sourceCode includesSubstring: '<FMClass: #TComment super: #Object>').
 	self assert: (method sourceCode includesSubstring: '<package: #Tst>').
 
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -9,10 +9,35 @@ Class {
 { #category : #meta }
 FamixStAccess class >> annotation [
 
-	<MSEClass: #Access super: #FamixStAssociation>
+	<FMClass: #Access super: #FamixStAssociation>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixStAccess >> isRead [
+	<FMProperty: #isRead type: #Boolean> <derived>
+	<FMComment: 'Read access'>
+	
+	^ isWrite isNil ifTrue: [ false ] ifFalse: [ isWrite not ]
+]
+
+{ #category : #accessing }
+FamixStAccess >> isReadWriteUnknown [
+	<FMProperty: #isReadWriteUnknown type: #Boolean> <derived>
+	<FMComment: ''>
+	
+	^ isWrite isNil
+]
+
+{ #category : #accessing }
+FamixStAccess >> isWrite [
+
+	<FMProperty: #isWrite type: #Boolean> 
+	<derived>
+	<FMComment: 'Write access'>
+	^ isWrite ifNil: [ false ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStAnnotationInstance class >> annotation [
 
-	<MSEClass: #AnnotationInstance super: #FamixStSourcedEntity>
+	<FMClass: #AnnotationInstance super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -29,4 +29,12 @@ FamixStAnnotationInstance >> name [
 			stream << '@'
 				<< (self annotationType ifNil: [ super name ] ifNotNil: [ :type | type name ])
 				<< ' on ' << (self annotatedEntity ifNotNil: #name ifNil: [ 'undefined' ]) ]
+]
+
+{ #category : #accessing }
+FamixStAnnotationInstance >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStAnnotationInstanceAttribute class >> annotation [
 
-	<MSEClass: #AnnotationInstanceAttribute super: #FamixStSourcedEntity>
+	<FMClass: #AnnotationInstanceAttribute super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -27,4 +27,12 @@ FamixStAnnotationInstanceAttribute >> name [
 	^ self annotationTypeAttribute notNil 
 		ifTrue: [ self annotationTypeAttribute name ]
 		ifFalse: [ nil ]
+]
+
+{ #category : #accessing }
+FamixStAnnotationInstanceAttribute >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStAnnotationType class >> annotation [
 
-	<MSEClass: #AnnotationType super: #FamixStContainerEntity>
+	<FMClass: #AnnotationType super: #FamixStContainerEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -31,4 +31,60 @@ FamixStAnnotationType >> directSubclasses [
 FamixStAnnotationType >> hierarchyNestingLevel [ 
 
 	^ 1
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStAnnotationType >> numberOfAttributes [
+	<FMProperty: #numberOfAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in the class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributes
+		computedAs: [self attributes size]
+]
+
+{ #category : #metrics }
+FamixStAnnotationType >> numberOfPrivateAttributes [
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of private attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPrivateAttributes
+		computedAs: [(self attributes select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixStAnnotationType >> numberOfProtectedAttributes [
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of protected attributes in a class'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedAttributes
+		computedAs: [(self attributes select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixStAnnotationType >> numberOfPublicAttributes [
+	<FMProperty: #numberOfPublicAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPublicAttributes
+		computedAs: [(self attributes select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixStAnnotationType >> numberOfRevealedAttributes [
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfRevealedAttributes
+		computedAs:
+			[self numberOfPublicAttributes + self numberOfAccessorMethods]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStAnnotationTypeAttribute class >> annotation [
 
-	<MSEClass: #AnnotationTypeAttribute super: #FamixStAttribute>
+	<FMClass: #AnnotationTypeAttribute super: #FamixStAttribute>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -17,8 +17,8 @@ FamixStAnnotationTypeAttribute class >> annotation [
 
 { #category : #accessing }
 FamixStAnnotationTypeAttribute >> parentAnnotationType [
-	<MSEProperty: #parentAnnotationType type: #FamixStAnnotationType> <derived> 
-	<MSEComment: 'This is an alias pointing to the AnnotationType that defines this attribute'>
+	<FMProperty: #parentAnnotationType type: #FamixStAnnotationType> <derived> 
+	<FMComment: 'This is an alias pointing to the AnnotationType that defines this attribute'>
 
 	^ self parentType
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAssociation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAssociation.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #meta }
 FamixStAssociation class >> annotation [
 
-	<MSEClass: #Association super: #FamixStSourcedEntity>
+	<FMClass: #Association super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -22,8 +22,8 @@ FamixStAssociation class >> annotation [
 { #category : #printing }
 FamixStAssociation >> from [
 
-	<MSEProperty: #from type: #FamixTNamed> <derived>
-	<MSEComment: 'Generic accessor to the entity originating the association. Refined by subclasses'>
+	<FMProperty: #from type: #FamixTNamed> <derived>
+	<FMComment: 'Generic accessor to the entity originating the association. Refined by subclasses'>
 	^ self subclassResponsibility
 ]
 
@@ -37,7 +37,7 @@ FamixStAssociation >> gtDisplayOn: aStream [
 { #category : #printing }
 FamixStAssociation >> to [
 
-	<MSEProperty: #to type: #FamixTNamed> <derived>
-	<MSEComment: 'Generic accessor to the target entity of the association'>
+	<FMProperty: #to type: #FamixTNamed> <derived>
+	<FMComment: 'Generic accessor to the target entity of the association'>
 	^ self subclassResponsibility
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FamixStAttribute class >> annotation [
 
-	<MSEClass: #Attribute super: #FamixStNamedEntity>
+	<FMClass: #Attribute super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -25,6 +25,14 @@ FamixStAttribute class >> requirements [
 	^ { FamixStAnnotationType }
 ]
 
+{ #category : #accessing }
+FamixStAttribute >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
 { #category : #'Famix-Implementation' }
 FamixStAttribute >> beSharedVariable [
 
@@ -33,8 +41,8 @@ FamixStAttribute >> beSharedVariable [
 
 { #category : #testing }
 FamixStAttribute >> hasClassScope [
-	<MSEProperty: #hasClassScope type: #Boolean>
-	<MSEComment: 'True if class-side attribute'>
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'True if class-side attribute'>
 
 	^ hasClassScope
 ]
@@ -47,9 +55,9 @@ FamixStAttribute >> hasClassScope: aBoolean [
 
 { #category : #'Famix-Implementation' }
 FamixStAttribute >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'Attribute hierarchy nesting level'>
+	<FMComment: 'Attribute hierarchy nesting level'>
 		
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -83,4 +91,59 @@ FamixStAttribute >> mooseNameOn: aStream [
 		[ parent mooseNameOn: aStream.
 		aStream nextPut: $. ].
 	self name ifNotNil: [ aStream nextPutAll: self name ].
+]
+
+{ #category : #accessing }
+FamixStAttribute >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixStAttribute >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixStAttribute >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixStAttribute >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixStAttribute >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStClass class >> annotation [
 
-	<MSEClass: #Class super: #FamixStContainerEntity>
+	<FMClass: #Class super: #FamixStContainerEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -39,10 +39,38 @@ FamixStClass >> extendedInPackages [
 
 { #category : #accessing }
 FamixStClass >> extendedMethods [
-	<MSEProperty: #extendedMethods type: #FamixStMethod>
-	<MSEComment: 'Methods which are class extensions in this class.'>
+	<FMProperty: #extendedMethods type: #FamixStMethod>
+	<FMComment: 'Methods which are class extensions in this class.'>
 	<derived>
 	^ self methods select: #isExtension
+]
+
+{ #category : #metrics }
+FamixStClass >> fanIn [
+	<FMProperty: #fanIn type: #Number>
+	<derived>
+	<FMComment: 'Number of client classes'>
+	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
+]
+
+{ #category : #metrics }
+FamixStClass >> hierarchyNestingLevel [
+	<FMProperty: #hierarchyNestingLevel type: #Number>
+	<derived>
+	<FMComment: 'The nesting of a class inside the hierarchy'>
+
+	^self
+		lookUpPropertyNamed: #hierarchyNestingLevel
+		computedAs:
+			[| currentMaxDepth |
+			(self directSuperclasses isEmpty or: [self isStub])
+				ifTrue: [0]
+				ifFalse:
+					[currentMaxDepth := 0.
+					self
+						allSuperclassesDo:
+							[:aClass | currentMaxDepth := currentMaxDepth max: aClass hierarchyNestingLevel].
+					currentMaxDepth + 1]]
 ]
 
 { #category : #testing }
@@ -90,17 +118,17 @@ FamixStClass >> isLonelyWithin: aClassGroup [
 
 { #category : #testing }
 FamixStClass >> isTestCase [
-	<MSEProperty: #isTestCase type: #Boolean>
+	<FMProperty: #isTestCase type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Java test'>
+	<FMComment: 'True if the method is considered as a Java test'>
 	self allSuperclassesDo: [ :each | each name = 'TestCase' ifTrue: [ ^ true ] ].
 	^ false
 ]
 
 { #category : #accessing }
 FamixStClass >> localMethods [
-	<MSEProperty: #extendedMethods type: #FamixStMethod>
-	<MSEComment: 'Methods which are local methods of the class and not extensions in this class.'>
+	<FMProperty: #extendedMethods type: #FamixStMethod>
+	<FMComment: 'Methods which are local methods of the class and not extensions in this class.'>
 	<derived>
 	^ self methods reject: #isExtension
 ]
@@ -118,6 +146,302 @@ FamixStClass >> methodsWithoutSutbsAndConstructors [
 	^ (self methods select: [ :each | each isStub not and: [ each isConstructor not ] ]) asSet
 ]
 
+{ #category : #metrics }
+FamixStClass >> numberOfAbstractMethods [
+	<FMProperty: #numberOfAbstractMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of abstract methods in the class'>
+	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfAccessesToForeignData [
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
+	<derived>
+	<FMComment: 'Number of accesses to foreign data'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessesToForeignData
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfAccessorMethods [
+	<FMProperty: #numberOfAccessorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of accessor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfAccessorMethods
+		computedAs: [ 
+			| noa |
+			noa := 0.
+			self methods
+				do: [ :method | 
+					method isPureAccessor
+						ifNotNil: [ 
+							(method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNil not ])
+								ifTrue: [ noa := noa + 1 ] ] ].
+			noa ]
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStClass >> numberOfAttributes [
+	<FMProperty: #numberOfAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in the class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributes
+		computedAs: [self attributes size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfAttributesInherited [
+	<FMProperty: #numberOfAttributesInherited type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in a class inherited from super classes'>	
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributesInherited
+		computedAs: [self inheritedAttributes size]
+]
+
+{ #category : #accessing }
+FamixStClass >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfDirectSubclasses [
+	<FMProperty: #numberOfDirectSubclasses type: #Number>
+	<FMComment: 'The number of direct subclasses'>
+	<derived>
+
+	^ self privateState propertyAt: #numberOfDirectSubclasses ifAbsentPut: [self directSubclasses size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfDuplicatedLinesOfCodeInternally [
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<derived>
+	<FMComment: 'The number of duplicated lines of code internally'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfLinesOfCode [
+
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<derived>
+	<FMComment: 'The number of lines of code in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [self methodsGroup sumNumbers: #numberOfLinesOfCode]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message sends from a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfMethodProtocols [
+	<FMProperty: #numberOfMethodProtocols type: #Number>
+	<derived>
+	<FMComment: 'The number of method protocols in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodProtocols
+		computedAs: [((self methods collect: [:each | each protocol]) reject: #isNil) asSet size]
+]
+
+{ #category : #accessing }
+FamixStClass >> numberOfMethods [
+	<FMProperty: #numberOfMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfMethods
+		computedAs: [self methods size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfMethodsAdded [
+	<FMProperty: #numberOfMethodsAdded type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class added with respect to super classes'>	
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodsAdded
+		computedAs: [self addedMethods size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfMethodsInHierarchy [
+	<FMProperty: #numberOfMethodsInHierarchy type: #Number>
+	<derived>
+	<FMComment: 'The number of methods of a class included the inherited ones'>	
+	
+	| totNom |
+	totNom := self methods size.
+	self superclassHierarchyGroup
+		do: [:aClass | totNom := totNom + aClass methods size].
+	^totNom
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfMethodsInherited [
+	<FMProperty: #numberOfMethodsInherited type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class inherited from super classes'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfMethodsInherited
+		computedAs: [self inheritedMethods size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfMethodsOverriden [
+	<FMProperty: #numberOfMethodsOverriden type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class overriden with respect to super classes'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfMethodsOverriden
+		computedAs: [self numberOfMethods - self numberOfMethodsAdded]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfParents [
+	<FMProperty: #numberOfParents type: #Number>
+	<derived>
+	<FMComment: 'The number of superclasses'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfParents
+		computedAs: [self directSuperclasses size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfPrivateAttributes [
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of private attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPrivateAttributes
+		computedAs: [(self attributes select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfPrivateMethods [
+	<FMProperty: #numberOfPrivateMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of private methods in a class'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfPrivateMethods
+		computedAs: [(self methods select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfProtectedAttributes [
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of protected attributes in a class'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedAttributes
+		computedAs: [(self attributes select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfProtectedMethods [
+	<FMProperty: #numberOfProtectedMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of protected methods in a class'>		
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedMethods
+		computedAs: [(self methods select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfPublicAttributes [
+	<FMProperty: #numberOfPublicAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPublicAttributes
+		computedAs: [(self attributes select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfPublicMethods [
+	<FMProperty: #numberOfPublicMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of public methods in a class'>		
+		
+	^self
+		lookUpPropertyNamed: #numberOfPublicMethods
+		computedAs: [(self methods select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfRevealedAttributes [
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfRevealedAttributes
+		computedAs:
+			[self numberOfPublicAttributes + self numberOfAccessorMethods]
+]
+
+{ #category : #metrics }
+FamixStClass >> numberOfSubclasses [
+	<FMProperty: #numberOfSubclasses type: #Number>
+	<derived>
+	<FMComment: 'The number of subclasses of a class'>
+	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
+]
+
 { #category : #'Famix-Implementation' }
 FamixStClass >> smalltalkClass [
 	"Returns the associated smalltalk class if it exist in the system."
@@ -133,10 +457,99 @@ FamixStClass >> sourceText [
 		ifNil: [ super sourceText ]
 ]
 
+{ #category : #metrics }
+FamixStClass >> subclassHierarchyDepth [ 
+	<FMProperty: #subclassHierarchyDepth type: #Number>
+	<derived>
+	<FMComment: 'The depth of the class hierarchy for which I am the root'>
+		
+	^ self directSubclasses isEmpty 
+		ifTrue: [ 0 ] 
+		ifFalse: 
+			[ | currentMaxDepth| 
+				currentMaxDepth := 0. 
+				self allSubclassesDo: 
+					[ :aClass | currentMaxDepth := currentMaxDepth max: aClass subclassHierarchyDepth ]. 
+            1 + currentMaxDepth ] 
+]
+
+{ #category : #metrics }
+FamixStClass >> tightClassCohesion [
+	<FMProperty: #tightClassCohesion type: #Number>
+	<derived>
+	<FMComment: 'Tight class cohesion of a class'>
+	self flag: #TODO.
+	^ self
+		lookUpPropertyNamed: #tightClassCohesion
+		computedAs: [ 
+			| tcc accessDictionary nom |
+			tcc := 0.
+			accessDictionary := Dictionary new.
+			self
+				methods do: [ :eachMethod | 
+					eachMethod accesses
+						do: [ :eachAccess | 
+							| var |
+							var := eachAccess variable.
+							var isAttribute
+								ifTrue: [ 
+									| varName accessedFrom |
+									varName := var name.
+									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
+									accessedFrom isNil
+										ifTrue: [ 
+											accessedFrom := Set new.
+											accessDictionary at: varName put: accessedFrom ].
+									accessedFrom add: eachMethod name ] ] ].
+			accessDictionary values
+				do: [ :each | 
+					| size |
+					size := each size.
+					tcc := tcc + (size * (size - 1) / 2) ].
+			nom := self numberOfMethods.
+			tcc := (nom = 0 or: [ nom = 1 ])
+				ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				ifTrue: [ 0 ].
+			tcc asFloat ]
+]
+
+{ #category : #metrics }
+FamixStClass >> totalNumberOfChildren [
+	<FMProperty: #totalNumberOfChildren type: #Number>
+	<derived>	
+	<FMComment: 'The total number of subclasses of a class'>
+	
+	^self
+		lookUpPropertyNamed: #totalNumberOfChildren
+		computedAs: [self subclassHierarchyGroup size]
+]
+
 { #category : #testing }
 FamixStClass >> understands: signature [
 	"returns true if a class is able to respond to an invocation to aSignature on itself; false otherwise"
 
 	self withSuperclassesDo: [ :each | (each implements: signature) ifTrue: [ ^ true ] ].
 	^ false
+]
+
+{ #category : #metrics }
+FamixStClass >> weightOfAClass [
+	<FMProperty: #weightOfAClass type: #Number>
+	<derived>
+	<FMComment: 'Weight of a class'>	
+			
+	^self
+		lookUpPropertyNamed: #weightOfAClass
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixStClass >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<derived>
+	<FMComment: 'The sum of the complexity in a class'>
+			
+	^self
+		lookUpPropertyNamed: #weightedMethodCount
+		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStComment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixStSourcedEntity>
+	<FMClass: #Comment super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStContainerEntity.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixStContainerEntity class >> annotation [
 
-	<MSEClass: #ContainerEntity super: #FamixStNamedEntity>
+	<FMClass: #ContainerEntity super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #metrics }
+FamixStContainerEntity >> fanOut [
+	<FMProperty: #fanOut type: #Number>
+	<derived>
+	<FMComment: 'Number of provider classes'>
+	^ self lookUpPropertyNamed: #fanOut computedAs: [ (self allProvidersAtScope: FamixTType) size ]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixStEntity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStGlobalVariable class >> annotation [
 
-	<MSEClass: #GlobalVariable super: #FamixStNamedEntity>
+	<FMClass: #GlobalVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -20,4 +20,67 @@ FamixStGlobalVariable class >> requirements [
 
 	<generated>
 	^ { FamixStScopingEntity }
+]
+
+{ #category : #accessing }
+FamixStGlobalVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
+{ #category : #accessing }
+FamixStGlobalVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixStGlobalVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixStGlobalVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixStGlobalVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixStGlobalVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -9,10 +9,18 @@ Class {
 { #category : #meta }
 FamixStImplicitVariable class >> annotation [
 
-	<MSEClass: #ImplicitVariable super: #FamixStNamedEntity>
+	<FMClass: #ImplicitVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixStImplicitVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #testing }
@@ -34,4 +42,59 @@ FamixStImplicitVariable >> mooseNameOn: stream [
 		stream nextPut: $. ].
 
 	self name ifNotNil: [ stream nextPutAll: self name ]
+]
+
+{ #category : #accessing }
+FamixStImplicitVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixStImplicitVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixStImplicitVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixStImplicitVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixStImplicitVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStInheritance class >> annotation [
 
-	<MSEClass: #Inheritance super: #FamixStAssociation>
+	<FMClass: #Inheritance super: #FamixStAssociation>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStInvocation class >> annotation [
 
-	<MSEClass: #Invocation super: #FamixStAssociation>
+	<FMClass: #Invocation super: #FamixStAssociation>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
@@ -9,10 +9,18 @@ Class {
 { #category : #meta }
 FamixStLocalVariable class >> annotation [
 
-	<MSEClass: #LocalVariable super: #FamixStNamedEntity>
+	<FMClass: #LocalVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixStLocalVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #accessing }
@@ -23,4 +31,59 @@ FamixStLocalVariable >> mooseNameOn: stream [
 		[ parent mooseNameOn: stream.
 		stream nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
+]
+
+{ #category : #accessing }
+FamixStLocalVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixStLocalVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixStLocalVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixStLocalVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixStLocalVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FamixStMethod class >> annotation [
 
-	<MSEClass: #Method super: #FamixStContainerEntity>
+	<FMClass: #Method super: #FamixStContainerEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -51,8 +51,8 @@ FamixStMethod >> computeNumberOfLinesOfCodeIfSmalltalk [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> cyclomaticComplexity [
-	<MSEProperty: #cyclomaticComplexity type: #Number>
-	<MSEComment: 'The number of linear-independent paths through a method.'>
+	<FMProperty: #cyclomaticComplexity type: #Number>
+	<FMComment: 'The number of linear-independent paths through a method.'>
 	^ self
 		lookUpPropertyNamed: #cyclomaticComplexity
 		computedAs: [ 
@@ -78,9 +78,9 @@ FamixStMethod >> hasEmptyBody [
 
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'The nesting level in the hierarchy'>
+	<FMComment: 'The nesting level in the hierarchy'>
 	
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -106,8 +106,8 @@ FamixStMethod >> invokedBehaviours [
 
 { #category : #'Famix-Extensions' }
 FamixStMethod >> invokedMethods [
-	<MSEProperty: #invokedMethods type: #FamixStMethod> <derived> <multivalued>
-	<MSEComment: 'The methods invoked by the receiver'>
+	<FMProperty: #invokedMethods type: #FamixStMethod> <derived> <multivalued>
+	<FMComment: 'The methods invoked by the receiver'>
 	
 	^ self invokedBehaviours select: [ :each | each isMethod ]
 ]
@@ -119,6 +119,33 @@ FamixStMethod >> isCalledInternally [
 			[:each | each sender isMethod and: [each sender belongsTo == self belongsTo]]
 ]
 
+{ #category : #testing }
+FamixStMethod >> isConstant [
+	<FMProperty: #isConstant type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method simply returns a constant'>
+	^#constant = self kind
+]
+
+{ #category : #testing }
+FamixStMethod >> isConstructor [
+	<FMProperty: #isConstructor type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a constructor of the class'>
+
+	^ #constructor = self kind or: [ 
+		self privateState propertyAt: #isConstructor ifAbsent: [false] ]
+]
+
+{ #category : #testing }
+FamixStMethod >> isGetter [
+	<FMProperty: #isGetter type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a getter of an attribute'>
+	
+	^#getter = self kind
+]
+
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> isInitializer [
 	^ (('*initialize*' match: self protocol) or: [ '*initialize*' match: self name ]) or: [ self isConstructor ] 
@@ -126,9 +153,9 @@ FamixStMethod >> isInitializer [
 
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> isInternalImplementation [
-	<MSEProperty: #isInternalImplementation type: #Boolean>
+	<FMProperty: #isInternalImplementation type: #Boolean>
 	<derived>
-	<MSEComment: 'Public Interface Layer Method'>
+	<FMComment: 'Public Interface Layer Method'>
 
 	^ (self isInitializer not and: [ self isCalledInternally ])
 		and: [ self isPureAccessor not ]
@@ -136,9 +163,9 @@ FamixStMethod >> isInternalImplementation [
 
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> isJUnit4Test [
-	<MSEProperty: #isJUnit4Test type: #Boolean>
+	<FMProperty: #isJUnit4Test type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is considered as a Junit 4 Java test'>
+	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
 	^ self isAnnotatedWith: 'Test'
 ]
 
@@ -146,9 +173,9 @@ FamixStMethod >> isJUnit4Test [
 FamixStMethod >> isOverriden [
 	"If we have a stub and we don't have the container, we can't have the information"
 
-	<MSEProperty: #isOverriden type: #Boolean>
+	<FMProperty: #isOverriden type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is overrided in a sub class'>
+	<FMComment: 'The method is overrided in a sub class'>
 	(self belongsTo isNil and: [ self isStub ]) ifTrue: [ ^ false ].
 
 	^ self belongsTo subclassHierarchyGroup anySatisfy: [ :each | each implements: self signature ]
@@ -156,12 +183,21 @@ FamixStMethod >> isOverriden [
 
 { #category : #accessing }
 FamixStMethod >> isOverriding [
-	<MSEProperty: #isOverriding type: #Boolean>
+	<FMProperty: #isOverriding type: #Boolean>
 	<derived>
-	<MSEComment: 'The method is overrinding a method defined in a super class'>
+	<FMComment: 'The method is overrinding a method defined in a super class'>
 	
 	^self belongsTo directSuperclasses anySatisfy: [:each | 
 		each understands: self signature]
+]
+
+{ #category : #testing }
+FamixStMethod >> isSetter [
+	<FMProperty: #isSetter type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is a setter on an attribute'>
+
+	^#setter = self kind
 ]
 
 { #category : #'Famix-Extensions-metrics-support' }
@@ -188,9 +224,9 @@ FamixStMethod >> isSurelyInvokedBy: aFAMIXMethod [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfAccesses [
-	<MSEProperty: #numberOfAccesses type: #Number>
+	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
-	<MSEComment: 'The number of accesses from a method'>
+	<FMComment: 'The number of accesses from a method'>
 	
 	^ self 
 		lookUpPropertyNamed: #numberOfAccesses
@@ -199,9 +235,9 @@ FamixStMethod >> numberOfAccesses [
 
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> numberOfAnnotationInstances [
-	<MSEProperty: #numberOfAnnotationInstances type: #Number>
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
 	<derived>
-	<MSEComment: 'The number of annotation instances defined in the method'>
+	<FMComment: 'The number of annotation instances defined in the method'>
 
 	^self
 		lookUpPropertyNamed: #numberOfAnnotationInstances
@@ -210,8 +246,8 @@ FamixStMethod >> numberOfAnnotationInstances [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfComments [
-	<MSEProperty: #numberOfComments type: #Number>
-	<MSEComment: 'The number of comment fragments'>
+	<FMProperty: #numberOfComments type: #Number>
+	<FMComment: 'The number of comment fragments'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
 ]
@@ -224,8 +260,8 @@ FamixStMethod >> numberOfComments: aNumber [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfConditionals [
-	<MSEProperty: #numberOfConditionals type: #Number>
-	<MSEComment: 'The number of conditionals in a method'>
+	<FMProperty: #numberOfConditionals type: #Number>
+	<FMComment: 'The number of conditionals in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfConditionals
 		computedAs: [ 
@@ -244,8 +280,8 @@ FamixStMethod >> numberOfConditionals: aNumber [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
-	<MSEComment: 'The number of lines of code in a method.'>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCode
 		computedAs: [ self computeNumberOfLinesOfCodeIfSmalltalk ]
@@ -253,9 +289,9 @@ FamixStMethod >> numberOfLinesOfCode [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfMessageSends [
-	<MSEProperty: #numberOfMessageSends type: #Number>
+	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
-	<MSEComment: 'The number of message from a method'>
+	<FMComment: 'The number of message from a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfMessageSends
 		computedAs: [ 
@@ -268,19 +304,27 @@ FamixStMethod >> numberOfMessageSends [
 
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfOutgoingInvocations [
-	<MSEProperty: #numberOfOutgoingInvocations type: #Number>
+	<FMProperty: #numberOfOutgoingInvocations type: #Number>
 	<derived>
-	<MSEComment: 'The number of invocations in a method'>
+	<FMComment: 'The number of invocations in a method'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfOutgoingInvocations
 		computedAs: [self outgoingInvocations size]
 ]
 
+{ #category : #accessing }
+FamixStMethod >> numberOfParameters [
+	<FMProperty: #numberOfParameters type: #Number>
+	<FMComment: 'The number of parameters in a method'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
+]
+
 { #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfStatements [
-	<MSEProperty: #numberOfStatements type: #Number>
-	<MSEComment: 'The number of statements in a method'>
+	<FMProperty: #numberOfStatements type: #Number>
+	<FMComment: 'The number of statements in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfStatements
 		computedAs: [
@@ -304,9 +348,9 @@ FamixStMethod >> outgoingTypeDeclarations [
 { #category : #accessing }
 FamixStMethod >> protocol [
 
-	<MSEProperty: #protocol type: #String>
+	<FMProperty: #protocol type: #String>
 	<generated>
-	<MSEComment: 'Protocol of the method'>
+	<FMComment: 'Protocol of the method'>
 	^ protocol
 ]
 
@@ -339,8 +383,8 @@ FamixStMethod >> sourceText [
 
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> timeStamp [
-	<MSEProperty: #timeStamp type: #String>
-	<MSEComment: 'TimeStamp of the method with author and time of the last change'>
+	<FMProperty: #timeStamp type: #String>
+	<FMComment: 'TimeStamp of the method with author and time of the last change'>
 	<package: 'Smalltalk'>
 	
 	^ self privateState attributeAt: #timeStamp ifAbsentPut: ['']

--- a/src/Famix-PharoSmalltalk-Entities/FamixStModel.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStModel.class.st
@@ -12,7 +12,7 @@ FamixStModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixStModel class >> annotation [
-	<MSEClass: #FamixStModel super: #MooseModel>
+	<FMClass: #FamixStModel super: #MooseModel>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStNamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixStSourcedEntity>
+	<FMClass: #NamedEntity super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -20,6 +20,91 @@ FamixStNamedEntity class >> requirements [
 
 	<generated>
 	^ { FamixStPackage }
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStNamedEntity >> isAbstract [
+	<FMProperty: #isAbstract type: #Boolean> <derived>
+	<FMComment: 'Flag true for abstract entities. Language dependent.'>
+	
+	^ self modifiers includes: #abstract
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStNamedEntity >> isFinal [
+	<FMProperty: #isFinal type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities defined as being final. Language dependent.'>	
+
+	^ self modifiers includes: #final
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStNamedEntity >> isPackage [
+	<FMProperty: #isPackage type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities that have a package visibility. Language dependent.'>
+	
+	^ self modifiers includes: #package
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStNamedEntity >> isPrivate [
+	<FMProperty: #isPrivate type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities invisible out of their owner scope. Language dependent.'>
+	
+	^ self modifiers includes: #private
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStNamedEntity >> isProtected [
+	<FMProperty: #isProtected type: #Boolean> <derived>
+	<FMComment: 'Flag true for protected entities, depending on language semantics.'>
+	
+	^ self modifiers includes: #protected
+]
+
+{ #category : #'Famix-Extensions' }
+FamixStNamedEntity >> isPublic [
+	<FMProperty: #isPublic type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities accessible from anywhere. Language dependent.'>	
+
+	^ self modifiers includes: #public
+]
+
+{ #category : #accessing }
+FamixStNamedEntity >> isStub [
+
+	<FMProperty: #isStub type: #Boolean>
+	<FMComment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'>
+	^ isStub ifNil: [ false ]
+]
+
+{ #category : #accessing }
+FamixStNamedEntity >> modifiers [
+
+	<FMProperty: #modifiers type: #String>
+	<multivalued>
+	<FMComment: 'Generic container for language dependent modifiers.'>
+	^ modifiers ifNil: [ modifiers := Set new ]
+]
+
+{ #category : #metrics }
+FamixStNamedEntity >> numberOfAnnotationInstances [
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
+	<derived>
+	<FMComment: 'The number of annotation instances defined in the class or in any of its methods'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAnnotationInstances
+		computedAs: [
+			self annotationInstances size + (self methods inject: 0 into: [:sum :each | sum + each numberOfAnnotationInstances])]
+]
+
+{ #category : #accessing }
+FamixStNamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStNamespace class >> annotation [
 
-	<MSEClass: #Namespace super: #FamixStScopingEntity>
+	<FMClass: #Namespace super: #FamixStScopingEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -18,9 +18,9 @@ FamixStNamespace class >> annotation [
 { #category : #'Famix-Extensions-metrics' }
 FamixStNamespace >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness of a package'>
+	<FMComment: 'Abstractness of a package'>
 
 	| nsClasses |
 	nsClasses := self allClasses select: [:c | c isInstanceSide].
@@ -48,9 +48,9 @@ FamixStNamespace >> mooseNameOn: aStream [
 
 { #category : #'Famix-Extensions' }
 FamixStNamespace >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
+	<FMProperty: #numberOfClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes in a namespace'>
+	<FMComment: 'The number of classes in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfClasses
@@ -65,9 +65,9 @@ FamixStNamespace >> numberOfClasses: aNumber [
 
 { #category : #'Famix-Extensions' }
 FamixStNamespace >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines of code in a namespace'>
+	<FMComment: 'The number of lines of code in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfLinesOfCode
@@ -84,9 +84,9 @@ FamixStNamespace >> numberOfLinesOfCode: aNumber [
 
 { #category : #'Famix-Extensions' }
 FamixStNamespace >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
+	<FMProperty: #numberOfMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a namespace'>
+	<FMComment: 'The number of methods in a namespace'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfMethods

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStPackage class >> annotation [
 
-	<MSEClass: #Package super: #FamixStScopingEntity>
+	<FMClass: #Package super: #FamixStScopingEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -18,15 +18,24 @@ FamixStPackage class >> annotation [
 { #category : #'Famix-Extensions-metrics' }
 FamixStPackage >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness of a package'>
+	<FMComment: 'Abstractness of a package'>
 
 	| nsClasses |
 	nsClasses := self allClasses select: [:c | c isInstanceSide].
 	(nsClasses size == 0) ifTrue: [^nil].
 	
 	^ (nsClasses select: [:c | c isAbstract]) size / (nsClasses size)
+]
+
+{ #category : #metrics }
+FamixStPackage >> afferentCoupling [
+	<FMProperty: #afferentCoupling type: #Number>
+	<derived>
+	<FMComment:
+		'Afferent Coupling of a namespace Afferent is the number of classes that depend upon this namespace'>
+	^ (((self queryAllIncoming outOfParentUsing: FamixTPackage) atScope: FamixTType) collect: [ :e | e isClassSide ifTrue: [ e instanceSide ] ifFalse: [ e ] ]) asSet  size
 ]
 
 { #category : #'Famix-Extensions' }
@@ -39,6 +48,33 @@ FamixStPackage >> classes [
 
 	^ self privateState 	cacheAt: #classes 
 							ifAbsentPut: [ self childEntities select: [ :child | child isClass ]]
+]
+
+{ #category : #metrics }
+FamixStPackage >> distance [
+	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
+	<FMProperty: #distance type: #Number>
+	<derived>
+	<FMComment: 'Distance of a package'>
+
+	
+	| abstractness instability |
+	abstractness := self abstractness.
+	instability := self instability.
+	
+	(abstractness isNil or: [instability isNil]) ifTrue: [^ nil].
+	^ abstractness + instability - 1
+]
+
+{ #category : #metrics }
+FamixStPackage >> efferentCoupling [
+	"Efferent coupling for a package is the number of classes it depends upon"
+
+	<FMProperty: #efferentCoupling type: #Number>
+	<derived>
+	<FMComment: 'Efferent Coupling of a package'>
+
+	^ (((self queryAllOutgoing outOfParentUsing: FamixTPackage) atScope: FamixTType) collect: [ :e | e isClassSide ifTrue: [ e instanceSide ] ifFalse: [ e ] ] ) asSet size
 ]
 
 { #category : #accessing }
@@ -68,6 +104,22 @@ FamixStPackage >> extensionMethods [
 		ifAbsentPut: [ self childEntities select: [ :child | child isMethod ]]
 ]
 
+{ #category : #metrics }
+FamixStPackage >> instability [
+	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
+
+	<FMProperty: #instability type: #Number>
+	<derived>
+	<FMComment: 'Instability of a package'>
+
+	| efferentCoupling afferentCoupling |
+	
+	efferentCoupling := self efferentCoupling.
+	afferentCoupling := self afferentCoupling.
+	(efferentCoupling + afferentCoupling) == 0 ifTrue: [^ nil].
+	^ efferentCoupling / (efferentCoupling + afferentCoupling)
+]
+
 { #category : #accessing }
 FamixStPackage >> localClasses [
 	"select all local classes. Just an alias"
@@ -93,6 +145,24 @@ FamixStPackage >> localMethods [
 			ifAbsentPut: [ self classes flatCollect: [:c | c localMethods ]]
 ]
 
+{ #category : #metrics }
+FamixStPackage >> martinCohesion [
+	"Computing cohesion as described by Robert C. Martin"
+
+	<FMProperty: #martinCohesion type: #Number>
+	<derived>
+	<FMComment: 'Cohesion as defined by Robert C. Martin.'>
+	| intraConnectivities myClasses |
+	myClasses := self childEntities select: #isClass.
+	myClasses := (myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ])) select: [ :c | c isInstanceSide ].
+	myClasses size == 0
+		ifTrue: [ ^ nil ].
+	intraConnectivities := (myClasses collect: [ :c | (c queryOutgoingDependencies atScope: FamixTType) withoutSelfLoops withinParentUsing: FamixTNamespace ])
+		inject: 0
+		into: [ :subTotal :each | subTotal + (each select: [ :c | c isInstanceSide ]) size ].
+	^ ((intraConnectivities + 1) / myClasses size) asFloat
+]
+
 { #category : #accessing }
 FamixStPackage >> methods [
 	^ self localMethods union: self extensionMethods
@@ -100,17 +170,17 @@ FamixStPackage >> methods [
 
 { #category : #accessing }
 FamixStPackage >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
+	<FMProperty: #numberOfClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes in a package'>
+	<FMComment: 'The number of classes in a package'>
 	
 	^ self classes size
 ]
 
 { #category : #accessing }
 FamixStPackage >> numberOfClientPackages [
-	<MSEProperty: #numberOfClientPackages type: #Number>
-	<MSEComment: 'The number of packages which depend on this package'>
+	<FMProperty: #numberOfClientPackages type: #Number>
+	<FMComment: 'The number of packages which depend on this package'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfClientPackages computedAs: [ self allClients size ]
 ]
@@ -123,9 +193,9 @@ FamixStPackage >> numberOfClientPackages: aNumber [
 
 { #category : #accessing }
 FamixStPackage >> relativeImportanceForSystem [
-	<MSEProperty: #relativeImportanceForSystem type: #Number>
+	<FMProperty: #relativeImportanceForSystem type: #Number>
 	<derived>
-	<MSEComment: 'The number of client packages normalized by the total number of packages'>
+	<FMComment: 'The number of client packages normalized by the total number of packages'>
 	
 	^ self lookUpPropertyNamed: #relativeImportanceForSystem
 				 computedAs: [
@@ -135,4 +205,12 @@ FamixStPackage >> relativeImportanceForSystem [
 							]
 						ifFalse: [0]
 						]
+]
+
+{ #category : #metrics }
+FamixStPackage >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<FMComment: 'The sum of the complexity in a package'>
+	<derived>
+	^ self lookUpPropertyNamed: #WMC computedAs: [ (self toScope: FamixTWithMethods) detectSum: #weightedMethodCount ]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
@@ -9,10 +9,18 @@ Class {
 { #category : #meta }
 FamixStParameter class >> annotation [
 
-	<MSEClass: #Parameter super: #FamixStNamedEntity>
+	<FMClass: #Parameter super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixStParameter >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
 ]
 
 { #category : #accessing }
@@ -23,4 +31,59 @@ FamixStParameter >> mooseNameOn: stream [
 		[ parent mooseNameOn: stream.
 		stream nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
+]
+
+{ #category : #accessing }
+FamixStParameter >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixStParameter >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixStParameter >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixStParameter >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixStParameter >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStReference class >> annotation [
 
-	<MSEClass: #Reference super: #FamixStAssociation>
+	<FMClass: #Reference super: #FamixStAssociation>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStScopingEntity class >> annotation [
 
-	<MSEClass: #ScopingEntity super: #FamixStContainerEntity>
+	<FMClass: #ScopingEntity super: #FamixStContainerEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #meta }
 FamixStSourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixStEntity>
+	<FMClass: #SourceAnchor super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -22,6 +22,16 @@ FamixStSourceAnchor class >> annotation [
 FamixStSourceAnchor >> initialize [
 	super initialize.
 	pharoEntity := WeakArray new: 1.
+]
+
+{ #category : #metrics }
+FamixStSourceAnchor >> lineCount [
+
+	<FMProperty: #lineCount type: #Number>
+	<derived>
+	<FMComment: 'The number of lines in the source text'>
+
+	^ self sourceText ifNotNil: #lineCount ifNil: [ self notExistentMetricValue ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStSourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixStEntity>
+	<FMClass: #SourceLanguage super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
@@ -27,8 +27,8 @@ FamixStSourceLanguage >> isSmalltalk [
 
 { #category : #accessing }
 FamixStSourceLanguage >> name [
-	<MSEProperty: #name type: #String>
+	<FMProperty: #name type: #String>
 	<derived>
-	<MSEComment: 'The name of the language'>
+	<FMComment: 'The name of the language'>
 	^ 'Pharo'
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStSourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixStSourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixStSourceAnchor>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
@@ -9,10 +9,44 @@ Class {
 { #category : #meta }
 FamixStSourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixStEntity>
+	<FMClass: #SourcedEntity super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixStSourcedEntity >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
+{ #category : #'Famix-Implementation' }
+FamixStSourcedEntity >> numberOfLinesOfCode [
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
+	^ self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [ self computeNumberOfLinesOfCode ]
+]
+
+{ #category : #metrics }
+FamixStSourcedEntity >> numberOfLinesOfCodeWithMoreThanOneCharacter [
+	<FMProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number> <derived>
+	<FMComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
+	the difference being that it only counts the lines with more than one non-whitespace characters.
+	This metric is particularly useful for comparing the density of other metrics on a line of code.
+	For example, depending on the formatting style chosen a Java curly brace, or a Smalltalk block 
+	can appear inline or on a separate line. For normalization purposes, these commonly appearing 
+	cases can be ruled out through the present metric.'>
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCodeWithMoreThanOneCharacter
+		computedAs: [			
+			(self sourceText lines select: [ :line |
+				line trimBoth size > 1 ]) size ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStUnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixStSourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixStSourceLanguage>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
@@ -9,8 +9,71 @@ Class {
 { #category : #meta }
 FamixStUnknownVariable class >> annotation [
 
-	<MSEClass: #UnknownVariable super: #FamixStNamedEntity>
+	<FMClass: #UnknownVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixStUnknownVariable >> accessors [
+	<FMProperty: #accessors type: #FamixTWithAccesses>
+	<multivalued>
+	<derived>
+	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
+]
+
+{ #category : #accessing }
+FamixStUnknownVariable >> numberOfAccesses [
+	<FMProperty: #numberOfAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses of an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccesses
+		computedAs: [self incomingAccesses size]
+]
+
+{ #category : #accessing }
+FamixStUnknownVariable >> numberOfAccessingClasses [
+	<FMProperty: #numberOfAccessingClasses type: #Number>
+	<derived>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
+
+	^self
+		lookUpPropertyNamed: #numberOfAccessingClasses
+		computedAs: [self accessingClasses size]
+]
+
+{ #category : #accessing }
+FamixStUnknownVariable >> numberOfAccessingMethods [
+	<FMProperty: #numberOfAccessingMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods accessing an attribute.'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessingMethods
+		computedAs: [self accessingMethods size]
+]
+
+{ #category : #accessing }
+FamixStUnknownVariable >> numberOfGlobalAccesses [
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+
+	^self
+		lookUpPropertyNamed: #numberOfGlobalAccesses
+		computedAs: [self globalAccesses size]
+]
+
+{ #category : #accessing }
+FamixStUnknownVariable >> numberOfLocalAccesses [
+	<FMProperty: #numberOfLocalAccesses type: #Number>
+	<derived>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+		
+	^self
+		lookUpPropertyNamed: #numberOfLocalAccesses
+		computedAs: [self localAccesses size]
 ]

--- a/src/Famix-Test1-Entities/FamixTest1AbstractFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1AbstractFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1AbstractFileAnchor class >> annotation [
 
-	<MSEClass: #AbstractFileAnchor super: #FamixTest1SourceAnchor>
+	<FMClass: #AbstractFileAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1Association class >> annotation [
 
-	<MSEClass: #Association super: #FamixTest1SourcedEntity>
+	<FMClass: #Association super: #FamixTest1SourcedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1Attribute class >> annotation [
 
-	<MSEClass: #Attribute super: #FamixTest1NamedEntity>
+	<FMClass: #Attribute super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Class.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Class.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1Class class >> annotation [
 
-	<MSEClass: #Class super: #FamixTest1NamedEntity>
+	<FMClass: #Class super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Comment.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Comment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1Comment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixTest1SourcedEntity>
+	<FMClass: #Comment super: #FamixTest1SourcedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTest1Entity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1File.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1File.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1File class >> annotation [
 
-	<MSEClass: #File super: #FamixTest1NamedEntity>
+	<FMClass: #File super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1FileAnchor class >> annotation [
 
-	<MSEClass: #FileAnchor super: #FamixTest1AbstractFileAnchor>
+	<FMClass: #FileAnchor super: #FamixTest1AbstractFileAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Folder.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Folder.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1Folder class >> annotation [
 
-	<MSEClass: #Folder super: #FamixTest1NamedEntity>
+	<FMClass: #Folder super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1IndexedFileAnchor class >> annotation [
 
-	<MSEClass: #IndexedFileAnchor super: #FamixTest1AbstractFileAnchor>
+	<FMClass: #IndexedFileAnchor super: #FamixTest1AbstractFileAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Method.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Method.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1Method class >> annotation [
 
-	<MSEClass: #Method super: #FamixTest1NamedEntity>
+	<FMClass: #Method super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1Model.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Model.class.st
@@ -12,7 +12,7 @@ FamixTest1Model class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTest1Model class >> annotation [
-	<MSEClass: #FamixTest1Model super: #MooseModel>
+	<FMClass: #FamixTest1Model super: #MooseModel>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 ]

--- a/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1MultipleFileAnchor class >> annotation [
 
-	<MSEClass: #MultipleFileAnchor super: #FamixTest1SourceAnchor>
+	<FMClass: #MultipleFileAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1NamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixTest1SourcedEntity>
+	<FMClass: #NamedEntity super: #FamixTest1SourcedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self
@@ -21,4 +21,12 @@ FamixTest1NamedEntity class >> dependencyFM3PropertyDescription [
 
 	^ self allDeclaredProperties
 		select: [ :e | e hasOpposite and: [ e opposite isSource or: [ e opposite isTarget ] ] ]
+]
+
+{ #category : #accessing }
+FamixTest1NamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1SourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixTest1Entity>
+	<FMClass: #SourceAnchor super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1SourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixTest1Entity>
+	<FMClass: #SourceLanguage super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1SourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixTest1SourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1SourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixTest1Entity>
+	<FMClass: #SourcedEntity super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test1-Entities/FamixTest1UnknownSourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1UnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest1UnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixTest1SourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixTest1SourceLanguage>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2Association.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Association.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2Association class >> annotation [
 
-	<MSEClass: #Association super: #FamixTest2SourcedEntity>
+	<FMClass: #Association super: #FamixTest2SourcedEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2Class class >> annotation [
 
-	<MSEClass: #Class super: #FamixTest2NamedEntity>
+	<FMClass: #Class super: #FamixTest2NamedEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2Comment.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Comment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2Comment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixTest2SourcedEntity>
+	<FMClass: #Comment super: #FamixTest2SourcedEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTest2Entity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2Inheritance class >> annotation [
 
-	<MSEClass: #Inheritance super: #FamixTest2Association>
+	<FMClass: #Inheritance super: #FamixTest2Association>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2Model.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Model.class.st
@@ -12,7 +12,7 @@ FamixTest2Model class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTest2Model class >> annotation [
-	<MSEClass: #FamixTest2Model super: #MooseModel>
+	<FMClass: #FamixTest2Model super: #MooseModel>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 ]

--- a/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixTest2NamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixTest2SourcedEntity>
+	<FMClass: #NamedEntity super: #FamixTest2SourcedEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTest2NamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2SourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixTest2Entity>
+	<FMClass: #SourceAnchor super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2SourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixTest2Entity>
+	<FMClass: #SourceLanguage super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2SourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixTest2SourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixTest2SourceAnchor>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2SourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixTest2Entity>
+	<FMClass: #SourcedEntity super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test2-Entities/FamixTest2UnknownSourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2UnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest2UnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixTest2SourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixTest2SourceLanguage>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Association.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Association.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Association class >> annotation [
 
-	<MSEClass: #Association super: #FamixTest3SourcedEntity>
+	<FMClass: #Association super: #FamixTest3SourcedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Class.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Class.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Class class >> annotation [
 
-	<MSEClass: #Class super: #FamixTest3Type>
+	<FMClass: #Class super: #FamixTest3Type>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Comment.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Comment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Comment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixTest3SourcedEntity>
+	<FMClass: #Comment super: #FamixTest3SourcedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTest3Entity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Invocation class >> annotation [
 
-	<MSEClass: #Invocation super: #FamixTest3Association>
+	<FMClass: #Invocation super: #FamixTest3Association>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Method.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Method.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Method class >> annotation [
 
-	<MSEClass: #Method super: #FamixTest3NamedEntity>
+	<FMClass: #Method super: #FamixTest3NamedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Model.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Model.class.st
@@ -12,7 +12,7 @@ FamixTest3Model class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTest3Model class >> annotation [
-	<MSEClass: #FamixTest3Model super: #MooseModel>
+	<FMClass: #FamixTest3Model super: #MooseModel>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 ]

--- a/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixTest3NamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixTest3SourcedEntity>
+	<FMClass: #NamedEntity super: #FamixTest3SourcedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTest3NamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3PrimitiveType class >> annotation [
 
-	<MSEClass: #PrimitiveType super: #FamixTest3Type>
+	<FMClass: #PrimitiveType super: #FamixTest3Type>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Reference.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Reference.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Reference class >> annotation [
 
-	<MSEClass: #Reference super: #FamixTest3Association>
+	<FMClass: #Reference super: #FamixTest3Association>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3SourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixTest3Entity>
+	<FMClass: #SourceAnchor super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3SourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixTest3Entity>
+	<FMClass: #SourceLanguage super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3SourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixTest3SourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixTest3SourceAnchor>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3SourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixTest3Entity>
+	<FMClass: #SourcedEntity super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3Type.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Type.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3Type class >> annotation [
 
-	<MSEClass: #Type super: #FamixTest3NamedEntity>
+	<FMClass: #Type super: #FamixTest3NamedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Entities/FamixTest3UnknownSourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3UnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTest3UnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixTest3SourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixTest3SourceLanguage>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #meta }
 FamixTest4Book class >> annotation [
 
-	<MSEClass: #Book super: #FamixTest4Entity>
+	<FMClass: #Book super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTest4Cafeteria class >> annotation [
 
-	<MSEClass: #Cafeteria super: #FamixTest4Room>
+	<FMClass: #Cafeteria super: #FamixTest4Room>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTest4Classroom class >> annotation [
 
-	<MSEClass: #Classroom super: #FamixTest4Room>
+	<FMClass: #Classroom super: #FamixTest4Room>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #meta }
 FamixTest4Entity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTest4Entity class >> metamodel [
 { #category : #accessing }
 FamixTest4Entity >> name [
 
-	<MSEProperty: #name type: #String>
+	<FMProperty: #name type: #String>
 	<generated>
 	^ name
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Model.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Model.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #meta }
 FamixTest4Model class >> annotation [
-	<MSEClass: #FamixTest4Model super: #MooseModel>
+	<FMClass: #FamixTest4Model super: #MooseModel>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #meta }
 FamixTest4Person class >> annotation [
 
-	<MSEClass: #Person super: #FamixTest4Entity>
+	<FMClass: #Person super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #meta }
 FamixTest4Principal class >> annotation [
 
-	<MSEClass: #Principal super: #FamixTest4Person>
+	<FMClass: #Principal super: #FamixTest4Person>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #meta }
 FamixTest4Room class >> annotation [
 
-	<MSEClass: #Room super: #FamixTest4Entity>
+	<FMClass: #Room super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #meta }
 FamixTest4School class >> annotation [
 
-	<MSEClass: #School super: #FamixTest4Entity>
+	<FMClass: #School super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #meta }
 FamixTest4Student class >> annotation [
 
-	<MSEClass: #Student super: #FamixTest4Person>
+	<FMClass: #Student super: #FamixTest4Person>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #meta }
 FamixTest4Teacher class >> annotation [
 
-	<MSEClass: #Teacher super: #FamixTest4Person>
+	<FMClass: #Teacher super: #FamixTest4Person>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3Model.class.st
+++ b/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3Model.class.st
@@ -12,7 +12,7 @@ FamixTestComposed3Model class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTestComposed3Model class >> annotation [
-	<MSEClass: #FamixTestComposed3Model super: #MooseModel>
+	<FMClass: #FamixTestComposed3Model super: #MooseModel>
 	<package: #'Famix-TestComposed3Metamodel-Entities'>
 	<generated>
 ]

--- a/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedModel.class.st
+++ b/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedModel.class.st
@@ -12,7 +12,7 @@ FamixTestComposedComposedModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTestComposedComposedModel class >> annotation [
-	<MSEClass: #FamixTestComposedComposedModel super: #MooseModel>
+	<FMClass: #FamixTestComposedComposedModel super: #MooseModel>
 	<package: #'Famix-TestComposedComposedMetamodel-Entities'>
 	<generated>
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed1CustomEntity1 >> c21 [
 	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11"
 
 	<generated>
-	<MSEProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11>
+	<FMProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c21 ifAbsent: [ nil ]
 ]
@@ -31,7 +31,7 @@ FamixTestComposed1CustomEntity1 >> customEntity1 [
 	<generated>
 	<container>
 	<derived>
-	<MSEProperty: #customEntity1 type: #FamixTestComposedCustomEntity1 opposite: #customEntity1>
+	<FMProperty: #customEntity1 type: #FamixTestComposedCustomEntity1 opposite: #customEntity1>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntity1 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1CustomEntity2 >> c22s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12>
+	<FMProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c12: ]
 ]
@@ -23,7 +23,7 @@ FamixTestComposed1CustomEntity2 >> customEntity2 [
 	"Relation named: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2"
 
 	<generated>
-	<MSEProperty: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2>
+	<FMProperty: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntity2 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed1CustomEntity3 >> c23 [
 	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s"
 
 	<generated>
-	<MSEProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s>
+	<FMProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c23 ifAbsent: [ nil ]
 ]
@@ -23,7 +23,7 @@ FamixTestComposed1CustomEntity3 >> customEntities3 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3>
+	<FMProperty: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntities3 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity3: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1CustomEntity4 >> c24s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s>
+	<FMProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c14s ]
 ]
@@ -23,7 +23,7 @@ FamixTestComposed1CustomEntity4 >> customEntities4 [
 	"Relation named: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4"
 
 	<generated>
-	<MSEProperty: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4>
+	<FMProperty: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1CustomEntity5 >> associations [
 
 	<generated>
 	<derived>
-	<MSEProperty: #associations type: #FamixTestComposedAssociation opposite: #c15>
+	<FMProperty: #associations type: #FamixTestComposedAssociation opposite: #c15>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c15: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed1Method >> entity [
 
 	<generated>
 	<derived>
-	<MSEProperty: #entity type: #FamixTestComposedEntity opposite: #method>
+	<FMProperty: #entity type: #FamixTestComposedEntity opposite: #method>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #entity ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed2CustomEntity1 >> c1 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c1 type: #FamixTestComposedCustomEntity1 opposite: #c21>
+	<FMProperty: #c1 type: #FamixTestComposedCustomEntity1 opposite: #c21>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c1 ifAbsent: [ nil ]
 ]
@@ -17,7 +17,7 @@ FamixTestComposed2CustomEntity1 >> c11 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c11 type: #FamixTestComposed1CustomEntity1 opposite: #c21>
+	<FMProperty: #c11 type: #FamixTestComposed1CustomEntity1 opposite: #c21>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c11 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed2CustomEntity2 >> c12 [
 	"Relation named: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s"
 
 	<generated>
-	<MSEProperty: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s>
+	<FMProperty: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c12 ifAbsent: [ nil ]
 ]
@@ -22,7 +22,7 @@ FamixTestComposed2CustomEntity2 >> c2 [
 	"Relation named: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s"
 
 	<generated>
-	<MSEProperty: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s>
+	<FMProperty: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c2 ifAbsent: [ nil ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed2CustomEntity3 >> c13s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23>
+	<FMProperty: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c13s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
 ]
@@ -24,7 +24,7 @@ FamixTestComposed2CustomEntity3 >> c3s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23>
+	<FMProperty: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c3s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
@@ -5,7 +5,7 @@ FamixTestComposed2CustomEntity4 >> c14s [
 	"Relation named: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s"
 
 	<generated>
-	<MSEProperty: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s>
+	<FMProperty: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c14s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c24s ]
 ]
@@ -22,7 +22,7 @@ FamixTestComposed2CustomEntity4 >> c4s [
 	"Relation named: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s"
 
 	<generated>
-	<MSEProperty: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s>
+	<FMProperty: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #c4s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c24s ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
@@ -6,7 +6,7 @@ FamixTestComposed2CustomEntity5 >> associations [
 
 	<generated>
 	<derived>
-	<MSEProperty: #associations type: #FamixTestComposedAssociation opposite: #c25>
+	<FMProperty: #associations type: #FamixTestComposedAssociation opposite: #c25>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self privateState attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c25: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposedAssociation class >> annotation [
 
-	<MSEClass: #Association super: #FamixTestComposedEntity>
+	<FMClass: #Association super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
@@ -21,7 +21,7 @@ FamixTestComposedAssociation >> c15 [
 
 	<generated>
 	<target>
-	<MSEProperty: #c15 type: #FamixTestComposed1CustomEntity5 opposite: #associations>
+	<FMProperty: #c15 type: #FamixTestComposed1CustomEntity5 opposite: #associations>
 	^ self privateState attributeAt: #c15 ifAbsent: [ nil ]
 ]
 
@@ -38,7 +38,7 @@ FamixTestComposedAssociation >> c25 [
 
 	<generated>
 	<source>
-	<MSEProperty: #c25 type: #FamixTestComposed2CustomEntity5 opposite: #associations>
+	<FMProperty: #c25 type: #FamixTestComposed2CustomEntity5 opposite: #associations>
 	^ self privateState attributeAt: #c25 ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposedCustomEntity1 class >> annotation [
 
-	<MSEClass: #CustomEntity1 super: #MooseEntity>
+	<FMClass: #CustomEntity1 super: #MooseEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTestComposedCustomEntity1 >> c21 [
 	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1"
 
 	<generated>
-	<MSEProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1>
+	<FMProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1>
 	^ self privateState attributeAt: #c21 ifAbsent: [ nil ]
 ]
 
@@ -48,7 +48,7 @@ FamixTestComposedCustomEntity1 >> customEntity1 [
 	"Relation named: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1"
 
 	<generated>
-	<MSEProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>
+	<FMProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>
 	^ self privateState attributeAt: #customEntity1 ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposedCustomEntity2 class >> annotation [
 
-	<MSEClass: #CustomEntity2 super: #MooseEntity>
+	<FMClass: #CustomEntity2 super: #MooseEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
@@ -38,7 +38,7 @@ FamixTestComposedCustomEntity2 >> c22s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2>
+	<FMProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2>
 	^ self privateState attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c2: ]
 ]
 
@@ -55,7 +55,7 @@ FamixTestComposedCustomEntity2 >> customEntities2 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2>
+	<FMProperty: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2>
 	^ self privateState attributeAt: #customEntities2 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity2: ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposedCustomEntity3 class >> annotation [
 
-	<MSEClass: #CustomEntity3 super: #MooseEntity>
+	<FMClass: #CustomEntity3 super: #MooseEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTestComposedCustomEntity3 >> c23 [
 	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s"
 
 	<generated>
-	<MSEProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s>
+	<FMProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s>
 	^ self privateState attributeAt: #c23 ifAbsent: [ nil ]
 ]
 
@@ -41,7 +41,7 @@ FamixTestComposedCustomEntity3 >> customEntity3 [
 	"Relation named: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3"
 
 	<generated>
-	<MSEProperty: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3>
+	<FMProperty: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3>
 	^ self privateState attributeAt: #customEntity3 ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposedCustomEntity4 class >> annotation [
 
-	<MSEClass: #CustomEntity4 super: #MooseEntity>
+	<FMClass: #CustomEntity4 super: #MooseEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
@@ -38,7 +38,7 @@ FamixTestComposedCustomEntity4 >> c24s [
 
 	<generated>
 	<derived>
-	<MSEProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s>
+	<FMProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s>
 	^ self privateState attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c4s ]
 ]
 
@@ -55,7 +55,7 @@ FamixTestComposedCustomEntity4 >> customEntities4 [
 
 	<generated>
 	<derived>
-	<MSEProperty: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4>
+	<FMProperty: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4>
 	^ self privateState attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposedEntity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTestComposedEntity >> method [
 	"Relation named: #method type: #FamixTestComposed1Method opposite: #entity"
 
 	<generated>
-	<MSEProperty: #method type: #FamixTestComposed1Method opposite: #entity>
+	<FMProperty: #method type: #FamixTestComposed1Method opposite: #entity>
 	^ self privateState attributeAt: #method ifAbsent: [ nil ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedModel.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedModel.class.st
@@ -12,7 +12,7 @@ FamixTestComposedModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTestComposedModel class >> annotation [
-	<MSEClass: #FamixTestComposedModel super: #MooseModel>
+	<FMClass: #FamixTestComposedModel super: #MooseModel>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 ]

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
@@ -65,7 +65,7 @@ FamixTestComposedMetamodels >> testGenerationOfComposedMetamodel [
 	self
 		assert:
 			(((env ask behaviorNamed: #FamixTestComposedCustomEntity1) methodNamed: #customEntity1) sourceCode
-				includesSubstring: '<MSEProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>')
+				includesSubstring: '<FMProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>')
 ]
 
 { #category : #running }

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsBuilding.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsBuilding.class.st
@@ -64,14 +64,14 @@ FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneNonRemote [
 	generatedMethod := ((env ringEnvironment ask classNamed: #Tst1Method) methodNamed: #binding).
 
 	self assert: (generatedMethod sourceCode includesSubstring: '<generated>').
-	self assert: (generatedMethod sourceCode includesSubstring: '<MSEProperty: #binding type: #TstComposedBinding opposite: #method>').
+	self assert: (generatedMethod sourceCode includesSubstring: '<FMProperty: #binding type: #TstComposedBinding opposite: #method>').
 	self assert: (generatedMethod sourceCode includesSubstring: 'privateState attributeAt: #binding').
 	self assert: generatedMethod package name equals: #TstComposed.
 
 	source := ((env ringEnvironment ask classNamed: #TstComposedBinding) methodNamed: #method) sourceCode.
 
 	self assert:  (source includesSubstring: '<generated>').
-	self assert:  (source includesSubstring: '<MSEProperty: #method type: #Tst1Method opposite: #binding>').
+	self assert:  (source includesSubstring: '<FMProperty: #method type: #Tst1Method opposite: #binding>').
 	self assert:  (source includesSubstring: 'privateState attributeAt: #method').
 	self assert: generatedMethod package name equals: #TstComposed.
 ]
@@ -90,14 +90,14 @@ FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneRemote [
 	generatedMethod := ((env ringEnvironment ask classNamed: #Tst1Method) methodNamed: #methodNode).
 
 	self assert: (generatedMethod sourceCode includesSubstring: '<generated>').
-	self assert: (generatedMethod sourceCode includesSubstring: '<MSEProperty: #methodNode type: #Tst2MethodNode opposite: #method>').
+	self assert: (generatedMethod sourceCode includesSubstring: '<FMProperty: #methodNode type: #Tst2MethodNode opposite: #method>').
 	self assert: (generatedMethod sourceCode includesSubstring: 'privateState attributeAt: #methodNode').
 	self assert: generatedMethod package name equals: #TstComposed.
 
 	source := ((env ringEnvironment ask classNamed: #Tst2MethodNode) methodNamed: #method) sourceCode.
 
 	self assert:  (source includesSubstring: '<generated>').
-	self assert:  (source includesSubstring: '<MSEProperty: #method type: #Tst1Method opposite: #methodNode>').
+	self assert:  (source includesSubstring: '<FMProperty: #method type: #Tst1Method opposite: #methodNode>').
 	self assert:  (source includesSubstring: 'privateState attributeAt: #method').
 	self assert: generatedMethod package name equals: #TstComposed.
 

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Association.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Association.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1Association class >> annotation [
 
-	<MSEClass: #Association super: #FamixTestComposed1SourcedEntity>
+	<FMClass: #Association super: #FamixTestComposed1SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1Class class >> annotation [
 
-	<MSEClass: #Class super: #FamixTestComposed1NamedEntity>
+	<FMClass: #Class super: #FamixTestComposed1NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1Comment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixTestComposed1SourcedEntity>
+	<FMClass: #Comment super: #FamixTestComposed1SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1CustomEntity1 class >> annotation [
 
-	<MSEClass: #CustomEntity1 super: #FamixTestComposed1Entity>
+	<FMClass: #CustomEntity1 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1CustomEntity2 class >> annotation [
 
-	<MSEClass: #CustomEntity2 super: #FamixTestComposed1Entity>
+	<FMClass: #CustomEntity2 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1CustomEntity3 class >> annotation [
 
-	<MSEClass: #CustomEntity3 super: #FamixTestComposed1Entity>
+	<FMClass: #CustomEntity3 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1CustomEntity4 class >> annotation [
 
-	<MSEClass: #CustomEntity4 super: #FamixTestComposed1Entity>
+	<FMClass: #CustomEntity4 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixTestComposed1CustomEntity5 class >> annotation [
 
-	<MSEClass: #CustomEntity5 super: #FamixTestComposed1Entity>
+	<FMClass: #CustomEntity5 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTestComposed1CustomEntity5 >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1Entity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1Method class >> annotation [
 
-	<MSEClass: #Method super: #FamixTestComposed1NamedEntity>
+	<FMClass: #Method super: #FamixTestComposed1NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Model.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Model.class.st
@@ -12,7 +12,7 @@ FamixTestComposed1Model class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTestComposed1Model class >> annotation [
-	<MSEClass: #FamixTestComposed1Model super: #MooseModel>
+	<FMClass: #FamixTestComposed1Model super: #MooseModel>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixTestComposed1NamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixTestComposed1SourcedEntity>
+	<FMClass: #NamedEntity super: #FamixTestComposed1SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTestComposed1NamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1SourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixTestComposed1Entity>
+	<FMClass: #SourceAnchor super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1SourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixTestComposed1Entity>
+	<FMClass: #SourceLanguage super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1SourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixTestComposed1SourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixTestComposed1SourceAnchor>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1SourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixTestComposed1Entity>
+	<FMClass: #SourcedEntity super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1UnknownSourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1UnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed1UnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixTestComposed1SourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixTestComposed1SourceLanguage>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Association.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Association.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2Association class >> annotation [
 
-	<MSEClass: #Association super: #FamixTestComposed2SourcedEntity>
+	<FMClass: #Association super: #FamixTestComposed2SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2Class class >> annotation [
 
-	<MSEClass: #Class super: #FamixTestComposed2NamedEntity>
+	<FMClass: #Class super: #FamixTestComposed2NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2Comment class >> annotation [
 
-	<MSEClass: #Comment super: #FamixTestComposed2SourcedEntity>
+	<FMClass: #Comment super: #FamixTestComposed2SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2CustomEntity1 class >> annotation [
 
-	<MSEClass: #CustomEntity1 super: #FamixTestComposed2Entity>
+	<FMClass: #CustomEntity1 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2CustomEntity2 class >> annotation [
 
-	<MSEClass: #CustomEntity2 super: #FamixTestComposed2Entity>
+	<FMClass: #CustomEntity2 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2CustomEntity3 class >> annotation [
 
-	<MSEClass: #CustomEntity3 super: #FamixTestComposed2Entity>
+	<FMClass: #CustomEntity3 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2CustomEntity4 class >> annotation [
 
-	<MSEClass: #CustomEntity4 super: #FamixTestComposed2Entity>
+	<FMClass: #CustomEntity4 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixTestComposed2CustomEntity5 class >> annotation [
 
-	<MSEClass: #CustomEntity5 super: #FamixTestComposed2Entity>
+	<FMClass: #CustomEntity5 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTestComposed2CustomEntity5 >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2Entity class >> annotation [
 
-	<MSEClass: #Entity super: #MooseEntity>
+	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2Method class >> annotation [
 
-	<MSEClass: #Method super: #FamixTestComposed2NamedEntity>
+	<FMClass: #Method super: #FamixTestComposed2NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Model.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Model.class.st
@@ -12,7 +12,7 @@ FamixTestComposed2Model class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixTestComposed2Model class >> annotation [
-	<MSEClass: #FamixTestComposed2Model super: #MooseModel>
+	<FMClass: #FamixTestComposed2Model super: #MooseModel>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
@@ -9,8 +9,16 @@ Class {
 { #category : #meta }
 FamixTestComposed2NamedEntity class >> annotation [
 
-	<MSEClass: #NamedEntity super: #FamixTestComposed2SourcedEntity>
+	<FMClass: #NamedEntity super: #FamixTestComposed2SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTestComposed2NamedEntity >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2SourceAnchor class >> annotation [
 
-	<MSEClass: #SourceAnchor super: #FamixTestComposed2Entity>
+	<FMClass: #SourceAnchor super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2SourceLanguage class >> annotation [
 
-	<MSEClass: #SourceLanguage super: #FamixTestComposed2Entity>
+	<FMClass: #SourceLanguage super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2SourceTextAnchor class >> annotation [
 
-	<MSEClass: #SourceTextAnchor super: #FamixTestComposed2SourceAnchor>
+	<FMClass: #SourceTextAnchor super: #FamixTestComposed2SourceAnchor>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2SourcedEntity class >> annotation [
 
-	<MSEClass: #SourcedEntity super: #FamixTestComposed2Entity>
+	<FMClass: #SourcedEntity super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2UnknownSourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2UnknownSourceLanguage.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposed2UnknownSourceLanguage class >> annotation [
 
-	<MSEClass: #UnknownSourceLanguage super: #FamixTestComposed2SourceLanguage>
+	<FMClass: #UnknownSourceLanguage super: #FamixTestComposed2SourceLanguage>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FAMIXTypeGroup.extension.st
+++ b/src/Famix-Traits/FAMIXTypeGroup.extension.st
@@ -4,9 +4,9 @@ Extension { #name : #FAMIXTypeGroup }
 FAMIXTypeGroup >> afferentCoupling [
 	"Afferent coupling for a class group is the number of external classes that depend upon this class group"
 
-	<MSEProperty: #afferentCoupling type: #Number>
+	<FMProperty: #afferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Afferent coupling for a class group is the number of external classes that depend upon this class group'>
+	<FMComment: 'Afferent coupling for a class group is the number of external classes that depend upon this class group'>
 	| cgClasses cgTypes |
 	cgClasses := self allClasses select: [ :c | c isInstanceSide ].
 	cgTypes := cgClasses flatCollect: [ :c | c allRecursiveTypes ].
@@ -20,9 +20,9 @@ FAMIXTypeGroup >> afferentCoupling [
 FAMIXTypeGroup >> bunchCohesion [
 	"Computing cohesion (Bunch formula). It is also considered anonymous and inner classes (in Java)."
 
-	<MSEProperty: #bunchCohesion type: #Number>
+	<FMProperty: #bunchCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Bunch Cohesion of a class group. It is also considered anonymous and inner classes (in Java).'>
+	<FMComment: 'Bunch Cohesion of a class group. It is also considered anonymous and inner classes (in Java).'>
 	| cgClasses cgTypes intraConnectivities |
 	cgClasses := self allClasses select: [ :c | c isInstanceSide ].
 	cgTypes := cgClasses flatCollect: [ :c | c allRecursiveTypes ].
@@ -66,9 +66,9 @@ FAMIXTypeGroup >> bunchCouplingWith: aClassGroup [
 FAMIXTypeGroup >> efferentCoupling [
 	"Efferent coupling for a class group is the number of classes it depends upon"
 
-	<MSEProperty: #efferentCoupling type: #Number>
+	<FMProperty: #efferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Efferent coupling for a class group is the number of classes it depends upon'>
+	<FMComment: 'Efferent coupling for a class group is the number of classes it depends upon'>
 	| cgClasses cgTypes |
 	cgClasses := self allClasses select: [ :c | c isInstanceSide ].
 	cgTypes := cgClasses flatCollect: [ :c | c allRecursiveTypes ].

--- a/src/Famix-Traits/FamixModel.class.st
+++ b/src/Famix-Traits/FamixModel.class.st
@@ -12,7 +12,7 @@ FamixModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 FamixModel class >> annotation [
-	<MSEClass: #FamixModel super: #MooseModel>
+	<FMClass: #FamixModel super: #MooseModel>
 	<package: #'Famix-Traits'>
 	<generated>
 ]

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -25,7 +25,7 @@ Trait {
 { #category : #meta }
 FamixTAccess classSide >> annotation [
 
-	<MSEClass: #TAccess super: #Object>
+	<FMClass: #TAccess super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -36,7 +36,7 @@ FamixTAccess >> accessor [
 	"Relation named: #accessor type: #FamixTWithAccesses opposite: #accesses"
 
 	<generated>
-	<MSEComment: 'Behavioural entity making the access to the variable. from-side of the association'>
+	<FMComment: 'Behavioural entity making the access to the variable. from-side of the association'>
 	<source>
 	^ accessor
 ]
@@ -68,16 +68,16 @@ FamixTAccess >> isAccess [
 
 { #category : #accessing }
 FamixTAccess >> isRead [
-	<MSEProperty: #isRead type: #Boolean> <derived>
-	<MSEComment: 'Read access'>
+	<FMProperty: #isRead type: #Boolean> <derived>
+	<FMComment: 'Read access'>
 	
 	^ isWrite isNil ifTrue: [ false ] ifFalse: [ isWrite not ]
 ]
 
 { #category : #accessing }
 FamixTAccess >> isReadWriteUnknown [
-	<MSEProperty: #isReadWriteUnknown type: #Boolean> <derived>
-	<MSEComment: ''>
+	<FMProperty: #isReadWriteUnknown type: #Boolean> <derived>
+	<FMComment: ''>
 	
 	^ isWrite isNil
 ]
@@ -85,9 +85,9 @@ FamixTAccess >> isReadWriteUnknown [
 { #category : #accessing }
 FamixTAccess >> isWrite [
 
-	<MSEProperty: #isWrite type: #Boolean> 
+	<FMProperty: #isWrite type: #Boolean> 
 	<derived>
-	<MSEComment: 'Write access'>
+	<FMComment: 'Write access'>
 	^ isWrite ifNil: [ false ]
 ]
 
@@ -114,7 +114,7 @@ FamixTAccess >> variable [
 	"Relation named: #variable type: #FamixTAccessible opposite: #incomingAccesses"
 
 	<generated>
-	<MSEComment: 'Variable accessed. to-side of the association'>
+	<FMComment: 'Variable accessed. to-side of the association'>
 	<target>
 	^ variable
 ]

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTAccessible classSide >> annotation [
 
-	<MSEClass: #TAccessible super: #Object>
+	<FMClass: #TAccessible super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -30,7 +30,7 @@ FamixTAccessible >> accessingMethods [
 
 { #category : #accessing }
 FamixTAccessible >> accessors [
-	<MSEProperty: #accessors type: #FamixTWithAccesses>
+	<FMProperty: #accessors type: #FamixTWithAccesses>
 	<multivalued>
 	<derived>
 	^ (self incomingAccesses collectAsSet: [ :each | each accessor ]) asMooseGroup
@@ -60,7 +60,7 @@ FamixTAccessible >> incomingAccesses [
 	"Relation named: #incomingAccesses type: #FamixTAccess opposite: #variable"
 
 	<generated>
-	<MSEComment: 'All Famix accesses pointing to this structural entity'>
+	<FMComment: 'All Famix accesses pointing to this structural entity'>
 	<derived>
 	^ incomingAccesses
 ]
@@ -89,9 +89,9 @@ FamixTAccessible >> localAccesses [
 
 { #category : #accessing }
 FamixTAccessible >> numberOfAccesses [
-	<MSEProperty: #numberOfAccesses type: #Number>
+	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
-	<MSEComment: 'The number of accesses of an attribute.'>
+	<FMComment: 'The number of accesses of an attribute.'>
 
 	^self
 		lookUpPropertyNamed: #numberOfAccesses
@@ -100,9 +100,9 @@ FamixTAccessible >> numberOfAccesses [
 
 { #category : #accessing }
 FamixTAccessible >> numberOfAccessingClasses [
-	<MSEProperty: #numberOfAccessingClasses type: #Number>
+	<FMProperty: #numberOfAccessingClasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of classes from which at least one method accesses an attribute.'>
+	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
 
 	^self
 		lookUpPropertyNamed: #numberOfAccessingClasses
@@ -111,9 +111,9 @@ FamixTAccessible >> numberOfAccessingClasses [
 
 { #category : #accessing }
 FamixTAccessible >> numberOfAccessingMethods [
-	<MSEProperty: #numberOfAccessingMethods type: #Number>
+	<FMProperty: #numberOfAccessingMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods accessing an attribute.'>				
+	<FMComment: 'The number of methods accessing an attribute.'>				
 	
 	^self
 		lookUpPropertyNamed: #numberOfAccessingMethods
@@ -122,9 +122,9 @@ FamixTAccessible >> numberOfAccessingMethods [
 
 { #category : #accessing }
 FamixTAccessible >> numberOfGlobalAccesses [
-	<MSEProperty: #numberOfGlobalAccesses type: #Number>
+	<FMProperty: #numberOfGlobalAccesses type: #Number>
 	<derived>
-	<MSEComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
 
 	^self
 		lookUpPropertyNamed: #numberOfGlobalAccesses
@@ -133,9 +133,9 @@ FamixTAccessible >> numberOfGlobalAccesses [
 
 { #category : #accessing }
 FamixTAccessible >> numberOfLocalAccesses [
-	<MSEProperty: #numberOfLocalAccesses type: #Number>
+	<FMProperty: #numberOfLocalAccesses type: #Number>
 	<derived>
-	<MSEComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
+	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
 		
 	^self
 		lookUpPropertyNamed: #numberOfLocalAccesses

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -24,7 +24,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationInstance classSide >> annotation [
 
-	<MSEClass: #TAnnotationInstance super: #Object>
+	<FMClass: #TAnnotationInstance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -43,7 +43,7 @@ FamixTAnnotationInstance >> annotatedEntity [
 	"Relation named: #annotatedEntity type: #FamixTWithAnnotationInstances opposite: #annotationInstances"
 
 	<generated>
-	<MSEComment: 'The NamedEntity on which the annotation occurs.'>
+	<FMComment: 'The NamedEntity on which the annotation occurs.'>
 	<container>
 	^ annotatedEntity
 ]
@@ -61,4 +61,12 @@ FamixTAnnotationInstance >> annotatedEntityGroup [
 	<generated>
 	<navigation: 'AnnotatedEntity'>
 	^ MooseGroup with: self annotatedEntity
+]
+
+{ #category : #accessing }
+FamixTAnnotationInstance >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -23,10 +23,18 @@ Trait {
 { #category : #meta }
 FamixTAnnotationInstanceAttribute classSide >> annotation [
 
-	<MSEClass: #TAnnotationInstanceAttribute super: #Object>
+	<FMClass: #TAnnotationInstanceAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
+]
+
+{ #category : #accessing }
+FamixTAnnotationInstanceAttribute >> numberOfChildren [
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
+	<derived>
+	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]
 
 { #category : #accessing }
@@ -34,7 +42,7 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstance [
 	"Relation named: #parentAnnotationInstance type: #FamixTWithAnnotationInstanceAttributes opposite: #attributes"
 
 	<generated>
-	<MSEComment: 'The instance of the annotation in which the attribute is used.'>
+	<FMComment: 'The instance of the annotation in which the attribute is used.'>
 	<container>
 	^ parentAnnotationInstance
 ]
@@ -57,9 +65,9 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstanceGroup [
 { #category : #accessing }
 FamixTAnnotationInstanceAttribute >> value [
 
-	<MSEProperty: #value type: #String>
+	<FMProperty: #value type: #String>
 	<generated>
-	<MSEComment: 'Actual value of the attribute used in an annotation'>
+	<FMComment: 'Actual value of the attribute used in an annotation'>
 	^ value
 ]
 

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -17,7 +17,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationType classSide >> annotation [
 
-	<MSEClass: #TAnnotationType super: #Object>
+	<FMClass: #TAnnotationType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -43,7 +43,7 @@ FamixTAnnotationType >> annotationTypesContainer [
 	"Relation named: #annotationTypesContainer type: #FamixTWithAnnotationTypes opposite: #definedAnnotationTypes"
 
 	<generated>
-	<MSEComment: 'Container in which an AnnotationType may reside'>
+	<FMComment: 'Container in which an AnnotationType may reside'>
 	<container>
 	^ annotationTypesContainer
 ]
@@ -68,7 +68,7 @@ FamixTAnnotationType >> instances [
 	"Relation named: #instances type: #FamixTTypedAnnotationInstance opposite: #annotationType"
 
 	<generated>
-	<MSEComment: 'Annotations of this type'>
+	<FMComment: 'Annotations of this type'>
 	<derived>
 	^ instances
 ]

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -27,7 +27,7 @@ Trait {
 { #category : #meta }
 FamixTAnnotationTypeAttribute classSide >> annotation [
 
-	<MSEClass: #TAnnotationTypeAttribute super: #Object>
+	<FMClass: #TAnnotationTypeAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -44,7 +44,7 @@ FamixTAnnotationTypeAttribute >> annotationAttributeInstances [
 	"Relation named: #annotationAttributeInstances type: #FamixTTypedAnnotationInstanceAttribute opposite: #annotationTypeAttribute"
 
 	<generated>
-	<MSEComment: 'A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances'>
+	<FMComment: 'A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances'>
 	<derived>
 	^ annotationAttributeInstances
 ]

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -29,7 +29,7 @@ Trait {
 { #category : #meta }
 FamixTAssociation classSide >> annotation [
 
-	<MSEClass: #TAssociation super: #Object>
+	<FMClass: #TAssociation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -47,7 +47,7 @@ FamixTAssociation >> next [
 	"Relation named: #next type: #FamixTAssociation opposite: #previous"
 
 	<generated>
-	<MSEComment: 'Next association in an ordered collection of associations. Currently not supported by the Moose importer'>
+	<FMComment: 'Next association in an ordered collection of associations. Currently not supported by the Moose importer'>
 	<derived>
 	^ next
 ]
@@ -65,7 +65,7 @@ FamixTAssociation >> previous [
 	"Relation named: #previous type: #FamixTAssociation opposite: #next"
 
 	<generated>
-	<MSEComment: 'Previous association in an ordered collection of associations. Currently not supported by the Moose importer'>
+	<FMComment: 'Previous association in an ordered collection of associations. Currently not supported by the Moose importer'>
 	^ previous
 ]
 

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTAttribute classSide >> annotation [
 
-	<MSEClass: #TAttribute super: #Object>
+	<FMClass: #TAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -33,7 +33,7 @@ FamixTAttribute >> parentType [
 	"Relation named: #parentType type: #FamixTWithAttributes opposite: #attributes"
 
 	<generated>
-	<MSEComment: 'Type declaring the attribute. belongsTo implementation'>
+	<FMComment: 'Type declaring the attribute. belongsTo implementation'>
 	<container>
 	^ parentType
 ]

--- a/src/Famix-Traits/FamixTCaughtException.trait.st
+++ b/src/Famix-Traits/FamixTCaughtException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTCaughtException classSide >> annotation [
 
-	<MSEClass: #TCaughtException super: #Object>
+	<FMClass: #TCaughtException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTClass classSide >> annotation [
 
-	<MSEClass: #TClass super: #Object>
+	<FMClass: #TClass super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -29,6 +29,14 @@ FamixTClass classSide >> famixTClassRelatedGroup [
 	^ FAMIXClassGroup
 ]
 
+{ #category : #metrics }
+FamixTClass >> fanIn [
+	<FMProperty: #fanIn type: #Number>
+	<derived>
+	<FMComment: 'Number of client classes'>
+	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
+]
+
 { #category : #testing }
 FamixTClass >> isClass [
 
@@ -39,8 +47,8 @@ FamixTClass >> isClass [
 { #category : #testing }
 FamixTClass >> isTestCase [
 
-	<MSEProperty: #isTestCase type: #Boolean>
-	<MSEComment: 'True if the method is considered as a test'>
+	<FMProperty: #isTestCase type: #Boolean>
+	<FMComment: 'True if the method is considered as a test'>
 	<derived>
 
 	^ self privateState attributeAt: #isTestCase ifAbsent: [ false ]
@@ -52,10 +60,269 @@ FamixTClass >> isTestCase: aBoolean [
 ]
 
 { #category : #metrics }
-FamixTClass >> weightOfAClass [
-	<MSEProperty: #weightOfAClass type: #Number>
+FamixTClass >> numberOfAbstractMethods [
+	<FMProperty: #numberOfAbstractMethods type: #Number>
 	<derived>
-	<MSEComment: 'Weight of a class'>	
+	<FMComment: 'The number of abstract methods in the class'>
+	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfAccessesToForeignData [
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
+	<derived>
+	<FMComment: 'Number of accesses to foreign data'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAccessesToForeignData
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfAccessorMethods [
+	<FMProperty: #numberOfAccessorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of accessor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfAccessorMethods
+		computedAs: [ 
+			| noa |
+			noa := 0.
+			self methods
+				do: [ :method | 
+					method isPureAccessor
+						ifNotNil: [ 
+							(method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNil not ])
+								ifTrue: [ noa := noa + 1 ] ] ].
+			noa ]
+]
+
+{ #category : #'Famix-Extensions' }
+FamixTClass >> numberOfAttributes [
+	<FMProperty: #numberOfAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of attributes in the class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfAttributes
+		computedAs: [self attributes size]
+]
+
+{ #category : #accessing }
+FamixTClass >> numberOfComments [
+	<FMProperty: #numberOfComments type: #Number>
+	<derived>
+	<FMComment: 'The number of comments in a class'>
+	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfDuplicatedLinesOfCodeInternally [
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<derived>
+	<FMComment: 'The number of duplicated lines of code internally'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
+		computedAs: [self notExistentMetricValue]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfLinesOfCode [
+
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<derived>
+	<FMComment: 'The number of lines of code in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [self methodsGroup sumNumbers: #numberOfLinesOfCode]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfMessageSends [
+	<FMProperty: #numberOfMessageSends type: #Number>
+	<derived>
+	<FMComment: 'The number of message sends from a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMessageSends
+		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfMethodProtocols [
+	<FMProperty: #numberOfMethodProtocols type: #Number>
+	<derived>
+	<FMComment: 'The number of method protocols in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfMethodProtocols
+		computedAs: [((self methods collect: [:each | each protocol]) reject: #isNil) asSet size]
+]
+
+{ #category : #accessing }
+FamixTClass >> numberOfMethods [
+	<FMProperty: #numberOfMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of methods in a class'>
+
+	^self
+		lookUpPropertyNamed: #numberOfMethods
+		computedAs: [self methods size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfPrivateAttributes [
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of private attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPrivateAttributes
+		computedAs: [(self attributes select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfPrivateMethods [
+	<FMProperty: #numberOfPrivateMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of private methods in a class'>
+			
+	^self
+		lookUpPropertyNamed: #numberOfPrivateMethods
+		computedAs: [(self methods select: [:each | each isPrivate]) size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfProtectedAttributes [
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of protected attributes in a class'>				
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedAttributes
+		computedAs: [(self attributes select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfProtectedMethods [
+	<FMProperty: #numberOfProtectedMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of protected methods in a class'>		
+	
+	^self
+		lookUpPropertyNamed: #numberOfProtectedMethods
+		computedAs: [(self methods select: [:each | each isProtected]) size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfPublicAttributes [
+	<FMProperty: #numberOfPublicAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes in a class'>
+	
+	^self
+		lookUpPropertyNamed: #numberOfPublicAttributes
+		computedAs: [(self attributes select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfPublicMethods [
+	<FMProperty: #numberOfPublicMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of public methods in a class'>		
+		
+	^self
+		lookUpPropertyNamed: #numberOfPublicMethods
+		computedAs: [(self methods select: [:each | each isPublic]) size]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfRevealedAttributes [
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
+	<derived>
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
+
+	^self
+		lookUpPropertyNamed: #numberOfRevealedAttributes
+		computedAs:
+			[self numberOfPublicAttributes + self numberOfAccessorMethods]
+]
+
+{ #category : #metrics }
+FamixTClass >> numberOfSubclasses [
+	<FMProperty: #numberOfSubclasses type: #Number>
+	<derived>
+	<FMComment: 'The number of subclasses of a class'>
+	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
+]
+
+{ #category : #metrics }
+FamixTClass >> tightClassCohesion [
+	<FMProperty: #tightClassCohesion type: #Number>
+	<derived>
+	<FMComment: 'Tight class cohesion of a class'>
+	self flag: #TODO.
+	^ self
+		lookUpPropertyNamed: #tightClassCohesion
+		computedAs: [ 
+			| tcc accessDictionary nom |
+			tcc := 0.
+			accessDictionary := Dictionary new.
+			self
+				methods do: [ :eachMethod | 
+					eachMethod accesses
+						do: [ :eachAccess | 
+							| var |
+							var := eachAccess variable.
+							var isAttribute
+								ifTrue: [ 
+									| varName accessedFrom |
+									varName := var name.
+									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
+									accessedFrom isNil
+										ifTrue: [ 
+											accessedFrom := Set new.
+											accessDictionary at: varName put: accessedFrom ].
+									accessedFrom add: eachMethod name ] ] ].
+			accessDictionary values
+				do: [ :each | 
+					| size |
+					size := each size.
+					tcc := tcc + (size * (size - 1) / 2) ].
+			nom := self numberOfMethods.
+			tcc := (nom = 0 or: [ nom = 1 ])
+				ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				ifTrue: [ 0 ].
+			tcc asFloat ]
+]
+
+{ #category : #metrics }
+FamixTClass >> weightOfAClass [
+	<FMProperty: #weightOfAClass type: #Number>
+	<derived>
+	<FMComment: 'Weight of a class'>	
 			
 	^self
 		lookUpPropertyNamed: #weightOfAClass
@@ -66,4 +333,15 @@ FamixTClass >> weightOfAClass [
 FamixTClass >> weightOfAClass: aNumber [
 
 	self privateState propertyAt: #weightOfAClass put: aNumber
+]
+
+{ #category : #metrics }
+FamixTClass >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<derived>
+	<FMComment: 'The sum of the complexity in a class'>
+			
+	^self
+		lookUpPropertyNamed: #weightedMethodCount
+		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
 ]

--- a/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
+++ b/src/Famix-Traits/FamixTClassHierarchyNavigation.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTClassHierarchyNavigation classSide >> annotation [
 
-	<MSEClass: #TClassHierarchyNavigation super: #Object>
+	<FMClass: #TClassHierarchyNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -70,9 +70,9 @@ FamixTClassHierarchyNavigation >> directSuperclasses [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> hierarchyNestingLevel [
-	<MSEProperty: #hierarchyNestingLevel type: #Number>
+	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
-	<MSEComment: 'The nesting of a class inside the hierarchy'>
+	<FMComment: 'The nesting of a class inside the hierarchy'>
 
 	^self
 		lookUpPropertyNamed: #hierarchyNestingLevel
@@ -154,9 +154,9 @@ FamixTClassHierarchyNavigation >> isHierarchyRootWithin: aClassGroup [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfAttributesInherited [
-	<MSEProperty: #numberOfAttributesInherited type: #Number>
+	<FMProperty: #numberOfAttributesInherited type: #Number>
 	<derived>
-	<MSEComment: 'The number of attributes in a class inherited from super classes'>	
+	<FMComment: 'The number of attributes in a class inherited from super classes'>	
 	
 	^self
 		lookUpPropertyNamed: #numberOfAttributesInherited
@@ -171,8 +171,8 @@ FamixTClassHierarchyNavigation >> numberOfAttributesInherited: aNumber [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfDirectSubclasses [
-	<MSEProperty: #numberOfDirectSubclasses type: #Number>
-	<MSEComment: 'The number of direct subclasses'>
+	<FMProperty: #numberOfDirectSubclasses type: #Number>
+	<FMComment: 'The number of direct subclasses'>
 	<derived>
 
 	^ self privateState propertyAt: #numberOfDirectSubclasses ifAbsentPut: [self directSubclasses size]
@@ -186,9 +186,9 @@ FamixTClassHierarchyNavigation >> numberOfDirectSubclasses: aNumber [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfMethodsAdded [
-	<MSEProperty: #numberOfMethodsAdded type: #Number>
+	<FMProperty: #numberOfMethodsAdded type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a class added with respect to super classes'>	
+	<FMComment: 'The number of methods in a class added with respect to super classes'>	
 	
 	^self
 		lookUpPropertyNamed: #numberOfMethodsAdded
@@ -203,9 +203,9 @@ FamixTClassHierarchyNavigation >> numberOfMethodsAdded: aNumber [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfMethodsInHierarchy [
-	<MSEProperty: #numberOfMethodsInHierarchy type: #Number>
+	<FMProperty: #numberOfMethodsInHierarchy type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods of a class included the inherited ones'>	
+	<FMComment: 'The number of methods of a class included the inherited ones'>	
 	
 	| totNom |
 	totNom := self methods size.
@@ -222,9 +222,9 @@ FamixTClassHierarchyNavigation >> numberOfMethodsInHierarchy: aNumber [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfMethodsInherited [
-	<MSEProperty: #numberOfMethodsInherited type: #Number>
+	<FMProperty: #numberOfMethodsInherited type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a class inherited from super classes'>	
+	<FMComment: 'The number of methods in a class inherited from super classes'>	
 
 	^self
 		lookUpPropertyNamed: #numberOfMethodsInherited
@@ -239,9 +239,9 @@ FamixTClassHierarchyNavigation >> numberOfMethodsInherited: aNumber [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfMethodsOverriden [
-	<MSEProperty: #numberOfMethodsOverriden type: #Number>
+	<FMProperty: #numberOfMethodsOverriden type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a class overriden with respect to super classes'>
+	<FMComment: 'The number of methods in a class overriden with respect to super classes'>
 			
 	^self
 		lookUpPropertyNamed: #numberOfMethodsOverriden
@@ -256,9 +256,9 @@ FamixTClassHierarchyNavigation >> numberOfMethodsOverriden: aNumber [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> numberOfParents [
-	<MSEProperty: #numberOfParents type: #Number>
+	<FMProperty: #numberOfParents type: #Number>
 	<derived>
-	<MSEComment: 'The number of superclasses'>
+	<FMComment: 'The number of superclasses'>
 			
 	^self
 		lookUpPropertyNamed: #numberOfParents
@@ -281,9 +281,9 @@ FamixTClassHierarchyNavigation >> subclassHierarchy [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> subclassHierarchyDepth [ 
-	<MSEProperty: #subclassHierarchyDepth type: #Number>
+	<FMProperty: #subclassHierarchyDepth type: #Number>
 	<derived>
-	<MSEComment: 'The depth of the class hierarchy for which I am the root'>
+	<FMComment: 'The depth of the class hierarchy for which I am the root'>
 		
 	^ self directSubclasses isEmpty 
 		ifTrue: [ 0 ] 
@@ -332,9 +332,9 @@ FamixTClassHierarchyNavigation >> superclassHierarchyGroup [
 
 { #category : #metrics }
 FamixTClassHierarchyNavigation >> totalNumberOfChildren [
-	<MSEProperty: #totalNumberOfChildren type: #Number>
+	<FMProperty: #totalNumberOfChildren type: #Number>
 	<derived>	
-	<MSEComment: 'The total number of subclasses of a class'>
+	<FMComment: 'The total number of subclasses of a class'>
 	
 	^self
 		lookUpPropertyNamed: #totalNumberOfChildren

--- a/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
+++ b/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
@@ -8,7 +8,7 @@ Trait {
 { #category : #meta }
 FamixTCohesionCouplingMetrics classSide >> annotation [
 
-	<MSEClass: #TCohesionCouplingMetrics super: #Object>
+	<FMClass: #TCohesionCouplingMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -17,9 +17,9 @@ FamixTCohesionCouplingMetrics classSide >> annotation [
 { #category : #metrics }
 FamixTCohesionCouplingMetrics >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."
-	<MSEProperty: #abstractness type: #Number>
+	<FMProperty: #abstractness type: #Number>
 	<derived>
-	<MSEComment: 'Abstractness of a package'>
+	<FMComment: 'Abstractness of a package'>
 
 	| nsClasses |
 	nsClasses := self childEntities .
@@ -30,9 +30,9 @@ FamixTCohesionCouplingMetrics >> abstractness [
 
 { #category : #metrics }
 FamixTCohesionCouplingMetrics >> afferentCoupling [
-	<MSEProperty: #afferentCoupling type: #Number>
+	<FMProperty: #afferentCoupling type: #Number>
 	<derived>
-	<MSEComment:
+	<FMComment:
 		'Afferent Coupling of a namespace Afferent is the number of classes that depend upon this namespace'>
 	^ (((self queryAllIncoming outOfParentUsing: FamixTPackage) atScope: FamixTType) collect: [ :e | e isClassSide ifTrue: [ e instanceSide ] ifFalse: [ e ] ]) asSet  size
 ]
@@ -40,9 +40,9 @@ FamixTCohesionCouplingMetrics >> afferentCoupling [
 { #category : #metrics }
 FamixTCohesionCouplingMetrics >> distance [
 	"D = A + I - 1. A package should be balanced between abstractness and instability, i.e., somewhere between abstract and stable or concrete and unstable. This rule defines the main sequence by the equation A + I - 1 = 0. D is the distance to the main sequence."
-	<MSEProperty: #distance type: #Number>
+	<FMProperty: #distance type: #Number>
 	<derived>
-	<MSEComment: 'Distance of a package'>
+	<FMComment: 'Distance of a package'>
 
 	
 	| abstractness instability |
@@ -57,9 +57,9 @@ FamixTCohesionCouplingMetrics >> distance [
 FamixTCohesionCouplingMetrics >> efferentCoupling [
 	"Efferent coupling for a package is the number of classes it depends upon"
 
-	<MSEProperty: #efferentCoupling type: #Number>
+	<FMProperty: #efferentCoupling type: #Number>
 	<derived>
-	<MSEComment: 'Efferent Coupling of a package'>
+	<FMComment: 'Efferent Coupling of a package'>
 
 	^ (((self queryAllOutgoing outOfParentUsing: FamixTPackage) atScope: FamixTType) collect: [ :e | e isClassSide ifTrue: [ e instanceSide ] ifFalse: [ e ] ] ) asSet size
 ]
@@ -68,9 +68,9 @@ FamixTCohesionCouplingMetrics >> efferentCoupling [
 FamixTCohesionCouplingMetrics >> instability [
 	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
 
-	<MSEProperty: #instability type: #Number>
+	<FMProperty: #instability type: #Number>
 	<derived>
-	<MSEComment: 'Instability of a package'>
+	<FMComment: 'Instability of a package'>
 
 	| efferentCoupling afferentCoupling |
 	
@@ -84,9 +84,9 @@ FamixTCohesionCouplingMetrics >> instability [
 FamixTCohesionCouplingMetrics >> martinCohesion [
 	"Computing cohesion as described by Robert C. Martin"
 
-	<MSEProperty: #martinCohesion type: #Number>
+	<FMProperty: #martinCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Cohesion as defined by Robert C. Martin.'>
+	<FMComment: 'Cohesion as defined by Robert C. Martin.'>
 	| intraConnectivities myClasses |
 	myClasses := self childEntities select: #isClass.
 	myClasses := (myClasses union: (myClasses flatCollect: [ :c | c allRecursiveTypes ])) select: [ :c | c isInstanceSide ].
@@ -96,4 +96,12 @@ FamixTCohesionCouplingMetrics >> martinCohesion [
 		inject: 0
 		into: [ :subTotal :each | subTotal + (each select: [ :c | c isInstanceSide ]) size ].
 	^ ((intraConnectivities + 1) / myClasses size) asFloat
+]
+
+{ #category : #metrics }
+FamixTCohesionCouplingMetrics >> weightedMethodCount [
+	<FMProperty: #weightedMethodCount type: #Number>
+	<FMComment: 'The sum of the complexity in a package'>
+	<derived>
+	^ self lookUpPropertyNamed: #WMC computedAs: [ (self toScope: FamixTWithMethods) detectSum: #weightedMethodCount ]
 ]

--- a/src/Famix-Traits/FamixTComment.trait.st
+++ b/src/Famix-Traits/FamixTComment.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 FamixTComment classSide >> annotation [
 
-	<MSEClass: #TComment super: #Object>
+	<FMClass: #TComment super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -31,7 +31,7 @@ FamixTComment >> container [
 	"Relation named: #container type: #FamixTWithComments opposite: #comments"
 
 	<generated>
-	<MSEComment: 'Source code entity containing the comment'>
+	<FMComment: 'Source code entity containing the comment'>
 	^ container
 ]
 
@@ -46,9 +46,9 @@ FamixTComment >> container: anObject [
 { #category : #accessing }
 FamixTComment >> content [
 
-	<MSEProperty: #content type: #String>
+	<FMProperty: #content type: #String>
 	<generated>
-	<MSEComment: 'Content of the comment as a String'>
+	<FMComment: 'Content of the comment as a String'>
 	^ content
 ]
 

--- a/src/Famix-Traits/FamixTCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTCompilationUnit.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTCompilationUnit classSide >> annotation [
 
-	<MSEClass: #TCompilationUnit super: #Object>
+	<FMClass: #TCompilationUnit super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -23,7 +23,7 @@ FamixTCompilationUnit >> compilationUnitOwner [
 	"Relation named: #compilationUnitOwner type: #FamixTWithCompilationUnit opposite: #compilationUnit"
 
 	<generated>
-	<MSEComment: 'The compilation unit that defines this module'>
+	<FMComment: 'The compilation unit that defines this module'>
 	^ compilationUnitOwner
 ]
 

--- a/src/Famix-Traits/FamixTDeclaredException.trait.st
+++ b/src/Famix-Traits/FamixTDeclaredException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTDeclaredException classSide >> annotation [
 
-	<MSEClass: #TDeclaredException super: #Object>
+	<FMClass: #TDeclaredException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTDefinedInModule.trait.st
+++ b/src/Famix-Traits/FamixTDefinedInModule.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTDefinedInModule classSide >> annotation [
 
-	<MSEClass: #TDefinedInModule super: #Object>
+	<FMClass: #TDefinedInModule super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTDefinedInModule >> parentModule [
 	"Relation named: #parentModule type: #FamixTModule opposite: #moduleEntities"
 
 	<generated>
-	<MSEComment: 'Module that contains the definition of this entity'>
+	<FMComment: 'Module that contains the definition of this entity'>
 	^ parentModule
 ]
 

--- a/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
+++ b/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
@@ -16,7 +16,7 @@ Trait {
 { #category : #meta }
 FamixTDereferencedInvocation classSide >> annotation [
 
-	<MSEClass: #TDereferencedInvocation super: #Object>
+	<FMClass: #TDereferencedInvocation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -27,7 +27,7 @@ FamixTDereferencedInvocation >> referencer [
 	"Relation named: #referencer type: #FamixTWithDereferencedInvocations opposite: #dereferencedInvocations"
 
 	<generated>
-	<MSEComment: 'Structural entity that references the BehaviouralEntity invoked'>
+	<FMComment: 'Structural entity that references the BehaviouralEntity invoked'>
 	^ referencer
 ]
 

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -22,7 +22,7 @@ Trait {
 { #category : #meta }
 FamixTEnumValue classSide >> annotation [
 
-	<MSEClass: #TEnumValue super: #Object>
+	<FMClass: #TEnumValue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -46,7 +46,7 @@ FamixTEnumValue >> parentEnum [
 	"Relation named: #parentEnum type: #FamixTWithEnumValues opposite: #enumValues"
 
 	<generated>
-	<MSEComment: 'The Enum declaring this value. It offers the implementation of belongsTo'>
+	<FMComment: 'The Enum declaring this value. It offers the implementation of belongsTo'>
 	<container>
 	^ parentEnum
 ]

--- a/src/Famix-Traits/FamixTException.trait.st
+++ b/src/Famix-Traits/FamixTException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTException classSide >> annotation [
 
-	<MSEClass: #TException super: #Object>
+	<FMClass: #TException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -23,7 +23,7 @@ FamixTException >> exceptionClass [
 	"Relation named: #exceptionClass type: #FamixTWithExceptions opposite: #exceptions"
 
 	<generated>
-	<MSEComment: 'Class to which the exception points. It is specific to Java'>
+	<FMComment: 'Class to which the exception points. It is specific to Java'>
 	^ exceptionClass
 ]
 

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTFile classSide >> annotation [
 
-	<MSEClass: #TFile super: #Object>
+	<FMClass: #TFile super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -35,8 +35,8 @@ FamixTFile >> addEntity: famixEntity [
 
 { #category : #accessing }
 FamixTFile >> averageNumberOfCharactersPerLine [
-	<MSEProperty: #averageNumberOfCharactersPerLine type: #Number>
-	<MSEComment: 'Average number of characters per line of text in a file.'>
+	<FMProperty: #averageNumberOfCharactersPerLine type: #Number>
+	<FMComment: 'Average number of characters per line of text in a file.'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #averageNumberOfCharactersPerLine
@@ -50,7 +50,7 @@ FamixTFile >> entities [
 	"Relation named: #entities type: #FamixTWithFiles opposite: #containerFiles"
 
 	<generated>
-	<MSEComment: 'List of entities defined in the file'>
+	<FMComment: 'List of entities defined in the file'>
 	<derived>
 	^ entities
 ]
@@ -95,8 +95,8 @@ FamixTFile >> isFolder [
 
 { #category : #properties }
 FamixTFile >> numberOfBytes [
-	<MSEProperty: #numberOfBytes type: #Number>
-	<MSEComment: 'Number of bytes in a file.'>
+	<FMProperty: #numberOfBytes type: #Number>
+	<FMComment: 'Number of bytes in a file.'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #numberOfBytes
@@ -107,16 +107,16 @@ FamixTFile >> numberOfBytes [
 
 { #category : #properties }
 FamixTFile >> numberOfCharacters [
-	<MSEProperty: #numberOfCharacters type: #Number>
-	<MSEComment: 'Number of characters in a file.'>
+	<FMProperty: #numberOfCharacters type: #Number>
+	<FMComment: 'Number of characters in a file.'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfCharacters computedAs: [ self sourceText size ]
 ]
 
 { #category : #properties }
 FamixTFile >> numberOfEmptyLinesOfText [
-	<MSEProperty: #numberOfEmptyLinesOfText type: #Number>
-	<MSEComment: 'Number of empty lines of text'>
+	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
+	<FMComment: 'Number of empty lines of text'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #numberOfEmptyLinesOfText
@@ -127,10 +127,18 @@ FamixTFile >> numberOfEmptyLinesOfText [
 
 { #category : #properties }
 FamixTFile >> numberOfKiloBytes [
-	<MSEProperty: #numberOfKiloBytes type: #Number>
-	<MSEComment: 'Number of kilo bytes in a file.'>
+	<FMProperty: #numberOfKiloBytes type: #Number>
+	<FMComment: 'Number of kilo bytes in a file.'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfKiloBytes computedAs: [ (self numberOfBytes / 1024) asFloat ]
+]
+
+{ #category : #accessing }
+FamixTFile >> numberOfLinesOfText [
+	<FMProperty: #numberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text which are not empty in a file'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
 ]
 
 { #category : #properties }
@@ -158,8 +166,8 @@ FamixTFile >> sourceText: aString [
 
 { #category : #properties }
 FamixTFile >> totalNumberOfLinesOfText [
-	<MSEProperty: #totalNumberOfLinesOfText type: #Number>
-	<MSEComment: 'Number of lines of text'>
+	<FMProperty: #totalNumberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #totalNumberOfLinesOfText

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTFileAnchor classSide >> annotation [
 
-	<MSEClass: #TFileAnchor super: #Object>
+	<FMClass: #TFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -42,9 +42,9 @@ FamixTFileAnchor >> containerFiles [
 { #category : #accessing }
 FamixTFileAnchor >> correspondingFile [
 
-	<MSEProperty: #correspondingFile type: #FamixTFile>
+	<FMProperty: #correspondingFile type: #FamixTFile>
 	<generated>
-	<MSEComment: 'File associated to this source anchor'>
+	<FMComment: 'File associated to this source anchor'>
 	^ correspondingFile
 ]
 
@@ -67,8 +67,8 @@ FamixTFileAnchor >> detectEncoding [
 
 { #category : #accessing }
 FamixTFileAnchor >> encoding [
-	<MSEProperty: #encoding type: #String>
-	<MSEComment: 'A string representing the encoding of a file'>
+	<FMProperty: #encoding type: #String>
+	<FMComment: 'A string representing the encoding of a file'>
 	^ encoding ifNil: [ encoding := self detectEncoding ]
 ]
 
@@ -83,9 +83,9 @@ FamixTFileAnchor >> encoding: anObject [
 { #category : #accessing }
 FamixTFileAnchor >> fileName [
 
-	<MSEProperty: #fileName type: #String>
+	<FMProperty: #fileName type: #String>
 	<generated>
-	<MSEComment: 'Name of the source file'>
+	<FMComment: 'Name of the source file'>
 	^ fileName
 ]
 

--- a/src/Famix-Traits/FamixTFileInclude.trait.st
+++ b/src/Famix-Traits/FamixTFileInclude.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTFileInclude classSide >> annotation [
 
-	<MSEClass: #TFileInclude super: #Object>
+	<FMClass: #TFileInclude super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -21,7 +21,7 @@ FamixTFileInclude >> source [
 	"Relation named: #source type: #FamixTWithFileIncludes opposite: #outgoingIncludeRelations"
 
 	<generated>
-	<MSEComment: 'The file that is including'>
+	<FMComment: 'The file that is including'>
 	^ source
 ]
 
@@ -38,7 +38,7 @@ FamixTFileInclude >> target [
 	"Relation named: #target type: #FamixTWithFileIncludes opposite: #incomingIncludeRelations"
 
 	<generated>
-	<MSEComment: 'The file that is included'>
+	<FMComment: 'The file that is included'>
 	^ target
 ]
 

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTFileNavigation classSide >> annotation [
 
-	<MSEClass: #TFileNavigation super: #Object>
+	<FMClass: #TFileNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -44,9 +44,9 @@ FamixTFileNavigation classSide >> fileName: aString startLine: anInteger startCo
 { #category : #accessing }
 FamixTFileNavigation >> endColumn [
 
-	<MSEProperty: #endColumn type: #Number>
+	<FMProperty: #endColumn type: #Number>
 	<generated>
-	<MSEComment: 'Number of the end column'>
+	<FMComment: 'Number of the end column'>
 	^ endColumn
 ]
 
@@ -61,9 +61,9 @@ FamixTFileNavigation >> endColumn: anObject [
 { #category : #accessing }
 FamixTFileNavigation >> endLine [
 
-	<MSEProperty: #endLine type: #Number>
+	<FMProperty: #endLine type: #Number>
 	<generated>
-	<MSEComment: 'Number of the end line'>
+	<FMComment: 'Number of the end line'>
 	^ endLine
 ]
 
@@ -152,9 +152,9 @@ FamixTFileNavigation >> sourceText [
 { #category : #accessing }
 FamixTFileNavigation >> startColumn [
 
-	<MSEProperty: #startColumn type: #Number>
+	<FMProperty: #startColumn type: #Number>
 	<generated>
-	<MSEComment: 'Number of the start column'>
+	<FMComment: 'Number of the start column'>
 	^ startColumn
 ]
 
@@ -169,9 +169,9 @@ FamixTFileNavigation >> startColumn: anObject [
 { #category : #accessing }
 FamixTFileNavigation >> startLine [
 
-	<MSEProperty: #startLine type: #Number>
+	<FMProperty: #startLine type: #Number>
 	<generated>
-	<MSEComment: 'Number of the start line'>
+	<FMComment: 'Number of the start line'>
 	^ startLine
 ]
 

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTFileSystemEntity classSide >> annotation [
 
-	<MSEClass: #TFileSystemEntity super: #Object>
+	<FMClass: #TFileSystemEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -89,8 +89,8 @@ FamixTFileSystemEntity >> numberOfEmptyLinesOfText [
 
 { #category : #accessing }
 FamixTFileSystemEntity >> numberOfLinesOfText [
-	<MSEProperty: #numberOfLinesOfText type: #Number>
-	<MSEComment: 'Number of lines of text which are not empty in a file'>
+	<FMProperty: #numberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text which are not empty in a file'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
 ]
@@ -100,7 +100,7 @@ FamixTFileSystemEntity >> parentFolder [
 	"Relation named: #parentFolder type: #FamixTFolder opposite: #childrenFileSystemEntities"
 
 	<generated>
-	<MSEComment: 'Folder entity containing this file.'>
+	<FMComment: 'Folder entity containing this file.'>
 	<container>
 	^ parentFolder
 ]

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTFolder classSide >> annotation [
 
-	<MSEClass: #TFolder super: #Object>
+	<FMClass: #TFolder super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -60,7 +60,7 @@ FamixTFolder >> childrenFileSystemEntities [
 	"Relation named: #childrenFileSystemEntities type: #FamixTFileSystemEntity opposite: #parentFolder"
 
 	<generated>
-	<MSEComment: 'List of entities contained in this folder.'>
+	<FMComment: 'List of entities contained in this folder.'>
 	<derived>
 	^ childrenFileSystemEntities
 ]
@@ -102,8 +102,8 @@ FamixTFolder >> isFolder [
 
 { #category : #properties }
 FamixTFolder >> numberOfEmptyLinesOfText [
-	<MSEProperty: #numberOfEmptyLinesOfText type: #Number>
-	<MSEComment: 'Number of empty lines of text'>
+	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
+	<FMComment: 'Number of empty lines of text'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfEmptyLinesOfText computedAs: [ 
 		self files, self folders sumNumbers: #numberOfEmptyLinesOfText
@@ -112,8 +112,8 @@ FamixTFolder >> numberOfEmptyLinesOfText [
 
 { #category : #properties }
 FamixTFolder >> numberOfFiles [
-	<MSEProperty: #numberOfFiles type: #Number>
-	<MSEComment: 'The number of files in a folder'>
+	<FMProperty: #numberOfFiles type: #Number>
+	<FMComment: 'The number of files in a folder'>
 	<derived>
 	^self
 		lookUpPropertyNamed: #numberOfFiles
@@ -122,8 +122,8 @@ FamixTFolder >> numberOfFiles [
 
 { #category : #properties }
 FamixTFolder >> numberOfFolders [
-	<MSEProperty: #numberOfFolders type: #Number>
-	<MSEComment: 'The number of folders in a folder'>
+	<FMProperty: #numberOfFolders type: #Number>
+	<FMComment: 'The number of folders in a folder'>
 	<derived>
 	^self
 		lookUpPropertyNamed: #numberOfFolders
@@ -132,8 +132,8 @@ FamixTFolder >> numberOfFolders [
 
 { #category : #properties }
 FamixTFolder >> totalNumberOfLinesOfText [
-	<MSEProperty: #totalNumberOfLinesOfText type: #Number>
-	<MSEComment: 'Number of lines of text'>
+	<FMProperty: #totalNumberOfLinesOfText type: #Number>
+	<FMComment: 'Number of lines of text'>
 	<derived>
 	^ self
 		lookUpPropertyNamed: #totalNumberOfLinesOfText

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTFunction classSide >> annotation [
 
-	<MSEClass: #TFunction super: #Object>
+	<FMClass: #TFunction super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -23,7 +23,7 @@ FamixTFunction >> functionOwner [
 	"Relation named: #functionOwner type: #FamixTWithFunctions opposite: #functions"
 
 	<generated>
-	<MSEComment: 'The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.'>
+	<FMComment: 'The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.'>
 	<container>
 	^ functionOwner
 ]

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTGlobalVariable classSide >> annotation [
 
-	<MSEClass: #TGlobalVariable super: #Object>
+	<FMClass: #TGlobalVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -34,7 +34,7 @@ FamixTGlobalVariable >> parentScope [
 	"Relation named: #parentScope type: #FamixTGlobalVariableScope opposite: #globalVariables"
 
 	<generated>
-	<MSEComment: 'Scope declaring the global variable. belongsTo implementation'>
+	<FMComment: 'Scope declaring the global variable. belongsTo implementation'>
 	<container>
 	^ parentScope
 ]

--- a/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariableScope.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTGlobalVariableScope classSide >> annotation [
 
-	<MSEClass: #TGlobalVariableScope super: #Object>
+	<FMClass: #TGlobalVariableScope super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTGlobalVariableScope >> globalVariables [
 	"Relation named: #globalVariables type: #FamixTGlobalVariable opposite: #parentScope"
 
 	<generated>
-	<MSEComment: 'Global variables defined in the scope, if any.'>
+	<FMComment: 'Global variables defined in the scope, if any.'>
 	<derived>
 	^ globalVariables
 ]

--- a/src/Famix-Traits/FamixTHeader.trait.st
+++ b/src/Famix-Traits/FamixTHeader.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTHeader classSide >> annotation [
 
-	<MSEClass: #THeader super: #Object>
+	<FMClass: #THeader super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTImplicitVariable classSide >> annotation [
 
-	<MSEClass: #TImplicitVariable super: #Object>
+	<FMClass: #TImplicitVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -32,7 +32,7 @@ FamixTImplicitVariable >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithImplicitVariables opposite: #implicitVariables"
 
 	<generated>
-	<MSEComment: 'The behaviour containing this implicit variable. belongsTo implementation'>
+	<FMComment: 'The behaviour containing this implicit variable. belongsTo implementation'>
 	<container>
 	^ parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTIndexedFileNavigation classSide >> annotation [
 
-	<MSEClass: #TIndexedFileNavigation super: #Object>
+	<FMClass: #TIndexedFileNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -60,9 +60,9 @@ FamixTIndexedFileNavigation >> countNumberOfLinesRuturnsFrom: aStream from: star
 { #category : #accessing }
 FamixTIndexedFileNavigation >> endPos [
 
-	<MSEProperty: #endPos type: #Number>
+	<FMProperty: #endPos type: #Number>
 	<generated>
-	<MSEComment: 'Stop position in the source'>
+	<FMComment: 'Stop position in the source'>
 	^ endPos
 ]
 
@@ -109,9 +109,9 @@ FamixTIndexedFileNavigation >> sourceText [
 { #category : #accessing }
 FamixTIndexedFileNavigation >> startPos [
 
-	<MSEProperty: #startPos type: #Number>
+	<FMProperty: #startPos type: #Number>
 	<generated>
-	<MSEComment: 'Start position in the source'>
+	<FMComment: 'Start position in the source'>
 	^ startPos
 ]
 

--- a/src/Famix-Traits/FamixTInheritance.trait.st
+++ b/src/Famix-Traits/FamixTInheritance.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTInheritance classSide >> annotation [
 
-	<MSEClass: #TInheritance super: #Object>
+	<FMClass: #TInheritance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -38,7 +38,7 @@ FamixTInheritance >> subclass [
 	"Relation named: #subclass type: #FamixTWithInheritances opposite: #superInheritances"
 
 	<generated>
-	<MSEComment: 'Subclass linked to in this relationship. from-side of the association'>
+	<FMComment: 'Subclass linked to in this relationship. from-side of the association'>
 	<source>
 	^ subclass
 ]
@@ -56,7 +56,7 @@ FamixTInheritance >> superclass [
 	"Relation named: #superclass type: #FamixTWithInheritances opposite: #subInheritances"
 
 	<generated>
-	<MSEComment: 'Superclass linked to in this relationship. to-side of the association'>
+	<FMComment: 'Superclass linked to in this relationship. to-side of the association'>
 	<target>
 	^ superclass
 ]

--- a/src/Famix-Traits/FamixTInvocable.trait.st
+++ b/src/Famix-Traits/FamixTInvocable.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTInvocable classSide >> annotation [
 
-	<MSEClass: #TInvocable super: #Object>
+	<FMClass: #TInvocable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTInvocable >> incomingInvocations [
 	"Relation named: #incomingInvocations type: #FamixTInvocation opposite: #candidates"
 
 	<generated>
-	<MSEComment: 'Incoming invocations from other behaviours computed by the candidate operator.'>
+	<FMComment: 'Incoming invocations from other behaviours computed by the candidate operator.'>
 	<derived>
 	^ incomingInvocations
 ]

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -23,7 +23,7 @@ Trait {
 { #category : #meta }
 FamixTInvocation classSide >> annotation [
 
-	<MSEClass: #TInvocation super: #Object>
+	<FMClass: #TInvocation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -54,7 +54,7 @@ FamixTInvocation >> candidates [
 	"Relation named: #candidates type: #FamixTInvocable opposite: #incomingInvocations"
 
 	<generated>
-	<MSEComment: 'List of candidate behavioural entities for receiving the invocation'>
+	<FMComment: 'List of candidate behavioural entities for receiving the invocation'>
 	<target>
 	^ candidates
 ]
@@ -89,7 +89,7 @@ FamixTInvocation >> receiver [
 	"Relation named: #receiver type: #FamixTInvocationsReceiver opposite: #receivingInvocations"
 
 	<generated>
-	<MSEComment: 'Named entity (variable, class...) receiving the invocation. to-side of the association'>
+	<FMComment: 'Named entity (variable, class...) receiving the invocation. to-side of the association'>
 	^ receiver
 ]
 
@@ -106,7 +106,7 @@ FamixTInvocation >> sender [
 	"Relation named: #sender type: #FamixTWithInvocations opposite: #outgoingInvocations"
 
 	<generated>
-	<MSEComment: 'Behavioural entity making the call. from-side of the association'>
+	<FMComment: 'Behavioural entity making the call. from-side of the association'>
 	<source>
 	^ sender
 ]

--- a/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
+++ b/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTInvocationsReceiver classSide >> annotation [
 
-	<MSEClass: #TInvocationsReceiver super: #Object>
+	<FMClass: #TInvocationsReceiver super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTInvocationsReceiver >> receivingInvocations [
 	"Relation named: #receivingInvocations type: #FamixTInvocation opposite: #receiver"
 
 	<generated>
-	<MSEComment: 'List of invocations performed on this entity (considered as the receiver)'>
+	<FMComment: 'List of invocations performed on this entity (considered as the receiver)'>
 	<derived>
 	^ receivingInvocations
 ]

--- a/src/Famix-Traits/FamixTLCOMMetrics.trait.st
+++ b/src/Famix-Traits/FamixTLCOMMetrics.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTLCOMMetrics classSide >> annotation [
 
-	<MSEClass: #TLCOMMetrics super: #Object>
+	<FMClass: #TLCOMMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -66,8 +66,8 @@ FamixTLCOMMetrics >> calculateLCOM3 [
 { #category : #'Famix-Extensions-metrics-support' }
 FamixTLCOMMetrics >> lcom2 [
 
-	<MSEProperty: #lcom2 type: #Number>
-	<MSEComment: 'lack of cohesion in methods 2 (lcom2)'>
+	<FMProperty: #lcom2 type: #Number>
+	<FMComment: 'lack of cohesion in methods 2 (lcom2)'>
 	<derived>
 
 	^ self
@@ -78,8 +78,8 @@ FamixTLCOMMetrics >> lcom2 [
 { #category : #'Famix-Extensions-metrics-support' }
 FamixTLCOMMetrics >> lcom3 [
 
-	<MSEProperty: #lcom3 type: #Number>
-	<MSEComment: 'lack of cohesion in methods 3 (lcom3)'>
+	<FMProperty: #lcom3 type: #Number>
+	<FMComment: 'lack of cohesion in methods 3 (lcom3)'>
 	<derived>
 
 	^ self

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTLocalVariable classSide >> annotation [
 
-	<MSEClass: #TLocalVariable super: #Object>
+	<FMClass: #TLocalVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTLocalVariable >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithLocalVariables opposite: #localVariables"
 
 	<generated>
-	<MSEComment: 'Behavioural entity declaring this local variable. belongsTo implementation'>
+	<FMComment: 'Behavioural entity declaring this local variable. belongsTo implementation'>
 	<container>
 	^ parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -19,7 +19,7 @@ Trait {
 { #category : #meta }
 FamixTMethod classSide >> annotation [
 
-	<MSEClass: #TMethod super: #Object>
+	<FMClass: #TMethod super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -35,8 +35,8 @@ FamixTMethod classSide >> famixTMethodRelatedGroup [
 
 { #category : #metrics }
 FamixTMethod >> cyclomaticComplexity [
-	<MSEProperty: #cyclomaticComplexity type: #Number>
-	<MSEComment: 'The number of linear-independent paths through a method.'>
+	<FMProperty: #cyclomaticComplexity type: #Number>
+	<FMComment: 'The number of linear-independent paths through a method.'>
 	^ self
 		lookUpPropertyNamed:  #cyclomaticComplexity
 		computedAs: [ self notExistentMetricValue ]
@@ -51,9 +51,9 @@ FamixTMethod >> cyclomaticComplexity: aNumber [
 { #category : #accessing }
 FamixTMethod >> isAbstract [
 
-	<MSEProperty: #isAbstract type: #Boolean>
+	<FMProperty: #isAbstract type: #Boolean>
 	<generated>
-	<MSEComment: 'True if abstract method'>
+	<FMComment: 'True if abstract method'>
 	^ isAbstract
 ]
 
@@ -68,9 +68,9 @@ FamixTMethod >> isAbstract: anObject [
 { #category : #accessing }
 FamixTMethod >> isClassSide [
 
-	<MSEProperty: #isClassSide type: #Boolean>
+	<FMProperty: #isClassSide type: #Boolean>
 	<generated>
-	<MSEComment: 'True if class-side method'>
+	<FMComment: 'True if class-side method'>
 	^ isClassSide
 ]
 
@@ -84,17 +84,17 @@ FamixTMethod >> isClassSide: anObject [
 
 { #category : #testing }
 FamixTMethod >> isConstant [
-	<MSEProperty: #isConstant type: #Boolean>
+	<FMProperty: #isConstant type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method simply returns a constant'>
+	<FMComment: 'True if the method simply returns a constant'>
 	^#constant = self kind
 ]
 
 { #category : #testing }
 FamixTMethod >> isConstructor [
-	<MSEProperty: #isConstructor type: #Boolean>
+	<FMProperty: #isConstructor type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is a constructor of the class'>
+	<FMComment: 'True if the method is a constructor of the class'>
 
 	^ #constructor = self kind or: [ 
 		self privateState propertyAt: #isConstructor ifAbsent: [false] ]
@@ -110,9 +110,9 @@ FamixTMethod >> isConstructor: aBoolean [
 
 { #category : #testing }
 FamixTMethod >> isGetter [
-	<MSEProperty: #isGetter type: #Boolean>
+	<FMProperty: #isGetter type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is a getter of an attribute'>
+	<FMComment: 'True if the method is a getter of an attribute'>
 	
 	^#getter = self kind
 ]
@@ -133,9 +133,9 @@ FamixTMethod >> isPureAccessor [
 
 { #category : #testing }
 FamixTMethod >> isSetter [
-	<MSEProperty: #isSetter type: #Boolean>
+	<FMProperty: #isSetter type: #Boolean>
 	<derived>
-	<MSEComment: 'True if the method is a setter on an attribute'>
+	<FMComment: 'True if the method is a setter on an attribute'>
 
 	^#setter = self kind
 ]
@@ -143,9 +143,9 @@ FamixTMethod >> isSetter [
 { #category : #accessing }
 FamixTMethod >> kind [
 
-	<MSEProperty: #kind type: #String>
+	<FMProperty: #kind type: #String>
 	<generated>
-	<MSEComment: 'Tag indicating a setter, getter, constant, constructor, or abstract method'>
+	<FMComment: 'Tag indicating a setter, getter, constant, constructor, or abstract method'>
 	^ kind
 ]
 
@@ -170,9 +170,9 @@ FamixTMethod >> mooseNameOn: stream [
 
 { #category : #metrics }
 FamixTMethod >> numberOfMessageSends [
-	<MSEProperty: #numberOfMessageSends type: #Number>
+	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
-	<MSEComment: 'The number of message from a method'>
+	<FMComment: 'The number of message from a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfMessageSends
 		computedAs: [ self notExistentMetricValue ]
@@ -185,11 +185,19 @@ FamixTMethod >> numberOfMessageSends: aNumber [
 ]
 
 { #category : #accessing }
+FamixTMethod >> numberOfParameters [
+	<FMProperty: #numberOfParameters type: #Number>
+	<FMComment: 'The number of parameters in a method'>
+	<derived>
+	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
+]
+
+{ #category : #accessing }
 FamixTMethod >> parentType [
 	"Relation named: #parentType type: #FamixTWithMethods opposite: #methods"
 
 	<generated>
-	<MSEComment: 'Type declaring the method. It provides the implementation for belongsTo.'>
+	<FMComment: 'Type declaring the method. It provides the implementation for belongsTo.'>
 	<container>
 	^ parentType
 ]

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 FamixTModule classSide >> annotation [
 
-	<MSEClass: #TModule super: #Object>
+	<FMClass: #TModule super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTMultipleFileAnchor classSide >> annotation [
 
-	<MSEClass: #TMultipleFileAnchor super: #Object>
+	<FMClass: #TMultipleFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -28,9 +28,9 @@ FamixTMultipleFileAnchor >> addToFile: entity [
 { #category : #accessing }
 FamixTMultipleFileAnchor >> allFiles [
 
-	<MSEProperty: #allFiles type: #FamixTFileAnchor>
+	<FMProperty: #allFiles type: #FamixTFileAnchor>
 	<multivalued>
-	<MSEComment: 'All source code definition files'>
+	<FMComment: 'All source code definition files'>
 	^ allFiles ifNil: [ allFiles := OrderedCollection new. ]
 ]
 

--- a/src/Famix-Traits/FamixTNamed.trait.st
+++ b/src/Famix-Traits/FamixTNamed.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTNamed classSide >> annotation [
 
-	<MSEClass: #TNamed super: #Object>
+	<FMClass: #TNamed super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -36,9 +36,9 @@ FamixTNamed >> mooseNameOn: stream [
 { #category : #accessing }
 FamixTNamed >> name [
 
-	<MSEProperty: #name type: #String>
+	<FMProperty: #name type: #String>
 	<generated>
-	<MSEComment: 'Basic name of the entity, not full reference.'>
+	<FMComment: 'Basic name of the entity, not full reference.'>
 	^ name
 ]
 

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -17,7 +17,7 @@ Trait {
 { #category : #meta }
 FamixTNamespace classSide >> annotation [
 
-	<MSEClass: #TNamespace super: #Object>
+	<FMClass: #TNamespace super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTNamespaceEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamespaceEntity.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTNamespaceEntity classSide >> annotation [
 
-	<MSEClass: #TNamespaceEntity super: #Object>
+	<FMClass: #TNamespaceEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTPackage classSide >> annotation [
 
-	<MSEClass: #TPackage super: #Object>
+	<FMClass: #TPackage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -77,8 +77,8 @@ FamixTPackage >> packageOwner: anObject [
 
 { #category : #metrics }
 FamixTPackage >> weightedMethodCount [
-	<MSEProperty: #weightedMethodCount type: #Number>
-	<MSEComment: 'The sum of the complexity in a package'>
+	<FMProperty: #weightedMethodCount type: #Number>
+	<FMComment: 'The sum of the complexity in a package'>
 	<derived>
 	^ self lookUpPropertyNamed: #WMC computedAs: [ (self toScope: FamixTWithMethods) detectSum: #weightedMethodCount ]
 ]

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTPackageable classSide >> annotation [
 
-	<MSEClass: #TPackageable super: #Object>
+	<FMClass: #TPackageable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTPackageable >> parentPackage [
 	"Relation named: #parentPackage type: #FamixTPackage opposite: #childEntities"
 
 	<generated>
-	<MSEComment: 'Package containing the entity in the code structure (if applicable)'>
+	<FMComment: 'Package containing the entity in the code structure (if applicable)'>
 	<container>
 	^ parentPackage
 ]

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -14,7 +14,7 @@ Trait {
 { #category : #meta }
 FamixTParameter classSide >> annotation [
 
-	<MSEClass: #TParameter super: #Object>
+	<FMClass: #TParameter super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTParameter >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithParameters opposite: #parameters"
 
 	<generated>
-	<MSEComment: 'Behavioural entity containing this parameter. belongsTo implementation'>
+	<FMComment: 'Behavioural entity containing this parameter. belongsTo implementation'>
 	<container>
 	^ parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTParameterType.trait.st
+++ b/src/Famix-Traits/FamixTParameterType.trait.st
@@ -16,7 +16,7 @@ Trait {
 { #category : #meta }
 FamixTParameterType classSide >> annotation [
 
-	<MSEClass: #TParameterType super: #Object>
+	<FMClass: #TParameterType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTParameterizedType.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedType.trait.st
@@ -19,7 +19,7 @@ Trait {
 { #category : #meta }
 FamixTParameterizedType classSide >> annotation [
 
-	<MSEClass: #TParameterizedType super: #Object>
+	<FMClass: #TParameterizedType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -30,7 +30,7 @@ FamixTParameterizedType >> parameterizableClass [
 	"Relation named: #parameterizableClass type: #FamixTWithParameterizedTypes opposite: #parameterizedTypes"
 
 	<generated>
-	<MSEComment: 'Base type of this parameterized type.'>
+	<FMComment: 'Base type of this parameterized type.'>
 	^ parameterizableClass
 ]
 

--- a/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTParameterizedTypeUser classSide >> annotation [
 
-	<MSEClass: #TParameterizedTypeUser super: #Object>
+	<FMClass: #TParameterizedTypeUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPossibleStub.trait.st
+++ b/src/Famix-Traits/FamixTPossibleStub.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTPossibleStub classSide >> annotation [
 
-	<MSEClass: #TPossibleStub super: #Object>
+	<FMClass: #TPossibleStub super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -18,8 +18,8 @@ FamixTPossibleStub classSide >> annotation [
 { #category : #accessing }
 FamixTPossibleStub >> isStub [
 
-	<MSEProperty: #isStub type: #Boolean>
-	<MSEComment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'>
+	<FMProperty: #isStub type: #Boolean>
+	<FMComment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'>
 	^ isStub ifNil: [ false ]
 ]
 

--- a/src/Famix-Traits/FamixTPreprocessorDefine.trait.st
+++ b/src/Famix-Traits/FamixTPreprocessorDefine.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTPreprocessorDefine classSide >> annotation [
 
-	<MSEClass: #TPreprocessorDefine super: #Object>
+	<FMClass: #TPreprocessorDefine super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTPreprocessorIfdef.trait.st
+++ b/src/Famix-Traits/FamixTPreprocessorIfdef.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTPreprocessorIfdef classSide >> annotation [
 
-	<MSEClass: #TPreprocessorIfdef super: #Object>
+	<FMClass: #TPreprocessorIfdef super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -23,7 +23,7 @@ Trait {
 { #category : #meta }
 FamixTReference classSide >> annotation [
 
-	<MSEClass: #TReference super: #Object>
+	<FMClass: #TReference super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -56,7 +56,7 @@ FamixTReference >> source [
 	"Relation named: #source type: #FamixTWithReferences opposite: #outgoingReferences"
 
 	<generated>
-	<MSEComment: 'Source entity making the reference. from-side of the association'>
+	<FMComment: 'Source entity making the reference. from-side of the association'>
 	<source>
 	^ source
 ]
@@ -74,7 +74,7 @@ FamixTReference >> target [
 	"Relation named: #target type: #FamixTReferenceable opposite: #incomingReferences"
 
 	<generated>
-	<MSEComment: 'Target entity referenced. to-side of the association'>
+	<FMComment: 'Target entity referenced. to-side of the association'>
 	<target>
 	^ target
 ]

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTReferenceable classSide >> annotation [
 
-	<MSEClass: #TReferenceable super: #Object>
+	<FMClass: #TReferenceable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTReferenceable >> incomingReferences [
 	"Relation named: #incomingReferences type: #FamixTReference opposite: #target"
 
 	<generated>
-	<MSEComment: 'References to this entity by other entities.'>
+	<FMComment: 'References to this entity by other entities.'>
 	<derived>
 	^ incomingReferences
 ]

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTScopingEntity classSide >> annotation [
 
-	<MSEClass: #TScopingEntity super: #Object>
+	<FMClass: #TScopingEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -57,7 +57,7 @@ FamixTScopingEntity >> childScopes [
 	"Relation named: #childScopes type: #FamixTScopingEntity opposite: #parentScope"
 
 	<generated>
-	<MSEComment: 'Child scopes embedded in this scope, if any.'>
+	<FMComment: 'Child scopes embedded in this scope, if any.'>
 	<derived>
 	^ childScopes
 ]
@@ -80,7 +80,7 @@ FamixTScopingEntity >> parentScope [
 	"Relation named: #parentScope type: #FamixTScopingEntity opposite: #childScopes"
 
 	<generated>
-	<MSEComment: 'Parent scope embedding this scope, if any.'>
+	<FMComment: 'Parent scope embedding this scope, if any.'>
 	<container>
 	^ parentScope
 ]

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTSourceAnchor classSide >> annotation [
 
-	<MSEClass: #TSourceAnchor super: #Object>
+	<FMClass: #TSourceAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -23,7 +23,7 @@ FamixTSourceAnchor >> element [
 	"Relation named: #element type: #FamixTWithSourceAnchor opposite: #sourceAnchor"
 
 	<generated>
-	<MSEComment: 'Enable the accessibility to the famix entity that this class is a source pointer for'>
+	<FMComment: 'Enable the accessibility to the famix entity that this class is a source pointer for'>
 	^ element
 ]
 
@@ -45,9 +45,9 @@ FamixTSourceAnchor >> isMultiple [
 { #category : #metrics }
 FamixTSourceAnchor >> lineCount [
 
-	<MSEProperty: #lineCount type: #Number>
+	<FMProperty: #lineCount type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines in the source text'>
+	<FMComment: 'The number of lines in the source text'>
 
 	^ self sourceText ifNotNil: #lineCount ifNil: [ self notExistentMetricValue ]
 ]

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -11,8 +11,33 @@ Trait {
 { #category : #meta }
 FamixTSourceEntity classSide >> annotation [
 
-	<MSEClass: #TSourceEntity super: #Object>
+	<FMClass: #TSourceEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
+]
+
+{ #category : #'Famix-Implementation' }
+FamixTSourceEntity >> numberOfLinesOfCode [
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
+	^ self
+		lookUpPropertyNamed: #numberOfLinesOfCode
+		computedAs: [ self computeNumberOfLinesOfCode ]
+]
+
+{ #category : #metrics }
+FamixTSourceEntity >> numberOfLinesOfCodeWithMoreThanOneCharacter [
+	<FMProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number> <derived>
+	<FMComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
+	the difference being that it only counts the lines with more than one non-whitespace characters.
+	This metric is particularly useful for comparing the density of other metrics on a line of code.
+	For example, depending on the formatting style chosen a Java curly brace, or a Smalltalk block 
+	can appear inline or on a separate line. For normalization purposes, these commonly appearing 
+	cases can be ruled out through the present metric.'>
+	^self
+		lookUpPropertyNamed: #numberOfLinesOfCodeWithMoreThanOneCharacter
+		computedAs: [			
+			(self sourceText lines select: [ :line |
+				line trimBoth size > 1 ]) size ]
 ]

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTSourceLanguage classSide >> annotation [
 
-	<MSEClass: #TSourceLanguage super: #Object>
+	<FMClass: #TSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -43,7 +43,7 @@ FamixTSourceLanguage >> sourcedEntities [
 	"Relation named: #sourcedEntities type: #FamixTWithSourceLanguage opposite: #declaredSourceLanguage"
 
 	<generated>
-	<MSEComment: 'References to the entities saying explicitly that are written in this language.'>
+	<FMComment: 'References to the entities saying explicitly that are written in this language.'>
 	<derived>
 	^ sourcedEntities
 ]

--- a/src/Famix-Traits/FamixTStructuralEntity.trait.st
+++ b/src/Famix-Traits/FamixTStructuralEntity.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 FamixTStructuralEntity classSide >> annotation [
 
-	<MSEClass: #TStructuralEntity super: #Object>
+	<FMClass: #TStructuralEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTemplate.trait.st
+++ b/src/Famix-Traits/FamixTTemplate.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTTemplate classSide >> annotation [
 
-	<MSEClass: #TTemplate super: #Object>
+	<FMClass: #TTemplate super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTemplateUser.trait.st
+++ b/src/Famix-Traits/FamixTTemplateUser.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTemplateUser classSide >> annotation [
 
-	<MSEClass: #TTemplateUser super: #Object>
+	<FMClass: #TTemplateUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTThrownException.trait.st
+++ b/src/Famix-Traits/FamixTThrownException.trait.st
@@ -12,7 +12,7 @@ Trait {
 { #category : #meta }
 FamixTThrownException classSide >> annotation [
 
-	<MSEClass: #TThrownException super: #Object>
+	<FMClass: #TThrownException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTrait.trait.st
+++ b/src/Famix-Traits/FamixTTrait.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 FamixTTrait classSide >> annotation [
 
-	<MSEClass: #TTrait super: #Object>
+	<FMClass: #TTrait super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTraitUsage.trait.st
+++ b/src/Famix-Traits/FamixTTraitUsage.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTTraitUsage classSide >> annotation [
 
-	<MSEClass: #TTraitUsage super: #Object>
+	<FMClass: #TTraitUsage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTTraitUser.trait.st
+++ b/src/Famix-Traits/FamixTTraitUser.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTraitUser classSide >> annotation [
 
-	<MSEClass: #TTraitUser super: #Object>
+	<FMClass: #TTraitUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -18,7 +18,7 @@ Trait {
 { #category : #meta }
 FamixTType classSide >> annotation [
 
-	<MSEClass: #TType super: #Object>
+	<FMClass: #TType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -39,9 +39,9 @@ FamixTType >> belongsTo [
 
 { #category : #metrics }
 FamixTType >> fanIn [
-	<MSEProperty: #fanIn type: #Number>
+	<FMProperty: #fanIn type: #Number>
 	<derived>
-	<MSEComment: 'Number of client classes'>
+	<FMComment: 'Number of client classes'>
 	^ self lookUpPropertyNamed: #fanIn computedAs: [ (self allClientsAtScope: FamixTType) size ]
 ]
 
@@ -69,9 +69,9 @@ FamixTType >> mooseNameOn: aStream [
 
 { #category : #metrics }
 FamixTType >> numberOfAccessesToForeignData [
-	<MSEProperty: #numberOfAccessesToForeignData type: #Number>
+	<FMProperty: #numberOfAccessesToForeignData type: #Number>
 	<derived>
-	<MSEComment: 'Number of accesses to foreign data'>
+	<FMComment: 'Number of accesses to foreign data'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfAccessesToForeignData
@@ -86,9 +86,9 @@ FamixTType >> numberOfAccessesToForeignData: aNumber [
 
 { #category : #metrics }
 FamixTType >> numberOfDuplicatedLinesOfCodeInternally [
-	<MSEProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
+	<FMProperty: #numberOfDuplicatedLinesOfCodeInternally type: #Number>
 	<derived>
-	<MSEComment: 'The number of duplicated lines of code internally'>		
+	<FMComment: 'The number of duplicated lines of code internally'>		
 
 	^self
 		lookUpPropertyNamed: #numberOfDuplicatedLinesOfCodeInternally
@@ -112,7 +112,7 @@ FamixTType >> typeContainer [
 	"Relation named: #typeContainer type: #FamixTWithTypes opposite: #types"
 
 	<generated>
-	<MSEComment: 'Container entity to which this type belongs to. Container is a namespace, not a package (Smalltalk).'>
+	<FMComment: 'Container entity to which this type belongs to. Container is a namespace, not a package (Smalltalk).'>
 	<container>
 	^ typeContainer
 ]

--- a/src/Famix-Traits/FamixTTypeAlias.trait.st
+++ b/src/Famix-Traits/FamixTTypeAlias.trait.st
@@ -15,7 +15,7 @@ Trait {
 { #category : #meta }
 FamixTTypeAlias classSide >> annotation [
 
-	<MSEClass: #TTypeAlias super: #Object>
+	<FMClass: #TTypeAlias super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTTypeAlias >> aliasedType [
 	"Relation named: #aliasedType type: #FamixTWithTypeAliases opposite: #typeAliases"
 
 	<generated>
-	<MSEComment: 'Points to the actual type.'>
+	<FMComment: 'Points to the actual type.'>
 	^ aliasedType
 ]
 

--- a/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTypedAnnotationInstance classSide >> annotation [
 
-	<MSEClass: #TTypedAnnotationInstance super: #Object>
+	<FMClass: #TTypedAnnotationInstance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTTypedAnnotationInstance >> annotationType [
 	"Relation named: #annotationType type: #FamixTAnnotationType opposite: #instances"
 
 	<generated>
-	<MSEComment: 'Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). '>
+	<FMComment: 'Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). '>
 	^ annotationType
 ]
 

--- a/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTypedAnnotationInstanceAttribute classSide >> annotation [
 
-	<MSEClass: #TTypedAnnotationInstanceAttribute super: #Object>
+	<FMClass: #TTypedAnnotationInstanceAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTTypedAnnotationInstanceAttribute >> annotationTypeAttribute [
 	"Relation named: #annotationTypeAttribute type: #FamixTAnnotationTypeAttribute opposite: #annotationAttributeInstances"
 
 	<generated>
-	<MSEComment: 'This corresponds to the type of the attribute in an AnnotationInstance'>
+	<FMComment: 'This corresponds to the type of the attribute in an AnnotationInstance'>
 	^ annotationTypeAttribute
 ]
 

--- a/src/Famix-Traits/FamixTTypedStructure.trait.st
+++ b/src/Famix-Traits/FamixTTypedStructure.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTTypedStructure classSide >> annotation [
 
-	<MSEClass: #TTypedStructure super: #Object>
+	<FMClass: #TTypedStructure super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTTypedStructure >> declaredType [
 	"Relation named: #declaredType type: #FamixTWithTypedStructures opposite: #structuresWithDeclaredType"
 
 	<generated>
-	<MSEComment: 'Type of the behavioral entity, if any'>
+	<FMComment: 'Type of the behavioral entity, if any'>
 	^ declaredType
 ]
 

--- a/src/Famix-Traits/FamixTUnknownSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTUnknownSourceLanguage.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTUnknownSourceLanguage classSide >> annotation [
 
-	<MSEClass: #TUnknownSourceLanguage super: #Object>
+	<FMClass: #TUnknownSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithAccesses.trait.st
+++ b/src/Famix-Traits/FamixTWithAccesses.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAccesses classSide >> annotation [
 
-	<MSEClass: #TWithAccesses super: #Object>
+	<FMClass: #TWithAccesses super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTWithAccesses >> accesses [
 	"Relation named: #accesses type: #FamixTAccess opposite: #accessor"
 
 	<generated>
-	<MSEComment: 'Accesses to variables made by this behaviour.'>
+	<FMComment: 'Accesses to variables made by this behaviour.'>
 	<derived>
 	^ accesses
 ]

--- a/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAnnotationInstanceAttributes classSide >> annotation [
 
-	<MSEClass: #TWithAnnotationInstanceAttributes super: #Object>
+	<FMClass: #TWithAnnotationInstanceAttributes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithAnnotationInstanceAttributes >> attributes [
 	"Relation named: #attributes type: #FamixTAnnotationInstanceAttribute opposite: #parentAnnotationInstance"
 
 	<generated>
-	<MSEComment: 'This corresponds to the actual values of the attributes in an AnnotationInstance'>
+	<FMComment: 'This corresponds to the actual values of the attributes in an AnnotationInstance'>
 	<derived>
 	^ attributes
 ]

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAnnotationInstances classSide >> annotation [
 
-	<MSEClass: #TWithAnnotationInstances super: #Object>
+	<FMClass: #TWithAnnotationInstances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -48,7 +48,7 @@ FamixTWithAnnotationInstances >> annotationInstances [
 	"Relation named: #annotationInstances type: #FamixTAnnotationInstance opposite: #annotatedEntity"
 
 	<generated>
-	<MSEComment: 'This property corresponds to the set of annotations associated to the entity'>
+	<FMComment: 'This property corresponds to the set of annotations associated to the entity'>
 	<derived>
 	^ annotationInstances
 ]
@@ -79,9 +79,9 @@ FamixTWithAnnotationInstances >> isAnnotatedWith: anAnnotationName [
 
 { #category : #metrics }
 FamixTWithAnnotationInstances >> numberOfAnnotationInstances [
-	<MSEProperty: #numberOfAnnotationInstances type: #Number>
+	<FMProperty: #numberOfAnnotationInstances type: #Number>
 	<derived>
-	<MSEComment: 'The number of annotation instances defined in the class or in any of its methods'>
+	<FMComment: 'The number of annotation instances defined in the class or in any of its methods'>
 
 	^self
 		lookUpPropertyNamed: #numberOfAnnotationInstances

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAnnotationTypes classSide >> annotation [
 
-	<MSEClass: #TWithAnnotationTypes super: #Object>
+	<FMClass: #TWithAnnotationTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTWithAnnotationTypes >> definedAnnotationTypes [
 	"Relation named: #definedAnnotationTypes type: #FamixTAnnotationType opposite: #annotationTypesContainer"
 
 	<generated>
-	<MSEComment: 'The container in which the AnnotationTypes may be declared'>
+	<FMComment: 'The container in which the AnnotationTypes may be declared'>
 	<derived>
 	^ definedAnnotationTypes
 ]

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithAttributes classSide >> annotation [
 
-	<MSEClass: #TWithAttributes super: #Object>
+	<FMClass: #TWithAttributes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithAttributes >> attributes [
 	"Relation named: #attributes type: #FamixTAttribute opposite: #parentType"
 
 	<generated>
-	<MSEComment: 'List of attributes declared by this type.'>
+	<FMComment: 'List of attributes declared by this type.'>
 	<derived>
 	^ attributes
 ]
@@ -40,9 +40,9 @@ FamixTWithAttributes >> attributes: anObject [
 
 { #category : #'Famix-Extensions' }
 FamixTWithAttributes >> numberOfAttributes [
-	<MSEProperty: #numberOfAttributes type: #Number>
+	<FMProperty: #numberOfAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of attributes in the class'>
+	<FMComment: 'The number of attributes in the class'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfAttributes
@@ -57,9 +57,9 @@ FamixTWithAttributes >> numberOfAttributes: aNumber [
 
 { #category : #metrics }
 FamixTWithAttributes >> numberOfPrivateAttributes [
-	<MSEProperty: #numberOfPrivateAttributes type: #Number>
+	<FMProperty: #numberOfPrivateAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of private attributes in a class'>
+	<FMComment: 'The number of private attributes in a class'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfPrivateAttributes
@@ -74,9 +74,9 @@ FamixTWithAttributes >> numberOfPrivateAttributes: aNumber [
 
 { #category : #metrics }
 FamixTWithAttributes >> numberOfProtectedAttributes [
-	<MSEProperty: #numberOfProtectedAttributes type: #Number>
+	<FMProperty: #numberOfProtectedAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of protected attributes in a class'>				
+	<FMComment: 'The number of protected attributes in a class'>				
 	
 	^self
 		lookUpPropertyNamed: #numberOfProtectedAttributes
@@ -91,9 +91,9 @@ FamixTWithAttributes >> numberOfProtectedAttributes: aNumber [
 
 { #category : #metrics }
 FamixTWithAttributes >> numberOfPublicAttributes [
-	<MSEProperty: #numberOfPublicAttributes type: #Number>
+	<FMProperty: #numberOfPublicAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of public attributes in a class'>
+	<FMComment: 'The number of public attributes in a class'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfPublicAttributes
@@ -108,9 +108,9 @@ FamixTWithAttributes >> numberOfPublicAttributes: aNumber [
 
 { #category : #metrics }
 FamixTWithAttributes >> numberOfRevealedAttributes [
-	<MSEProperty: #numberOfRevealedAttributes type: #Number>
+	<FMProperty: #numberOfRevealedAttributes type: #Number>
 	<derived>
-	<MSEComment: 'The number of public attributes plus the number of accessor methods'>		
+	<FMComment: 'The number of public attributes plus the number of accessor methods'>		
 
 	^self
 		lookUpPropertyNamed: #numberOfRevealedAttributes

--- a/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithCaughtExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithCaughtExceptions classSide >> annotation [
 
-	<MSEClass: #TWithCaughtExceptions super: #Object>
+	<FMClass: #TWithCaughtExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTWithCaughtExceptions >> caughtExceptions [
 	"Relation named: #caughtExceptions type: #FamixTCaughtException opposite: #definingEntity"
 
 	<generated>
-	<MSEComment: 'The exceptions caught by the method'>
+	<FMComment: 'The exceptions caught by the method'>
 	<derived>
 	^ caughtExceptions
 ]

--- a/src/Famix-Traits/FamixTWithClassScope.trait.st
+++ b/src/Famix-Traits/FamixTWithClassScope.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithClassScope classSide >> annotation [
 
-	<MSEClass: #TWithClassScope super: #Object>
+	<FMClass: #TWithClassScope super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithClasses.trait.st
+++ b/src/Famix-Traits/FamixTWithClasses.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithClasses classSide >> annotation [
 
-	<MSEClass: #TWithClasses super: #Object>
+	<FMClass: #TWithClasses super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithComments classSide >> annotation [
 
-	<MSEClass: #TWithComments super: #Object>
+	<FMClass: #TWithComments super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -27,7 +27,7 @@ FamixTWithComments >> comments [
 	"Relation named: #comments type: #FamixTComment opposite: #container"
 
 	<generated>
-	<MSEComment: 'list of comments defined in the entity'>
+	<FMComment: 'list of comments defined in the entity'>
 	<derived>
 	^ comments
 ]
@@ -47,9 +47,9 @@ FamixTWithComments >> hasComments [
 
 { #category : #accessing }
 FamixTWithComments >> numberOfComments [
-	<MSEProperty: #numberOfComments type: #Number>
+	<FMProperty: #numberOfComments type: #Number>
 	<derived>
-	<MSEComment: 'The number of comments in a class'>
+	<FMComment: 'The number of comments in a class'>
 	self flag: #todo.	"Cyril: I am not a big fan of this implementation... We should revisit it."
 	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size + (self methods asArray inject: 0 into: [ :sum :el | el numberOfComments + sum ]) ]
 ]

--- a/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnit.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithCompilationUnit classSide >> annotation [
 
-	<MSEClass: #TWithCompilationUnit super: #Object>
+	<FMClass: #TWithCompilationUnit super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithDeclaredExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithDeclaredExceptions classSide >> annotation [
 
-	<MSEClass: #TWithDeclaredExceptions super: #Object>
+	<FMClass: #TWithDeclaredExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithDeclaredExceptions >> declaredExceptions [
 	"Relation named: #declaredExceptions type: #FamixTDeclaredException opposite: #definingEntity"
 
 	<generated>
-	<MSEComment: 'The exceptions declared by the method'>
+	<FMComment: 'The exceptions declared by the method'>
 	<derived>
 	^ declaredExceptions
 ]

--- a/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithDereferencedInvocations classSide >> annotation [
 
-	<MSEClass: #TWithDereferencedInvocations super: #Object>
+	<FMClass: #TWithDereferencedInvocations super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithDereferencedInvocations >> dereferencedInvocations [
 	"Relation named: #dereferencedInvocations type: #FamixTDereferencedInvocation opposite: #referencer"
 
 	<generated>
-	<MSEComment: 'List of invocations performed on BehaviouralEntities referenced by this entity'>
+	<FMComment: 'List of invocations performed on BehaviouralEntities referenced by this entity'>
 	<derived>
 	^ dereferencedInvocations
 ]

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithEnumValues classSide >> annotation [
 
-	<MSEClass: #TWithEnumValues super: #Object>
+	<FMClass: #TWithEnumValues super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithExceptions classSide >> annotation [
 
-	<MSEClass: #TWithExceptions super: #Object>
+	<FMClass: #TWithExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTWithExceptions >> exceptions [
 	"Relation named: #exceptions type: #FamixTException opposite: #exceptionClass"
 
 	<generated>
-	<MSEComment: 'Exceptions which class is myself.'>
+	<FMComment: 'Exceptions which class is myself.'>
 	<derived>
 	^ exceptions
 ]

--- a/src/Famix-Traits/FamixTWithFileIncludes.trait.st
+++ b/src/Famix-Traits/FamixTWithFileIncludes.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTWithFileIncludes classSide >> annotation [
 
-	<MSEClass: #TWithFileIncludes super: #Object>
+	<FMClass: #TWithFileIncludes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -33,7 +33,7 @@ FamixTWithFileIncludes >> incomingIncludeRelations [
 	"Relation named: #incomingIncludeRelations type: #FamixTFileInclude opposite: #target"
 
 	<generated>
-	<MSEComment: 'The include entities that have this file as a target.'>
+	<FMComment: 'The include entities that have this file as a target.'>
 	<derived>
 	^ incomingIncludeRelations
 ]
@@ -51,7 +51,7 @@ FamixTWithFileIncludes >> outgoingIncludeRelations [
 	"Relation named: #outgoingIncludeRelations type: #FamixTFileInclude opposite: #source"
 
 	<generated>
-	<MSEComment: 'The include entities that have this file as a source.'>
+	<FMComment: 'The include entities that have this file as a source.'>
 	<derived>
 	^ outgoingIncludeRelations
 ]

--- a/src/Famix-Traits/FamixTWithFiles.trait.st
+++ b/src/Famix-Traits/FamixTWithFiles.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithFiles classSide >> annotation [
 
-	<MSEClass: #TWithFiles super: #Object>
+	<FMClass: #TWithFiles super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTWithFiles >> containerFiles [
 	"Relation named: #containerFiles type: #FamixTFile opposite: #entities"
 
 	<generated>
-	<MSEComment: 'List of files containing the entity'>
+	<FMComment: 'List of files containing the entity'>
 	^ containerFiles
 ]
 

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithFunctions classSide >> annotation [
 
-	<MSEClass: #TWithFunctions super: #Object>
+	<FMClass: #TWithFunctions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -26,7 +26,7 @@ FamixTWithFunctions >> functions [
 	"Relation named: #functions type: #FamixTFunction opposite: #functionOwner"
 
 	<generated>
-	<MSEComment: 'Functions defined in the container, if any.'>
+	<FMComment: 'Functions defined in the container, if any.'>
 	<derived>
 	^ functions
 ]

--- a/src/Famix-Traits/FamixTWithHeader.trait.st
+++ b/src/Famix-Traits/FamixTWithHeader.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithHeader classSide >> annotation [
 
-	<MSEClass: #TWithHeader super: #Object>
+	<FMClass: #TWithHeader super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTWithHeader >> header [
 	"Relation named: #header type: #FamixTHeader opposite: #headerOwner"
 
 	<generated>
-	<MSEComment: 'The header file that defines this module'>
+	<FMComment: 'The header file that defines this module'>
 	<derived>
 	^ header
 ]

--- a/src/Famix-Traits/FamixTWithImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTWithImmediateSource.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithImmediateSource classSide >> annotation [
 
-	<MSEClass: #TWithImmediateSource super: #Object>
+	<FMClass: #TWithImmediateSource super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -24,9 +24,9 @@ FamixTWithImmediateSource >> isFile [
 { #category : #accessing }
 FamixTWithImmediateSource >> source [
 
-	<MSEProperty: #source type: #String>
+	<FMProperty: #source type: #String>
 	<generated>
-	<MSEComment: 'Actual source code of the source entity'>
+	<FMComment: 'Actual source code of the source entity'>
 	^ source
 ]
 

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithImplicitVariables classSide >> annotation [
 
-	<MSEClass: #TWithImplicitVariables super: #Object>
+	<FMClass: #TWithImplicitVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithImplicitVariables >> implicitVariables [
 	"Relation named: #implicitVariables type: #FamixTImplicitVariable opposite: #parentBehaviouralEntity"
 
 	<generated>
-	<MSEComment: 'Implicit variables used locally by this behaviour.'>
+	<FMComment: 'Implicit variables used locally by this behaviour.'>
 	<derived>
 	^ implicitVariables
 ]

--- a/src/Famix-Traits/FamixTWithInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithInheritances.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #meta }
 FamixTWithInheritances classSide >> annotation [
 
-	<MSEClass: #TWithInheritances super: #Object>
+	<FMClass: #TWithInheritances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -28,9 +28,9 @@ FamixTWithInheritances >> addSuperInheritance: anInheritance [
 
 { #category : #metrics }
 FamixTWithInheritances >> numberOfSubclasses [
-	<MSEProperty: #numberOfSubclasses type: #Number>
+	<FMProperty: #numberOfSubclasses type: #Number>
 	<derived>
-	<MSEComment: 'The number of subclasses of a class'>
+	<FMComment: 'The number of subclasses of a class'>
 	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
 ]
 
@@ -45,7 +45,7 @@ FamixTWithInheritances >> subInheritances [
 	"Relation named: #subInheritances type: #FamixTInheritance opposite: #superclass"
 
 	<generated>
-	<MSEComment: 'Subinheritance relationships, i.e. known subclasses of this type.'>
+	<FMComment: 'Subinheritance relationships, i.e. known subclasses of this type.'>
 	<derived>
 	^ subInheritances
 ]
@@ -63,7 +63,7 @@ FamixTWithInheritances >> superInheritances [
 	"Relation named: #superInheritances type: #FamixTInheritance opposite: #subclass"
 
 	<generated>
-	<MSEComment: 'Superinheritance relationships, i.e. known superclasses of this type.'>
+	<FMComment: 'Superinheritance relationships, i.e. known superclasses of this type.'>
 	<derived>
 	^ superInheritances
 ]

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithInvocations classSide >> annotation [
 
-	<MSEClass: #TWithInvocations super: #Object>
+	<FMClass: #TWithInvocations super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithInvocations >> outgoingInvocations [
 	"Relation named: #outgoingInvocations type: #FamixTInvocation opposite: #sender"
 
 	<generated>
-	<MSEComment: 'Outgoing invocations sent by this behaviour.'>
+	<FMComment: 'Outgoing invocations sent by this behaviour.'>
 	<derived>
 	^ outgoingInvocations
 ]

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithLocalVariables classSide >> annotation [
 
-	<MSEClass: #TWithLocalVariables super: #Object>
+	<FMClass: #TWithLocalVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithLocalVariables >> localVariables [
 	"Relation named: #localVariables type: #FamixTLocalVariable opposite: #parentBehaviouralEntity"
 
 	<generated>
-	<MSEComment: 'Variables locally defined by this behaviour.'>
+	<FMComment: 'Variables locally defined by this behaviour.'>
 	<derived>
 	^ localVariables
 ]

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithMethods classSide >> annotation [
 
-	<MSEClass: #TWithMethods super: #Object>
+	<FMClass: #TWithMethods super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithMethods >> methods [
 	"Relation named: #methods type: #FamixTMethod opposite: #parentType"
 
 	<generated>
-	<MSEComment: 'Methods declared by this type.'>
+	<FMComment: 'Methods declared by this type.'>
 	<derived>
 	^ methods
 ]
@@ -48,9 +48,9 @@ FamixTWithMethods >> methodsGroup [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfAbstractMethods [
-	<MSEProperty: #numberOfAbstractMethods type: #Number>
+	<FMProperty: #numberOfAbstractMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of abstract methods in the class'>
+	<FMComment: 'The number of abstract methods in the class'>
 	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
 ]
 
@@ -61,9 +61,9 @@ FamixTWithMethods >> numberOfAbstractMethods: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfAccessorMethods [
-	<MSEProperty: #numberOfAccessorMethods type: #Number>
+	<FMProperty: #numberOfAccessorMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of accessor methods in a class'>
+	<FMComment: 'The number of accessor methods in a class'>
 	^ self
 		lookUpPropertyNamed: #numberOfAccessorMethods
 		computedAs: [ 
@@ -86,9 +86,9 @@ FamixTWithMethods >> numberOfAccessorMethods: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfConstructorMethods [
-	<MSEProperty: #numberOfConstructorMethods type: #Number>
+	<FMProperty: #numberOfConstructorMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of constructor methods in a class'>
+	<FMComment: 'The number of constructor methods in a class'>
 	^ self
 		lookUpPropertyNamed: #numberOfConstructorMethods
 		computedAs: [ 
@@ -112,9 +112,9 @@ FamixTWithMethods >> numberOfConstructorMethods: aNumber [
 { #category : #metrics }
 FamixTWithMethods >> numberOfLinesOfCode [
 
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<derived>
-	<MSEComment: 'The number of lines of code in a class'>
+	<FMComment: 'The number of lines of code in a class'>
 
 	^self
 		lookUpPropertyNamed: #numberOfLinesOfCode
@@ -129,9 +129,9 @@ FamixTWithMethods >> numberOfLinesOfCode: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfMessageSends [
-	<MSEProperty: #numberOfMessageSends type: #Number>
+	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
-	<MSEComment: 'The number of message sends from a class'>
+	<FMComment: 'The number of message sends from a class'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfMessageSends
@@ -146,9 +146,9 @@ FamixTWithMethods >> numberOfMessageSends: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfMethodProtocols [
-	<MSEProperty: #numberOfMethodProtocols type: #Number>
+	<FMProperty: #numberOfMethodProtocols type: #Number>
 	<derived>
-	<MSEComment: 'The number of method protocols in a class'>
+	<FMComment: 'The number of method protocols in a class'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfMethodProtocols
@@ -163,9 +163,9 @@ FamixTWithMethods >> numberOfMethodProtocols: aNumber [
 
 { #category : #accessing }
 FamixTWithMethods >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
+	<FMProperty: #numberOfMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of methods in a class'>
+	<FMComment: 'The number of methods in a class'>
 
 	^self
 		lookUpPropertyNamed: #numberOfMethods
@@ -180,9 +180,9 @@ FamixTWithMethods >> numberOfMethods: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfPrivateMethods [
-	<MSEProperty: #numberOfPrivateMethods type: #Number>
+	<FMProperty: #numberOfPrivateMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of private methods in a class'>
+	<FMComment: 'The number of private methods in a class'>
 			
 	^self
 		lookUpPropertyNamed: #numberOfPrivateMethods
@@ -197,9 +197,9 @@ FamixTWithMethods >> numberOfPrivateMethods: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfProtectedMethods [
-	<MSEProperty: #numberOfProtectedMethods type: #Number>
+	<FMProperty: #numberOfProtectedMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of protected methods in a class'>		
+	<FMComment: 'The number of protected methods in a class'>		
 	
 	^self
 		lookUpPropertyNamed: #numberOfProtectedMethods
@@ -214,9 +214,9 @@ FamixTWithMethods >> numberOfProtectedMethods: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> numberOfPublicMethods [
-	<MSEProperty: #numberOfPublicMethods type: #Number>
+	<FMProperty: #numberOfPublicMethods type: #Number>
 	<derived>
-	<MSEComment: 'The number of public methods in a class'>		
+	<FMComment: 'The number of public methods in a class'>		
 		
 	^self
 		lookUpPropertyNamed: #numberOfPublicMethods
@@ -231,9 +231,9 @@ FamixTWithMethods >> numberOfPublicMethods: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> tightClassCohesion [
-	<MSEProperty: #tightClassCohesion type: #Number>
+	<FMProperty: #tightClassCohesion type: #Number>
 	<derived>
-	<MSEComment: 'Tight class cohesion of a class'>
+	<FMComment: 'Tight class cohesion of a class'>
 	self flag: #TODO.
 	^ self
 		lookUpPropertyNamed: #tightClassCohesion
@@ -277,9 +277,9 @@ FamixTWithMethods >> tightClassCohesion: aNumber [
 
 { #category : #metrics }
 FamixTWithMethods >> weightedMethodCount [
-	<MSEProperty: #weightedMethodCount type: #Number>
+	<FMProperty: #weightedMethodCount type: #Number>
 	<derived>
-	<MSEComment: 'The sum of the complexity in a class'>
+	<FMComment: 'The sum of the complexity in a class'>
 			
 	^self
 		lookUpPropertyNamed: #weightedMethodCount

--- a/src/Famix-Traits/FamixTWithModifiers.trait.st
+++ b/src/Famix-Traits/FamixTWithModifiers.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithModifiers classSide >> annotation [
 
-	<MSEClass: #TWithModifiers super: #Object>
+	<FMClass: #TWithModifiers super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -37,8 +37,8 @@ FamixTWithModifiers >> bePublic [
 
 { #category : #'Famix-Extensions' }
 FamixTWithModifiers >> isAbstract [
-	<MSEProperty: #isAbstract type: #Boolean> <derived>
-	<MSEComment: 'Flag true for abstract entities. Language dependent.'>
+	<FMProperty: #isAbstract type: #Boolean> <derived>
+	<FMComment: 'Flag true for abstract entities. Language dependent.'>
 	
 	^ self modifiers includes: #abstract
 ]
@@ -50,8 +50,8 @@ FamixTWithModifiers >> isAbstract: aBoolean [
 
 { #category : #'Famix-Extensions' }
 FamixTWithModifiers >> isFinal [
-	<MSEProperty: #isFinal type: #Boolean> <derived>
-	<MSEComment: 'Flag true for entities defined as being final. Language dependent.'>	
+	<FMProperty: #isFinal type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities defined as being final. Language dependent.'>	
 
 	^ self modifiers includes: #final
 ]
@@ -63,8 +63,8 @@ FamixTWithModifiers >> isFinal: aBoolean [
 
 { #category : #'Famix-Extensions' }
 FamixTWithModifiers >> isPackage [
-	<MSEProperty: #isPackage type: #Boolean> <derived>
-	<MSEComment: 'Flag true for entities that have a package visibility. Language dependent.'>
+	<FMProperty: #isPackage type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities that have a package visibility. Language dependent.'>
 	
 	^ self modifiers includes: #package
 ]
@@ -76,8 +76,8 @@ FamixTWithModifiers >> isPackage: aBoolean [
 
 { #category : #'Famix-Extensions' }
 FamixTWithModifiers >> isPrivate [
-	<MSEProperty: #isPrivate type: #Boolean> <derived>
-	<MSEComment: 'Flag true for entities invisible out of their owner scope. Language dependent.'>
+	<FMProperty: #isPrivate type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities invisible out of their owner scope. Language dependent.'>
 	
 	^ self modifiers includes: #private
 ]
@@ -89,8 +89,8 @@ FamixTWithModifiers >> isPrivate: aBoolean [
 
 { #category : #'Famix-Extensions' }
 FamixTWithModifiers >> isProtected [
-	<MSEProperty: #isProtected type: #Boolean> <derived>
-	<MSEComment: 'Flag true for protected entities, depending on language semantics.'>
+	<FMProperty: #isProtected type: #Boolean> <derived>
+	<FMComment: 'Flag true for protected entities, depending on language semantics.'>
 	
 	^ self modifiers includes: #protected
 ]
@@ -102,8 +102,8 @@ FamixTWithModifiers >> isProtected: aBoolean [
 
 { #category : #'Famix-Extensions' }
 FamixTWithModifiers >> isPublic [
-	<MSEProperty: #isPublic type: #Boolean> <derived>
-	<MSEComment: 'Flag true for entities accessible from anywhere. Language dependent.'>	
+	<FMProperty: #isPublic type: #Boolean> <derived>
+	<FMComment: 'Flag true for entities accessible from anywhere. Language dependent.'>	
 
 	^ self modifiers includes: #public
 ]
@@ -121,9 +121,9 @@ FamixTWithModifiers >> modifierSet: aBoolean for: aSymbol [
 { #category : #accessing }
 FamixTWithModifiers >> modifiers [
 
-	<MSEProperty: #modifiers type: #String>
+	<FMProperty: #modifiers type: #String>
 	<multivalued>
-	<MSEComment: 'Generic container for language dependent modifiers.'>
+	<FMComment: 'Generic container for language dependent modifiers.'>
 	^ modifiers ifNil: [ modifiers := Set new ]
 ]
 

--- a/src/Famix-Traits/FamixTWithNamespaces.trait.st
+++ b/src/Famix-Traits/FamixTWithNamespaces.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithNamespaces classSide >> annotation [
 
-	<MSEClass: #TWithNamespaces super: #Object>
+	<FMClass: #TWithNamespaces super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithPackages.trait.st
+++ b/src/Famix-Traits/FamixTWithPackages.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithPackages classSide >> annotation [
 
-	<MSEClass: #TWithPackages super: #Object>
+	<FMClass: #TWithPackages super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithParameterizedTypeUsers classSide >> annotation [
 
-	<MSEClass: #TWithParameterizedTypeUsers super: #Object>
+	<FMClass: #TWithParameterizedTypeUsers super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithParameterizedTypes classSide >> annotation [
 
-	<MSEClass: #TWithParameterizedTypes super: #Object>
+	<FMClass: #TWithParameterizedTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithParameters classSide >> annotation [
 
-	<MSEClass: #TWithParameters super: #Object>
+	<FMClass: #TWithParameters super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -22,8 +22,8 @@ FamixTWithParameters >> addParameter: aParameter [
 
 { #category : #accessing }
 FamixTWithParameters >> numberOfParameters [
-	<MSEProperty: #numberOfParameters type: #Number>
-	<MSEComment: 'The number of parameters in a method'>
+	<FMProperty: #numberOfParameters type: #Number>
+	<FMComment: 'The number of parameters in a method'>
 	<derived>
 	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
 ]
@@ -39,7 +39,7 @@ FamixTWithParameters >> parameters [
 	"Relation named: #parameters type: #FamixTParameter opposite: #parentBehaviouralEntity"
 
 	<generated>
-	<MSEComment: 'List of formal parameters declared by this behaviour.'>
+	<FMComment: 'List of formal parameters declared by this behaviour.'>
 	<derived>
 	^ parameters
 ]

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithReferences classSide >> annotation [
 
-	<MSEClass: #TWithReferences super: #Object>
+	<FMClass: #TWithReferences super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithReferences >> outgoingReferences [
 	"Relation named: #outgoingReferences type: #FamixTReference opposite: #source"
 
 	<generated>
-	<MSEComment: 'References from this entity to other entities.'>
+	<FMComment: 'References from this entity to other entities.'>
 	<derived>
 	^ outgoingReferences
 ]

--- a/src/Famix-Traits/FamixTWithSignature.trait.st
+++ b/src/Famix-Traits/FamixTWithSignature.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSignature classSide >> annotation [
 
-	<MSEClass: #TWithSignature super: #Object>
+	<FMClass: #TWithSignature super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -18,9 +18,9 @@ FamixTWithSignature classSide >> annotation [
 { #category : #accessing }
 FamixTWithSignature >> signature [
 
-	<MSEProperty: #signature type: #String>
+	<FMProperty: #signature type: #String>
 	<generated>
-	<MSEComment: 'Signature of the message being sent'>
+	<FMComment: 'Signature of the message being sent'>
 	^ signature
 ]
 

--- a/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSourceAnchor classSide >> annotation [
 
-	<MSEClass: #TWithSourceAnchor super: #Object>
+	<FMClass: #TWithSourceAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -36,8 +36,8 @@ FamixTWithSourceAnchor >> notExistentMetricValue [
 
 { #category : #'Famix-Implementation' }
 FamixTWithSourceAnchor >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
-	<MSEComment: 'The number of lines of code in a method.'>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code in a method.'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCode
 		computedAs: [ self computeNumberOfLinesOfCode ]
@@ -51,8 +51,8 @@ FamixTWithSourceAnchor >> numberOfLinesOfCode: aNumber [
 
 { #category : #metrics }
 FamixTWithSourceAnchor >> numberOfLinesOfCodeWithMoreThanOneCharacter [
-	<MSEProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number> <derived>
-	<MSEComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
+	<FMProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number> <derived>
+	<FMComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
 	the difference being that it only counts the lines with more than one non-whitespace characters.
 	This metric is particularly useful for comparing the density of other metrics on a line of code.
 	For example, depending on the formatting style chosen a Java curly brace, or a Smalltalk block 
@@ -70,7 +70,7 @@ FamixTWithSourceAnchor >> sourceAnchor [
 	"Relation named: #sourceAnchor type: #FamixTSourceAnchor opposite: #element"
 
 	<generated>
-	<MSEComment: 'SourceAnchor entity linking to the original source code for this entity'>
+	<FMComment: 'SourceAnchor entity linking to the original source code for this entity'>
 	<derived>
 	^ sourceAnchor
 ]

--- a/src/Famix-Traits/FamixTWithSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceLanguage.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithSourceLanguage classSide >> annotation [
 
-	<MSEClass: #TWithSourceLanguage super: #Object>
+	<FMClass: #TWithSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -20,7 +20,7 @@ FamixTWithSourceLanguage >> declaredSourceLanguage [
 	"Relation named: #declaredSourceLanguage type: #FamixTSourceLanguage opposite: #sourcedEntities"
 
 	<generated>
-	<MSEComment: 'The declared SourceLanguage for the source code of this entity'>
+	<FMComment: 'The declared SourceLanguage for the source code of this entity'>
 	^ declaredSourceLanguage
 ]
 

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -6,7 +6,7 @@ Trait {
 { #category : #meta }
 FamixTWithStatements classSide >> annotation [
 
-	<MSEClass: #TWithStatements super: #Object>
+	<FMClass: #TWithStatements super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -14,9 +14,9 @@ FamixTWithStatements classSide >> annotation [
 
 { #category : #metrics }
 FamixTWithStatements >> numberOfStatements [
-	<MSEProperty: #numberOfStatements type: #Number>
+	<FMProperty: #numberOfStatements type: #Number>
 	<derived>
-	<MSEComment: 'The number of statements in a class'>
+	<FMComment: 'The number of statements in a class'>
 	^ self lookUpPropertyNamed: #numberOfStatements computedAs: [ (self toScope: FamixTWithStatements) detectSum: #numberOfStatements ]
 ]
 

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTemplates classSide >> annotation [
 
-	<MSEClass: #TWithTemplates super: #Object>
+	<FMClass: #TWithTemplates super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithThrownExceptions.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithThrownExceptions classSide >> annotation [
 
-	<MSEClass: #TWithThrownExceptions super: #Object>
+	<FMClass: #TWithThrownExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -25,7 +25,7 @@ FamixTWithThrownExceptions >> thrownExceptions [
 	"Relation named: #thrownExceptions type: #FamixTThrownException opposite: #definingEntity"
 
 	<generated>
-	<MSEComment: 'The exceptions thrown by the method'>
+	<FMComment: 'The exceptions thrown by the method'>
 	<derived>
 	^ thrownExceptions
 ]

--- a/src/Famix-Traits/FamixTWithTraits.trait.st
+++ b/src/Famix-Traits/FamixTWithTraits.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTraits classSide >> annotation [
 
-	<MSEClass: #TWithTraits super: #Object>
+	<FMClass: #TWithTraits super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTWithTypeAliases.trait.st
+++ b/src/Famix-Traits/FamixTWithTypeAliases.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTypeAliases classSide >> annotation [
 
-	<MSEClass: #TWithTypeAliases super: #Object>
+	<FMClass: #TWithTypeAliases super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -40,7 +40,7 @@ FamixTWithTypeAliases >> typeAliases [
 	"Relation named: #typeAliases type: #FamixTTypeAlias opposite: #aliasedType"
 
 	<generated>
-	<MSEComment: 'Aliases'>
+	<FMComment: 'Aliases'>
 	<derived>
 	^ typeAliases
 ]

--- a/src/Famix-Traits/FamixTWithTypedStructures.trait.st
+++ b/src/Famix-Traits/FamixTWithTypedStructures.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTypedStructures classSide >> annotation [
 
-	<MSEClass: #TWithTypedStructures super: #Object>
+	<FMClass: #TWithTypedStructures super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -46,7 +46,7 @@ FamixTWithTypedStructures >> structuresWithDeclaredType [
 	"Relation named: #structuresWithDeclaredType type: #FamixTTypedStructure opposite: #declaredType"
 
 	<generated>
-	<MSEComment: 'Structural entities that have this type as declaredType'>
+	<FMComment: 'Structural entities that have this type as declaredType'>
 	<derived>
 	^ structuresWithDeclaredType
 ]

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -9,7 +9,7 @@ Trait {
 { #category : #meta }
 FamixTWithTypes classSide >> annotation [
 
-	<MSEClass: #TWithTypes super: #Object>
+	<FMClass: #TWithTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
@@ -41,9 +41,9 @@ FamixTWithTypes >> allRecursiveTypesDo: aBlock [
 
 { #category : #metrics }
 FamixTWithTypes >> fanOut [
-	<MSEProperty: #fanOut type: #Number>
+	<FMProperty: #fanOut type: #Number>
 	<derived>
-	<MSEComment: 'Number of provider classes'>
+	<FMComment: 'Number of provider classes'>
 	^ self lookUpPropertyNamed: #fanOut computedAs: [ (self allProvidersAtScope: FamixTType) size ]
 ]
 
@@ -58,7 +58,7 @@ FamixTWithTypes >> types [
 	"Relation named: #types type: #FamixTType opposite: #typeContainer"
 
 	<generated>
-	<MSEComment: 'Types contained (declared) in this entity, if any.
+	<FMComment: 'Types contained (declared) in this entity, if any.
 #types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.'>
 	<derived>
 	^ types

--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -257,22 +257,22 @@ MooseAbstractGroup >> allTypes [
 
 { #category : #'*Famix-Traits' }
 MooseAbstractGroup >> numberOfAssociations [
-	<MSEProperty: #numberOfAssociations type: #Number>
-	<MSEComment: 'The total number of associations'>
+	<FMProperty: #numberOfAssociations type: #Number>
+	<FMComment: 'The total number of associations'>
 	^ (self allWithSubTypesOf: FamixTAssociation) size
 ]
 
 { #category : #'*Famix-Traits' }
 MooseAbstractGroup >> numberOfEntities [
-	<MSEProperty: #numberOfEntities type: #Number>
-	<MSEComment: 'The total number of entities (items that are not associations)'>
+	<FMProperty: #numberOfEntities type: #Number>
+	<FMComment: 'The total number of entities (items that are not associations)'>
 	^ self numberOfItems - self numberOfAssociations
 ]
 
 { #category : #'*Famix-Traits' }
 MooseAbstractGroup >> numberOfLinesOfCode [
-	<MSEProperty: #numberOfLinesOfCode type: #Number>
-	<MSEComment: 'The number of classes in the model'>
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of classes in the model'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCode
 		computedAs: [ self allMethods sum: #numberOfLinesOfCode ]
@@ -280,7 +280,7 @@ MooseAbstractGroup >> numberOfLinesOfCode [
 
 { #category : #'*Famix-Traits' }
 MooseAbstractGroup >> numberOfPackages [
-	<MSEProperty: #numberOfPackages type: #Number>
-	<MSEComment: 'Total number of packages'>
+	<FMProperty: #numberOfPackages type: #Number>
+	<FMComment: 'Total number of packages'>
 	^ self privateState propertyAt: #numberOfPackages ifAbsentPut: [ self allPackages size ] 
 ]

--- a/src/Famix-Traits/MooseModel.extension.st
+++ b/src/Famix-Traits/MooseModel.extension.st
@@ -17,16 +17,16 @@ MooseModel >> allSourceLanguages [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> averageCyclomaticComplexity [
-	<MSEProperty: #averageCyclomaticComplexity type: #Number>
+	<FMProperty: #averageCyclomaticComplexity type: #Number>
 	<derived>
-	<MSEComment: 'The average cyclomatic complexity for methods'>
+	<FMComment: 'The average cyclomatic complexity for methods'>
 	^ self lookUpPropertyNamed: #averageCyclomaticComplexity computedAs: [ (self allMethods collect: #cyclomaticComplexity) ifEmpty: [ 1 ] ifNotEmpty: #average ]
 ]
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfClassesPerPackage [
-	<MSEProperty: #numberOfClassesPerPackage type: #Number>
-	<MSEComment: 'The number of methods per package in the model'>
+	<FMProperty: #numberOfClassesPerPackage type: #Number>
+	<FMComment: 'The number of methods per package in the model'>
 	^ self
 		lookUpPropertyNamed: #numberOfClassesPerPackage
 		computedAs: [ self numberOfMethods / self numberOfClasses ]
@@ -34,8 +34,8 @@ MooseModel >> numberOfClassesPerPackage [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfLinesOfCodePerMethod [
-	<MSEProperty: #numberOfLinesOfCodePerMethod type: #Number>
-	<MSEComment: 'The number of lines of code per method in the model'>
+	<FMProperty: #numberOfLinesOfCodePerMethod type: #Number>
+	<FMComment: 'The number of lines of code per method in the model'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCodePerMethod
 		computedAs: [ self numberOfLinesOfCode / self numberOfMethods ]
@@ -43,8 +43,8 @@ MooseModel >> numberOfLinesOfCodePerMethod [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfLinesOfCodePerPackage [
-	<MSEProperty: #numberOfLinesOfCodePerPackage type: #Number>
-	<MSEComment: 'The number of lines of code per package in the model'>
+	<FMProperty: #numberOfLinesOfCodePerPackage type: #Number>
+	<FMComment: 'The number of lines of code per package in the model'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCodePerPackage
 		computedAs: [ self numberOfLinesOfCode / self numberOfPackages ]
@@ -52,8 +52,8 @@ MooseModel >> numberOfLinesOfCodePerPackage [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfMethods [
-	<MSEProperty: #numberOfMethods type: #Number>
-	<MSEComment: 'The number of methods'>
+	<FMProperty: #numberOfMethods type: #Number>
+	<FMComment: 'The number of methods'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfMethods
@@ -62,8 +62,8 @@ MooseModel >> numberOfMethods [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfMethodsPerPackage [
-	<MSEProperty: #numberOfClassesPerPackage type: #Number>
-	<MSEComment: 'The number of methods per package in the model'>
+	<FMProperty: #numberOfClassesPerPackage type: #Number>
+	<FMComment: 'The number of methods per package in the model'>
 	^ self
 		lookUpPropertyNamed: #numberOfMethodsPerPackage
 		computedAs: [ self numberOfMethods / self numberOfPackages ]
@@ -71,8 +71,8 @@ MooseModel >> numberOfMethodsPerPackage [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfModelClasses [
-	<MSEProperty: #numberOfModelClasses type: #Number>
-	<MSEComment: 'The number of classes in the model'>
+	<FMProperty: #numberOfModelClasses type: #Number>
+	<FMComment: 'The number of classes in the model'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfModelClasses
@@ -81,8 +81,8 @@ MooseModel >> numberOfModelClasses [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> numberOfModelMethods [
-	<MSEProperty: #numberOfModelMethods type: #Number>
-	<MSEComment: 'The number of methods in the model'>
+	<FMProperty: #numberOfModelMethods type: #Number>
+	<FMComment: 'The number of methods in the model'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfModelMethods
@@ -91,8 +91,8 @@ MooseModel >> numberOfModelMethods [
 
 { #category : #'*Famix-Traits' }
 MooseModel >> sourceLanguage [
-	<MSEProperty: #sourceLanguage type: #FamixTSourceLanguage>
-	<MSEComment: 'Source of the Language to which the model corresponds'>
+	<FMProperty: #sourceLanguage type: #FamixTSourceLanguage>
+	<FMComment: 'Source of the Language to which the model corresponds'>
 	^ self privateState
 		propertyAt: #sourceLanguage
 		ifAbsentPut: [ self allSourceLanguages detect: [ :each | each isAttached not ] ifNone: [ nil ] ]

--- a/src/Moose-Core/FAMIXMetaModelClassesNotDeclaredInFameRule.class.st
+++ b/src/Moose-Core/FAMIXMetaModelClassesNotDeclaredInFameRule.class.st
@@ -22,7 +22,7 @@ FAMIXMetaModelClassesNotDeclaredInFameRule >> checkClass: aContext [
 	class := aContext.
 
 	(self metaModelClasses includes: class instanceSide)
-		ifTrue: [ pragmas := Pragma allNamed: #MSEClass:super: in: class.
+		ifTrue: [ pragmas := Pragma allNamed: #FMClass:super: in: class.
 			pragmas
 				ifEmpty: [ class isMeta ifTrue: [ result addClass: class ].
 					^ self ].
@@ -45,7 +45,7 @@ FAMIXMetaModelClassesNotDeclaredInFameRule >> metaModelClasses [
 { #category : #accessing }
 FAMIXMetaModelClassesNotDeclaredInFameRule >> name [
 
-	^ 'A metamodel class is not properly Fame-described by a <MSEClass:super:> pragma'
+	^ 'A metamodel class is not properly Fame-described by a <FMClass:super:> pragma'
 ]
 
 { #category : #running }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -18,7 +18,7 @@ Class {
 
 { #category : #meta }
 MooseAbstractGroup class >> annotation [
-	<MSEClass: #AbstractGroup super: #MooseEntity>
+	<FMClass: #AbstractGroup super: #MooseEntity>
 	<package: #Moose>
 	<abstract>
 
@@ -547,8 +547,8 @@ MooseAbstractGroup >> notEmpty [
 
 { #category : #accessing }
 MooseAbstractGroup >> numberOfItems [ 
-	<MSEProperty: #numberOfItems type: #Number>
-	<MSEComment: 'The total number of items in the group'>
+	<FMProperty: #numberOfItems type: #Number>
+	<FMComment: 'The total number of items in the group'>
 	
 	^self size
 ]

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -119,7 +119,7 @@ MooseEntity class >> allPropertySelectorsComputableIn: aMooseModel [
 
 { #category : #meta }
 MooseEntity class >> annotation [
-	<MSEClass: #Entity super: #Object>
+	<FMClass: #Entity super: #Object>
 	<package: #Moose>
 	<abstract>
 ]

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #meta }
 MooseGroup class >> annotation [
-	<MSEClass: #Group super: #MooseAbstractGroup>
+	<FMClass: #Group super: #MooseAbstractGroup>
 	<package: #Moose>
 
 ]

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -24,7 +24,7 @@ MooseModel class >> allSubmetamodelsPackagesNames [
 
 { #category : #meta }
 MooseModel class >> annotation [
-	<MSEClass: #Model super: #MooseAbstractGroup>
+	<FMClass: #Model super: #MooseAbstractGroup>
 	<package: #Moose>
 
 ]
@@ -508,8 +508,8 @@ MooseModel >> name: aStringOrSymbol [
 
 { #category : #'Famix-Extensions' }
 MooseModel >> numberOfClasses [
-	<MSEProperty: #numberOfClasses type: #Number>
-	<MSEComment: 'The number of classes'>
+	<FMProperty: #numberOfClasses type: #Number>
+	<FMComment: 'The number of classes'>
 	
 	^self
 		lookUpPropertyNamed: #numberOfClasses
@@ -518,8 +518,8 @@ MooseModel >> numberOfClasses [
 
 { #category : #'Famix-Extensions' }
 MooseModel >> numberOfLinesOfCodePerClass [
-	<MSEProperty: #numberOfLinesOfCodePerClass type: #Number>
-	<MSEComment: 'The number of lines of code per class in the model'>
+	<FMProperty: #numberOfLinesOfCodePerClass type: #Number>
+	<FMComment: 'The number of lines of code per class in the model'>
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCodePerClass
 		computedAs: [ self numberOfLinesOfCode / self numberOfClasses ]

--- a/src/Moose-Core/MoosePropertyGroup.class.st
+++ b/src/Moose-Core/MoosePropertyGroup.class.st
@@ -17,7 +17,7 @@ Class {
 
 { #category : #meta }
 MoosePropertyGroup class >> annotation [
-	<MSEClass: #PropertyGroup super: #MooseGroup>
+	<FMClass: #PropertyGroup super: #MooseGroup>
 	<package: #Moose>
 ]
 
@@ -45,8 +45,8 @@ MoosePropertyGroup >> originalGroup: anObject [
 
 { #category : #accessing }
 MoosePropertyGroup >> property [
-	<MSEProperty: #property type: #String>
-	<MSEComment: 'Description of the property'>
+	<FMProperty: #property type: #String>
+	<FMComment: 'Description of the property'>
 	
 	^ propertySymbolOrBlock
 ]
@@ -58,40 +58,40 @@ MoosePropertyGroup >> property: anObject [
 
 { #category : #accessing }
 MoosePropertyGroup >> propertyRatio [
-	<MSEProperty: #propertyRatio type: #Number>
-	<MSEComment: 'Fraction represented by this group compared to originalGroup with respect to the property'>
+	<FMProperty: #propertyRatio type: #Number>
+	<FMComment: 'Fraction represented by this group compared to originalGroup with respect to the property'>
 	
 	^ (self propertyTotal / self propertyTotalOriginal) asFloat 
 ]
 
 { #category : #accessing }
 MoosePropertyGroup >> propertyTotal [
-	<MSEProperty: #propertyTotal type: #Number>
-	<MSEComment: 'Sum of values computed for the property in this group'>
+	<FMProperty: #propertyTotal type: #Number>
+	<FMComment: 'Sum of values computed for the property in this group'>
 
 	^ self sumNumbers: self property
 ]
 
 { #category : #accessing }
 MoosePropertyGroup >> propertyTotalOriginal [
-	<MSEProperty: #propertyTotalOriginal type: #Number>
-	<MSEComment: 'Sum of values computed for the property in the original group'>
+	<FMProperty: #propertyTotalOriginal type: #Number>
+	<FMComment: 'Sum of values computed for the property in the original group'>
 
 	^ self originalGroup sumNumbers: self property 
 ]
 
 { #category : #accessing }
 MoosePropertyGroup >> sizeOriginal [
-	<MSEProperty: #sizeOriginal type: #Number>
-	<MSEComment: 'Size of the original group'>
+	<FMProperty: #sizeOriginal type: #Number>
+	<FMComment: 'Size of the original group'>
 	
 	^ self originalGroup size
 ]
 
 { #category : #accessing }
 MoosePropertyGroup >> sizeRatio [
-	<MSEProperty: #sizeRatio type: #Number>
-	<MSEComment: 'Fraction represented by this group compared to originalGroup'>	
+	<FMProperty: #sizeRatio type: #Number>
+	<FMComment: 'Fraction represented by this group compared to originalGroup'>	
 
 	^ (self size / self originalGroup size) asFloat
 ]

--- a/src/Moose-Finder/MooseEntity.extension.st
+++ b/src/Moose-Finder/MooseEntity.extension.st
@@ -26,7 +26,7 @@ MooseEntity >> complexPropertyPragmas [
 		ifNil: [ NotInitializedMooseDescriptionError signal: 'Moose description are not initialized. Have you refreshed the meta-model? (e.g., MooseModel resetMeta)' ].
 	navProps := (Pragma allNamed: #navigation: from: self class to: MooseEntity) sorted: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ].
 	definedProps := (self mooseDescription allProperties reject: [ :a | a type isPrimitive ])
-		flatCollect: [ :prop | prop compiledMethod pragmas select: [ :each | each selector beginsWith: 'MSEProperty:' ] ].
+		flatCollect: [ :prop | prop compiledMethod pragmas select: [ :each | each selector beginsWith: 'FMProperty:' ] ].
 	^ (OrderedCollection withAll: definedProps)
 		addAll: navProps;
 		yourself

--- a/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
@@ -11,7 +11,7 @@ Trait {
 { #category : #meta }
 TAssociationMetaLevelDependency classSide >> annotation [
 
-	<MSEClass: #TAssociationMetaLevelDependency super: #Object>
+	<FMClass: #TAssociationMetaLevelDependency super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self

--- a/src/Moose-Query/TDependencyQueries.trait.st
+++ b/src/Moose-Query/TDependencyQueries.trait.st
@@ -64,7 +64,7 @@ Trait {
 { #category : #meta }
 TDependencyQueries classSide >> annotation [
 
-	<MSEClass: #TDependencyQueries super: #Object>
+	<FMClass: #TDependencyQueries super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -39,7 +39,7 @@ TEntityMetaLevelDependency classSide >> allParentTypesIn: aMetamodel [
 { #category : #meta }
 TEntityMetaLevelDependency classSide >> annotation [
 
-	<MSEClass: #TEntityMetaLevelDependency super: #Object>
+	<FMClass: #TEntityMetaLevelDependency super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self
@@ -570,8 +570,8 @@ TEntityMetaLevelDependency >> incomingMSEProperties [
 
 { #category : #accessing }
 TEntityMetaLevelDependency >> numberOfChildren [
-	<MSEProperty: #numberOfChildren type: #Number>
-	<MSEComment: 'Number of direct children entities in the containment tree.'>
+	<FMProperty: #numberOfChildren type: #Number>
+	<FMComment: 'Number of direct children entities in the containment tree.'>
 	<derived>
 	^ self isContainerEntity ifTrue: [ self children size ] ifFalse: [ 0 ]
 ]

--- a/src/Moose-Query/TOODependencyQueries.trait.st
+++ b/src/Moose-Query/TOODependencyQueries.trait.st
@@ -13,7 +13,7 @@ Trait {
 { #category : #meta }
 TOODependencyQueries classSide >> annotation [
 
-	<MSEClass: #TOODependencyQueries super: #Object>
+	<FMClass: #TOODependencyQueries super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
 	^self

--- a/src/Moose-Tests-Core/MooseModelDescriptionTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelDescriptionTest.class.st
@@ -6,22 +6,19 @@ Class {
 
 { #category : #running }
 MooseModelDescriptionTest >> msePropertyPragmaFor: aMethod [
-	^ aMethod pragmas detect: [ :p | p selector = #MSEProperty:type:opposite: ] ifNone: [ nil ]
+	^ aMethod pragmas detect: [ :p | p selector = #FMProperty:type:opposite: ] ifNone: [ nil ]
 ]
 
 { #category : #tests }
 MooseModelDescriptionTest >> notTested_AllPropertyCommented [
 	| allProps |
 	"MSE properties with opposite"
-	allProps := SystemNavigation new allMethods select: [:e | e hasPragmaNamed: #MSEProperty:type:opposite: ].
-	self assert: (allProps select: [ :m | m pragmas noneSatisfy: [:p | p keyword = #MSEComment: ] ]) size
-		equals: 0.
-		
-	"MSE properties without opposite"
-	allProps := SystemNavigation new allMethods select: [:e | e hasPragmaNamed: #MSEProperty:type: ].
-	self assert: (allProps select: [ :m | m pragmas noneSatisfy: [:p | p keyword = #MSEComment: ] ]) size
-		equals: 0.
+	allProps := SystemNavigation new allMethods select: [ :e | e hasPragmaNamed: #'FMProperty::type:opposite:' ].
+	self assertEmpty: (allProps select: [ :m | m pragmas noneSatisfy: [ :p | p keyword = #FMComment: ] ]).
 
+	"MSE properties without opposite"
+	allProps := SystemNavigation new allMethods select: [ :e | e hasPragmaNamed: #FMProperty:type: ].
+	self assertEmpty: (allProps select: [ :m | m pragmas noneSatisfy: [ :p | p keyword = #FMComment: ] ])
 ]
 
 { #category : #tests }
@@ -42,28 +39,27 @@ MooseModelDescriptionTest >> testAsMooseDescriptionAttributes [
 MooseModelDescriptionTest >> testOppositeOfOppositePropertyIsMyself [
 	| allSelector dictOpposite |
 
-	allSelector := SystemNavigation new allMethods select: [:e | e hasPragmaNamed: #MSEProperty:type:opposite: ].
+	allSelector := SystemNavigation new allMethods select: [:e | e hasPragmaNamed: #FMProperty:type:opposite: ].
 
 	dictOpposite := Dictionary new.
 	allSelector do: [ :s || pragma |
 		pragma := self msePropertyPragmaFor: s.
 		dictOpposite at: (pragma arguments second -> pragma arguments third) put: s selector
 	].
-	self assert: (allSelector reject: [ :s || pragma |
+
+	self assertEmpty: (allSelector reject: [ :s || pragma |
 							pragma := self msePropertyPragmaFor: s.
 							[(dictOpposite at: (s methodClass -> s selector)) = (pragma arguments third)]
 							on: KeyNotFound
 							do: [ true ] "ignore, will be treated by testOppositePropertyExist"
-						]) size
-			equals: 0.
-
+						]) 
 ]
 
 { #category : #tests }
 MooseModelDescriptionTest >> testOppositePropertyExist [
 	| allSelector |
 
-	allSelector := SystemNavigation new allMethods select: [:e | e hasPragmaNamed: #MSEProperty:type:opposite: ].
+	allSelector := SystemNavigation new allMethods select: [:e | e hasPragmaNamed: #FMProperty:type:opposite: ].
 
 	self assert: (allSelector reject: [ :s || pragma |
 							pragma := self msePropertyPragmaFor: s.

--- a/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXClassNavigationChefTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-KGB/FAMIXClassNavigationChefTest.class.st
@@ -562,7 +562,7 @@ FAMIXClassNavigationChefTest >> testReferencingPackages [
 { #category : #'tests - outgoing invocations' }
 FAMIXClassNavigationChefTest >> testSourcesInReferencedMethods [
 	self
-		assertCollection: (self c6FullReferencerInSideOutSide queryAllOutgoingInvocations outOfParentUsing: FamixTNamespace) sourceMethods
+		assertCollection: (self c6FullReferencerInSideOutSide queryAllOutgoingInvocations outOfParentUsing: FamixTNamespace) sources
 		hasSameElements: {(self getMethod: 'm1p3c6Mtd1()') . (self getMethod: 'm1p3c6Mtd2()')}
 ]
 


### PR DESCRIPTION
Fame-Core should not be aware of the exporters/importers. 

I renamed the pragmas with MSE to use FM prefix instead. The pragma processor is still backward compatible for the time been.