### PR TITLE
Improve-FMImporter-making-MSEImporter-obsolete

### DIFF
--- a/src/Fame-ImportExport/FMImporter.class.st
+++ b/src/Fame-ImportExport/FMImporter.class.st
@@ -7,12 +7,12 @@ Class {
 		'stack',
 		'elements',
 		'model',
-		'metamodel',
 		'stream',
 		'tally',
 		'reminderDict',
 		'serialDict',
-		'translationUnit'
+		'translationUnit',
+		'ensureNoDandlingReferences'
 	],
 	#category : #'Fame-ImportExport-Importers'
 }
@@ -34,6 +34,13 @@ FMImporter >> assign: element to: serial [
 			each resolve: element.
 			tally := tally - 1.
 			self assert: tally >= 0 ]
+]
+
+{ #category : #accessing }
+FMImporter >> autorizeDandlingReferencesAtEnd [
+	"I am using DandlingReferences to manage references during the import. At the end I can check that all dandling references are resolved. Calling this method, I'll not do the check and allow partial loading of models."
+
+	ensureNoDandlingReferences := false
 ]
 
 { #category : #parsing }
@@ -82,7 +89,7 @@ FMImporter >> endAttribute: name [
 FMImporter >> endDocument [
 	self assert: stack isEmpty.
 	stack := nil.
-	self assert: tally = 0.
+	ensureNoDandlingReferences ifTrue: [ tally = 0 ifFalse: [ FMUnresolvedDanglingReferences signal ] ].
 	model addAll: elements
 ]
 
@@ -109,12 +116,13 @@ FMImporter >> index [
 { #category : #initialization }
 FMImporter >> initialize [
 	super initialize.
-	translationUnit := FMNullTranslationUnit new
+	translationUnit := FMNullTranslationUnit new.
+	ensureNoDandlingReferences := true
 ]
 
 { #category : #accessing }
 FMImporter >> metamodel [
-	^metamodel
+	^ model metamodel
 ]
 
 { #category : #accessing }
@@ -124,8 +132,7 @@ FMImporter >> model [
 
 { #category : #accessing }
 FMImporter >> model: aModel [
-	model := aModel.
-	metamodel := aModel metamodel
+	model := aModel
 ]
 
 { #category : #parsing }

--- a/src/Fame-ImportExport/FMUnresolvedDanglingReferences.class.st
+++ b/src/Fame-ImportExport/FMUnresolvedDanglingReferences.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FMUnresolvedDanglingReferences,
+	#superclass : #Error,
+	#category : #'Fame-ImportExport-Importers'
+}
+
+{ #category : #accessing }
+FMUnresolvedDanglingReferences >> messageText [
+	^ 'The import ended with unresolved references and was configured to fail in this case.'
+]

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -14,7 +14,7 @@ FM3ClassTest >> addUnamedOwnerTo: anElement [
 	anElement package: FM3Package new
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testAllProperties [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allProperties isNotNil.
@@ -22,7 +22,7 @@ FM3ClassTest >> testAllProperties [
 	self denyEmpty: element allProperties
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testAllPropertiesMoreThanProperties [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allProperties size > element properties size.
@@ -30,7 +30,7 @@ FM3ClassTest >> testAllPropertiesMoreThanProperties [
 	self assert: (element allProperties includesAll: element properties)
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testAllPropertiesNotHot [
 	| class prop size |
 	class := metaMetamodel elementNamed: 'FM3.Class'.
@@ -43,7 +43,7 @@ FM3ClassTest >> testAllPropertiesNotHot [
 	self assert: prop mmClass equals: class
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testAllSuperclasses [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element allSuperclasses isNotNil.
@@ -51,34 +51,34 @@ FM3ClassTest >> testAllSuperclasses [
 	self assert: element allSuperclasses size equals: 2
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testHasOwner [
 	self assert: metaMetamodel classes anyOne hasOwner.
 	self assert: metaMetamodel properties anyOne hasOwner.
 	self deny: metaMetamodel packages anyOne hasOwner
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testHasPackage [
 	self assert: metaMetamodel classes anyOne hasPackage
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testHasSuperclass [
 	self assert: metaMetamodel classes anyOne hasSuperclass
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testIsPrimitive [
 	self deny: metaMetamodel classes anyOne isPrimitive
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testIsRoot [
 	self deny: metaMetamodel classes anyOne isRoot
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testProperties [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: element properties isNotNil.
@@ -86,7 +86,7 @@ FM3ClassTest >> testProperties [
 	self denyEmpty: element properties
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testPropertiesIsHot [
 	| class prop size |
 	class := metaMetamodel elementNamed: 'FM3.Class'.
@@ -99,7 +99,7 @@ FM3ClassTest >> testPropertiesIsHot [
 	self assert: prop mmClass isNil
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testPropertyNamed [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: (element propertyNamed: #owner) isNotNil.
@@ -107,7 +107,7 @@ FM3ClassTest >> testPropertyNamed [
 	self assert: (element propertyNamed: #zork) isNil
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testPropertyNamedString [
 	element := metaMetamodel elementNamed: 'FM3.Class'.
 	self assert: (element propertyNamed: 'owner') isNotNil.
@@ -115,7 +115,7 @@ FM3ClassTest >> testPropertyNamedString [
 	self assert: (element propertyNamed: 'zork') isNil
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3ClassTest >> testSubclasses [
 	self denyEmpty: (metaMetamodel elementNamed: 'FM3.Element') subclasses
 ]

--- a/src/Fame-Tests/FM3PropertyTest.class.st
+++ b/src/Fame-Tests/FM3PropertyTest.class.st
@@ -14,7 +14,7 @@ FM3PropertyTest >> addUnamedOwnerTo: anElement [
 	anElement mmClass: FM3Class new
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3PropertyTest >> testClassHasOpposite [
 	| e |
 	e := metaMetamodel elementNamed: 'FM3.Property.class'.
@@ -22,14 +22,14 @@ FM3PropertyTest >> testClassHasOpposite [
 	self assert: e opposite fullName equals: 'FM3.Class.properties'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3PropertyTest >> testIsCompositeDerived [
 	| e |
 	e := metaMetamodel elementNamed: 'FM3.Property.composite'.
 	self assert: e isDerived
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FM3PropertyTest >> testTypeHasOpposite [
 	| e |
 	e := metaMetamodel elementNamed: 'FM3.Property.type'.

--- a/src/Fame-Tests/FMCodeGenerationTest.class.st
+++ b/src/Fame-Tests/FMCodeGenerationTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Fame-Tests'
 }
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testClassNamePrefix [
 	| gen |
 	gen := FMDefaultCodeGenerator new.
@@ -13,7 +13,7 @@ FMCodeGenerationTest >> testClassNamePrefix [
 	self assert: gen classNamePrefix equals: 'Zork'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testComplexGeneration [
 	| metamodel generator |
 	metamodel := FMMetaModel fromString: FMMSEParserTest famix30mse.
@@ -25,7 +25,7 @@ FMCodeGenerationTest >> testComplexGeneration [
 	generator previewChangesIfShiftPressed
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testDefaultCategory [
 	| gen |
 	gen := FMDefaultCodeGenerator new.
@@ -34,7 +34,7 @@ FMCodeGenerationTest >> testDefaultCategory [
 	self assert: gen defaultCategory equals: 'Fame-Example'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testDefaultClass [
 	| gen |
 	gen := FMDefaultCodeGenerator new.
@@ -43,7 +43,7 @@ FMCodeGenerationTest >> testDefaultClass [
 	self assert: gen defaultSuperclass name equals: #LIBRoot
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testFM3Generation [
 	self
 		shouldnt: [ FMDefaultCodeGenerator new
@@ -52,7 +52,7 @@ FMCodeGenerationTest >> testFM3Generation [
 		raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testLIBGeneration [
 	| generator |
 	generator := FMDefaultCodeGenerator new.
@@ -61,7 +61,7 @@ FMCodeGenerationTest >> testLIBGeneration [
 	generator previewChangesIfShiftPressed
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testRPGGeneration [
 	| generator |
 	generator := FMDefaultCodeGenerator new.
@@ -70,7 +70,7 @@ FMCodeGenerationTest >> testRPGGeneration [
 	generator previewChangesIfShiftPressed
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMCodeGenerationTest >> testSimpleGeneration [
 	| gen |
 	gen := FMDefaultCodeGenerator new.

--- a/src/Fame-Tests/FMDungeonExample.class.st
+++ b/src/Fame-Tests/FMDungeonExample.class.st
@@ -37,7 +37,7 @@ FMDungeonExample >> setUp [
 	metamodel := FMMetaModelBuilder metamodelFrom: {RPGDragon . RPGTreasure . RPGHero}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testDragonHoard [
 	| a b x y |
 	a := (metamodel elementNamed: 'RPG.Dragon') createInstance.
@@ -75,7 +75,7 @@ FMDungeonExample >> testDragonHoard [
 	self deny: (b hoard includes: y)
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testDragonKilledBy [
 	| a b x y |
 	a := (metamodel elementNamed: 'RPG.Dragon') createInstance.
@@ -133,7 +133,7 @@ FMDungeonExample >> testDragonKilledBy [
 	self assert: y kills size equals: 0
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testHeroKills [
 	| a b x y |
 	a := (metamodel elementNamed: 'RPG.Dragon') createInstance.
@@ -191,7 +191,7 @@ FMDungeonExample >> testHeroKills [
 	self assert: y kills size equals: 0
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testHeroTalisman [
 	| a b x y |
 	a := (metamodel elementNamed: 'RPG.Hero') createInstance.
@@ -228,7 +228,7 @@ FMDungeonExample >> testHeroTalisman [
 	self assert: y owner isNil
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testHeroTwin [
 	| a b c |
 	a := (metamodel elementNamed: 'RPG.Hero') createInstance.
@@ -258,7 +258,7 @@ FMDungeonExample >> testHeroTwin [
 	self assert: c twin isNil
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testTreasureKeeper [
 	| a b x y |
 	a := (metamodel elementNamed: 'RPG.Dragon') createInstance.
@@ -296,7 +296,7 @@ FMDungeonExample >> testTreasureKeeper [
 	self deny: (b hoard includes: y)
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMDungeonExample >> testTreasureOwner [
 	| a b x y |
 	a := (metamodel elementNamed: 'RPG.Hero') createInstance.

--- a/src/Fame-Tests/FMEquationSystemExample.class.st
+++ b/src/Fame-Tests/FMEquationSystemExample.class.st
@@ -66,13 +66,13 @@ FMEquationSystemExample >> setUp [
 	metaModel := self class createMetamodel
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMEquationSystemExample >> testAllSubclasses [
 	self assert: (metaModel elementNamed: 'EQ.Expression') notNil.
 	self assert: (metaModel elementNamed: 'EQ.Expression') allSubclasses size equals: 4
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMEquationSystemExample >> testMetamodel [
 	self assert: metaModel elements size equals: 19.
 	self assert: metaModel packages size equals: 1.
@@ -80,12 +80,12 @@ FMEquationSystemExample >> testMetamodel [
 	self assert: metaModel properties size equals: 9
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMEquationSystemExample >> testMetamodelContainsCompound [
 	self assert: (metaModel elementNamed: 'EQ.Compound') notNil
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMEquationSystemExample >> testPrintString [
 	| model systems |
 	model := (FMModel withMetamodel: metaModel)

--- a/src/Fame-Tests/FMExporterTest.class.st
+++ b/src/Fame-Tests/FMExporterTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Fame-Tests'
 }
 
-{ #category : #running }
+{ #category : #tests }
 FMExporterTest >> testExportAsMSE [
 	| printer |
 	printer := FMMSEPrinter onString.
@@ -13,7 +13,7 @@ FMExporterTest >> testExportAsMSE [
 	self assert: printer stream contents first equals: $(
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMExporterTest >> testExportAsXML [
 	| printer |
 	printer := FMXMLPrinter onString.

--- a/src/Fame-Tests/FMHeinekenExample.class.st
+++ b/src/Fame-Tests/FMHeinekenExample.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Fame-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #resources }
 FMHeinekenExample class >> metamodelMSE [
 
 	^'((FM3.Package 
@@ -64,7 +64,7 @@ FMHeinekenExample class >> metamodelMSE [
 	)))'.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #resources }
 FMHeinekenExample class >> modelMSE [
 
 	^'((HNK.Beer (id: 1)
@@ -86,6 +86,28 @@ FMHeinekenExample class >> modelMSE [
 		(HNK.Customer (id: 4)
 			(name ''Joe Example'')
 			(address ''Levittown''))	
+	)'.
+]
+
+{ #category : #resources }
+FMHeinekenExample class >> modelMSEWithDanglingReferences [
+
+	^'((HNK.Beer (id: 1)
+			(name ''Heineken'')
+			(alcvol 5)
+			(price 0.6)
+			(vol 0.5)
+			(instock 1000))
+		(HNK.Order (id: 2)
+			(item (ref: 1))
+			(amount 6)
+			(date ''2008-08-25 11:45'')
+			(customer (ref: 4)))
+		(HNK.Order (id: 3)
+			(item (ref: 1))
+			(amount 12)
+			(date ''2008-08-17 18:30'')
+			(customer (ref: 4)))
 	)'.
 ]
 

--- a/src/Fame-Tests/FMHeinekenExample.class.st
+++ b/src/Fame-Tests/FMHeinekenExample.class.st
@@ -111,7 +111,7 @@ FMHeinekenExample class >> modelMSEWithDanglingReferences [
 	)'.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMHeinekenExample >> testImportMetamodelAndCreateClasses [
 	| gen |
 	gen := FMDefaultCodeGenerator new.

--- a/src/Fame-Tests/FMImporterTest.class.st
+++ b/src/Fame-Tests/FMImporterTest.class.st
@@ -19,7 +19,16 @@ FMImporterTest class >> simpleCompositeMetamodelExtension [
 			(FM3.Property (name ''name'') (type (ref: String)) (class (ref: EG.Leaf))))))'
 ]
 
-{ #category : #running }
+{ #category : #tests }
+FMImporterTest >> testAutorizeDandlingReferencesAtEnd [
+	| importer |
+	importer := FMImporter model: (FMModel withMetamodel: (FMMetaModel fromString: FMHeinekenExample metamodelMSE)).
+	importer fromString: FMHeinekenExample modelMSEWithDanglingReferences.
+	importer autorizeDandlingReferencesAtEnd.
+	self shouldnt: [ importer run ] raise: FMUnresolvedDanglingReferences
+]
+
+{ #category : #tests }
 FMImporterTest >> testElementNamed [
 	| metamodel |
 	metamodel := FMMetaModel fromString: FMHeinekenExample metamodelMSE.
@@ -28,7 +37,15 @@ FMImporterTest >> testElementNamed [
 	self assert: (metamodel elementNamed: 'HNK.Beer') fullName equals: 'HNK.Beer'
 ]
 
-{ #category : #running }
+{ #category : #tests }
+FMImporterTest >> testEnsureNoDandlingReferences [
+	| importer |
+	importer := FMImporter model: (FMModel withMetamodel: (FMMetaModel fromString: FMHeinekenExample metamodelMSE)).
+	importer fromString: FMHeinekenExample modelMSEWithDanglingReferences.
+	self should: [ importer run ] raise: FMUnresolvedDanglingReferences
+]
+
+{ #category : #tests }
 FMImporterTest >> testImportBook [
 	| importer builder |
 	importer := FMImporter model: FMMetaModel new.
@@ -39,7 +56,7 @@ FMImporterTest >> testImportBook [
 	self assert: importer model elements anyOne name equals: #Book
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testImportHeinekenMetamodel [
 	| metamodel |
 	metamodel := FMMetaModel fromString: FMHeinekenExample metamodelMSE.
@@ -48,7 +65,7 @@ FMImporterTest >> testImportHeinekenMetamodel [
 	self assert: metamodel properties size equals: 12
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testImportHeinekenModel [
 	| model |
 	model := FMModel new.
@@ -57,7 +74,7 @@ FMImporterTest >> testImportHeinekenModel [
 	self assert: model elements size equals: 4
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testOrderOfElements [
 	| model metamodel containers |
 	model := FMModel new.
@@ -75,7 +92,7 @@ FMImporterTest >> testOrderOfElements [
 	self assert: (containers anyOne at: (metamodel elementNamed: 'EG.Container.children')) size equals: 4
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testResolving [
 	| importer builder |
 	importer := FMImporter model: FMMetaModel new.
@@ -85,7 +102,7 @@ FMImporterTest >> testResolving [
 	self assert: importer model elements anyOne isFM3Class
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testResolvingId [
 	| importer builder |
 	importer := FMImporter model: FMMetaModel new.
@@ -103,7 +120,7 @@ FMImporterTest >> testResolvingId [
 	self assert: importer model elements size equals: 2
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testResolvingMultiArgs [
 	| importer pack ref2 ref4 ref5 model |
 	importer := (FMImporter model: FMMetaModel new)
@@ -161,7 +178,7 @@ FMImporterTest >> testResolvingMultiArgs [
 	self assert: (pack classes includes: ref5)
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testSimpleExtensions [
 	| metamodel |
 	metamodel := FMMetaModel fromString: self class simpleCompositeMetamodel.
@@ -172,7 +189,7 @@ FMImporterTest >> testSimpleExtensions [
 	self assert: (metamodel elementNamed: 'EG.Leaf.name') package equals: (metamodel elementNamed: 'MORE')
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMImporterTest >> testSimpleMetamodel [
 	| metamodel |
 	metamodel := FMMetaModel fromString: self class simpleCompositeMetamodel.

--- a/src/Fame-Tests/FMMSEParserTest.class.st
+++ b/src/Fame-Tests/FMMSEParserTest.class.st
@@ -474,7 +474,7 @@ FMMSEParserTest >> setUp [
 	p importer: r
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttribute [
 	a := #(#(#beginAttribute: 'name') #(#endAttribute: 'name')).
 	r reset.
@@ -489,7 +489,7 @@ FMMSEParserTest >> testAttribute [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeNameWithUnderscore [
 	a := #(#(#beginAttribute: 'name_with_underscore') #(#endAttribute: 'name_with_underscore')).
 	r reset.
@@ -504,7 +504,7 @@ FMMSEParserTest >> testAttributeNameWithUnderscore [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeWithBoolean [
 	a := #(#(#beginAttribute: 'name') #(#primitive: true) #(#primitive: false) #(#endAttribute: 'name')).
 	r reset.
@@ -519,7 +519,7 @@ FMMSEParserTest >> testAttributeWithBoolean [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeWithElements [
 	a := #(#(#beginAttribute: 'name') #(#beginElement: 'Foo') #(#endElement: 'Foo') #(#beginElement: 'Bar') #(#endElement: 'Bar') #(#endAttribute: 'name')).
 	r reset.
@@ -534,7 +534,7 @@ FMMSEParserTest >> testAttributeWithElements [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeWithNumbers [
 	a := #(#(#beginAttribute: 'name') #(#primitive: 1) #(#primitive: 2) #(#primitive: 3) #(#endAttribute: 'name')).
 	r reset.
@@ -549,7 +549,7 @@ FMMSEParserTest >> testAttributeWithNumbers [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeWithReferences [
 	a := #(#(#beginAttribute: 'name') #(#referenceNumber: 2) #(#referenceNumber: 3) #(#endAttribute: 'name')).
 	r reset.
@@ -564,7 +564,7 @@ FMMSEParserTest >> testAttributeWithReferences [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeWithStrings [
 	a := #(#(#beginAttribute: 'name') #(#primitive: 'bar') #(#primitive: 'ba') #(#primitive: 'rossa') #(#endAttribute: 'name')).
 	r reset.
@@ -579,7 +579,7 @@ FMMSEParserTest >> testAttributeWithStrings [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testAttributeWithStrings2 [
 	a := #(#(#beginAttribute: 'name') #(#primitive: 'bar''ba''rossa') #(#endAttribute: 'name')).
 	r reset.
@@ -594,7 +594,7 @@ FMMSEParserTest >> testAttributeWithStrings2 [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testBacktrack [
 	| pos |
 	p fromString: 'abcdefg'.
@@ -612,7 +612,7 @@ FMMSEParserTest >> testBacktrack [
 	self assert: p next equals: $e
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testElement [
 	a := #(#(#beginElement: 'Foo') #(#endElement: 'Foo')).
 	r reset.
@@ -627,7 +627,7 @@ FMMSEParserTest >> testElement [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testElementWithAttributes [
 	a := #(#(#beginElement: 'Foo') #(#beginAttribute: 'name') #(#endAttribute: 'name') #(#beginAttribute: 'count') #(#endAttribute: 'count') #(#endElement: 'Foo')).
 	r reset.
@@ -642,7 +642,7 @@ FMMSEParserTest >> testElementWithAttributes [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testElementWithAttributesAndID [
 	a := #(#(#beginElement: 'Foo') #(#serial: 42) #(#beginAttribute: 'name') #(#endAttribute: 'name') #(#beginAttribute: 'count') #(#endAttribute: 'count') #(#endElement: 'Foo')).
 	r reset.
@@ -657,7 +657,7 @@ FMMSEParserTest >> testElementWithAttributesAndID [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testElementWithID [
 	a := #(#(#beginElement: 'Foo') #(#serial: 42) #(#endElement: 'Foo')).
 	r reset.
@@ -672,7 +672,7 @@ FMMSEParserTest >> testElementWithID [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testEmptyDocument [
 	p fromString: ''.
 	p Document.
@@ -680,14 +680,14 @@ FMMSEParserTest >> testEmptyDocument [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testEmptyExportString [
 	p fromString: ''.
 	p Document.
 	self assert: r exportString equals: '()'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFamixModel [
 	| metamodel names famixPackage accessClass accessorProperty behaviouralEntity outgoingAccesses |
 	metamodel := FMMetaModel fromString: self class famix30mse.
@@ -761,7 +761,7 @@ FMMSEParserTest >> testFamixModel [
 	self assert: accessorProperty opposite equals: outgoingAccesses
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFullDocument [
 	r reset.
 	p fromString: self class famix30mse.
@@ -772,7 +772,7 @@ FMMSEParserTest >> testFullDocument [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFullName [
 	p fromString: 'Foo'.
 	r := p tFULLNAME.
@@ -784,7 +784,7 @@ FMMSEParserTest >> testFullName [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFullName2 [
 	p fromString: 'Foo.Bar'.
 	r := p tFULLNAME.
@@ -796,7 +796,7 @@ FMMSEParserTest >> testFullName2 [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFullName3 [
 	p fromString: 'Foo.Bar.Qux'.
 	r := p tFULLNAME.
@@ -808,24 +808,24 @@ FMMSEParserTest >> testFullName3 [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFullNameDotDotFails [
 	p fromString: 'Foo..Bar'.
 	self should: [ p tFULLNAME ] raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testFullNameTrailingDotFails [
 	p fromString: 'Foo.'.
 	self should: [ p tFULLNAME ] raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testImporter [
 	self assert: p importer equals: r
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testMatchString [
 	p fromString: '''Lorem'''.
 	r := p String.
@@ -841,7 +841,7 @@ FMMSEParserTest >> testMatchString [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testNumber [
 	p fromString: '14'.
 	r := p Number.
@@ -861,7 +861,7 @@ FMMSEParserTest >> testNumber [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testNumber2 [
 	p fromString: '12.91'.
 	r := p Number.
@@ -881,7 +881,7 @@ FMMSEParserTest >> testNumber2 [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testNumber3 [
 	p fromString: '12.91e33'.
 	r := p Number.
@@ -905,19 +905,19 @@ FMMSEParserTest >> testNumber3 [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testNumberTrailingDotFails [
 	p fromString: '12.'.
 	self should: [ p Number ] raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testNumberTrailingLetterFails [
 	p fromString: '12.11e'.
 	self should: [ p Number ] raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testSerial [
 	p fromString: '(id:42)'.
 	p Serial.
@@ -931,7 +931,7 @@ FMMSEParserTest >> testSerial [
 	self setUp
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testSimpleDocument [
 	p fromString: '()'.
 	p Document.
@@ -944,7 +944,7 @@ FMMSEParserTest >> testSimpleDocument [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueFloat [
 	r reset.
 	p fromString: '3.14'.
@@ -953,21 +953,21 @@ FMMSEParserTest >> testValueFloat [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueFloatError [
 	r reset.
 	p fromString: '3.14e$'.
 	self should: [ p Value ] raise: FMSyntaxError
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueFloatError2 [
 	r reset.
 	p fromString: '1..2'.
 	self should: [ p Value ] raise: FMSyntaxError
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueFloatWithExponent [
 	r reset.
 	p fromString: '1.291e3'.
@@ -976,7 +976,7 @@ FMMSEParserTest >> testValueFloatWithExponent [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueNegativeNumber [
 	r reset.
 	p fromString: '-42'.
@@ -985,7 +985,7 @@ FMMSEParserTest >> testValueNegativeNumber [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueNegativeNumberError [
 	r reset.
 	p fromString: '--42'.
@@ -994,7 +994,7 @@ FMMSEParserTest >> testValueNegativeNumberError [
 	self assert: p position equals: 1
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueNumber [
 	r reset.
 	p fromString: '13'.
@@ -1003,7 +1003,7 @@ FMMSEParserTest >> testValueNumber [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueReference [
 	r reset.
 	p fromString: '(ref: 24)'.
@@ -1012,7 +1012,7 @@ FMMSEParserTest >> testValueReference [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueReferenceBigInteger [
 	r reset.
 	p fromString: '(ref: 112233445566778899)'.
@@ -1021,7 +1021,7 @@ FMMSEParserTest >> testValueReferenceBigInteger [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueReferenceFullName [
 	r reset.
 	p fromString: '(ref: EG.Foo)'.
@@ -1030,7 +1030,7 @@ FMMSEParserTest >> testValueReferenceFullName [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueReferenceName [
 	r reset.
 	p fromString: '(ref: Foo)'.
@@ -1039,7 +1039,7 @@ FMMSEParserTest >> testValueReferenceName [
 	self assert: p atEnd
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMSEParserTest >> testValueReferenceStringError [
 	r reset.
 	p fromString: '(ref: ''String'')'.

--- a/src/Fame-Tests/FMMetamodelBuilderTest.class.st
+++ b/src/Fame-Tests/FMMetamodelBuilderTest.class.st
@@ -14,7 +14,7 @@ FMMetamodelBuilderTest >> setUp [
 	metamodel document: FMDungeonExample dungeonScript
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testClasses [
 	self assert: metamodel classes size equals: 3.
 	self assert: (metamodel elementNamed: 'RPG.Dragon') notNil.
@@ -25,7 +25,7 @@ FMMetamodelBuilderTest >> testClasses [
 	self assert: (metamodel elementNamed: 'RPG.Hero') isFM3Class
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testDragonHoardsTreasures [
 	| a b |
 	a := metamodel elementNamed: 'RPG.Dragon.hoard'.
@@ -38,7 +38,7 @@ FMMetamodelBuilderTest >> testDragonHoardsTreasures [
 	self deny: b isMultivalued
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testDragonsKilledByHeros [
 	| a b |
 	a := metamodel elementNamed: 'RPG.Dragon.killedBy'.
@@ -51,7 +51,7 @@ FMMetamodelBuilderTest >> testDragonsKilledByHeros [
 	self assert: b isMultivalued
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testHeroHasTwinHero [
 	| a |
 	a := metamodel elementNamed: 'RPG.Hero.twin'.
@@ -60,7 +60,7 @@ FMMetamodelBuilderTest >> testHeroHasTwinHero [
 	self deny: a isMultivalued
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testHeroOwnsTalisman [
 	| a b |
 	a := metamodel elementNamed: 'RPG.Treasure.owner'.
@@ -73,14 +73,14 @@ FMMetamodelBuilderTest >> testHeroOwnsTalisman [
 	self deny: b isMultivalued
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testPackages [
 	self assert: metamodel packages size equals: 1.
 	self assert: metamodel packages anyOne name isSymbol.
 	self assert: metamodel packages anyOne name equals: #RPG
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMetamodelBuilderTest >> testProperties [
 	self assert: metamodel properties size equals: 7.
 	self assert: (metamodel elementNamed: 'RPG.Dragon.hoard') notNil.

--- a/src/Fame-Tests/FMModelBuilderTest.class.st
+++ b/src/Fame-Tests/FMModelBuilderTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Fame-Tests'
 }
 
-{ #category : #running }
+{ #category : #tests }
 FMModelBuilderTest >> testDocument [
 	| client m s |
 	client := FMMSEPrinter onString.
@@ -14,7 +14,7 @@ FMModelBuilderTest >> testDocument [
 	self assert: s equals: '()'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMModelBuilderTest >> testPerson [
 	| client m s |
 	client := FMMSEPrinter onString.
@@ -29,7 +29,7 @@ FMModelBuilderTest >> testPerson [
 		(name ''John Doe'')))'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMModelBuilderTest >> testPersonWithDog [
 	| client m s |
 	client := FMMSEPrinter onString.
@@ -57,7 +57,7 @@ FMModelBuilderTest >> testPersonWithDog [
 				(age 5)))))'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMModelBuilderTest >> testPersonWithDogUsingIdReferences [
 	| client m s |
 	client := FMMSEPrinter onString.
@@ -85,7 +85,7 @@ FMModelBuilderTest >> testPersonWithDogUsingIdReferences [
 		(age 5)))'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMModelBuilderTest >> testPersonWithNicknames [
 	| client m s |
 	client := FMMSEPrinter onString.

--- a/src/Fame-Tests/FMMultivalueLinkTest.class.st
+++ b/src/Fame-Tests/FMMultivalueLinkTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Fame-Tests'
 }
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testBookPerson [
 	| book person |
 	book := LIBBook new.
@@ -20,7 +20,7 @@ FMMultivalueLinkTest >> testBookPerson [
 	self assert: person books anyOne equals: book
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testClassPackage [
 	| package meta |
 	package := FM3Package new.
@@ -34,7 +34,7 @@ FMMultivalueLinkTest >> testClassPackage [
 	self assert: meta package equals: package
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testClassProperty [
 	| meta prop |
 	meta := FM3Class new.
@@ -48,12 +48,12 @@ FMMultivalueLinkTest >> testClassProperty [
 	self assert: prop mmClass equals: meta
 ]
 
-{ #category : #'running collection' }
+{ #category : #tests }
 FMMultivalueLinkTest >> testIntersection [
 	self shouldnt: [ FM3Class new properties intersection: #() ] raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testMenageATrois [
 	| me you her |
 	me := FM3Property new.
@@ -72,7 +72,7 @@ FMMultivalueLinkTest >> testMenageATrois [
 	self assert: her opposite equals: me
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testOpposite [
 	| opposite prop |
 	opposite := FM3Property new.
@@ -84,7 +84,7 @@ FMMultivalueLinkTest >> testOpposite [
 	self assert: prop opposite equals: opposite
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testPackageClass [
 	| package meta |
 	package := FM3Package new.
@@ -98,7 +98,7 @@ FMMultivalueLinkTest >> testPackageClass [
 	self assert: meta package equals: package
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testPackageProperty [
 	| package prop |
 	package := FM3Package new.
@@ -112,7 +112,7 @@ FMMultivalueLinkTest >> testPackageProperty [
 	self assert: prop package equals: package
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testPersonBook [
 	| book person |
 	book := LIBBook new.
@@ -128,7 +128,7 @@ FMMultivalueLinkTest >> testPersonBook [
 	self assert: person books anyOne equals: book
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testPropertyClass [
 	| meta prop |
 	meta := FM3Class new.
@@ -142,7 +142,7 @@ FMMultivalueLinkTest >> testPropertyClass [
 	self assert: prop mmClass equals: meta
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testPropertyPackage [
 	| package prop |
 	package := FM3Package new.
@@ -156,12 +156,12 @@ FMMultivalueLinkTest >> testPropertyPackage [
 	self assert: prop package equals: package
 ]
 
-{ #category : #'running collection' }
+{ #category : #tests }
 FMMultivalueLinkTest >> testUnion [
 	self shouldnt: [ FM3Class new properties union: #() ] raise: Error
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMMultivalueLinkTest >> testUnsetOpposite [
 	| opposite prop |
 	opposite := FM3Property new.

--- a/src/Fame-Tests/FMPragmaProcessorTest.class.st
+++ b/src/Fame-Tests/FMPragmaProcessorTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Fame-Tests'
 }
 
-{ #category : #running }
+{ #category : #tests }
 FMPragmaProcessorTest >> testAnnotationTypes [
 	| metaMetaModel package class property properties |
 	metaMetaModel := FMMetaMetaModel new.
@@ -49,7 +49,7 @@ FMPragmaProcessorTest >> testAnnotationTypes [
 	self assert: (properties noneSatisfy: #isContainer)
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMPragmaProcessorTest >> testBuildFM3 [
 	| processor all |
 	processor := FMMetaModelBuilder new.
@@ -60,14 +60,14 @@ FMPragmaProcessorTest >> testBuildFM3 [
 	self assert: all anyOne name equals: #FM3	"We do not test more here, please refer to FMMetaRepositoryTest for more FM3 tests..."
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMPragmaProcessorTest >> testEmptyProcessor [
 	"An empty processor knows all primitives, but does not contain them as elements!"
 
 	self assertEmpty: FMMetaModelBuilder new elements
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FMPragmaProcessorTest >> testSimple [
 	"--- FIXME: these 4 lines are moot ---"
 

--- a/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXModelQueriesTest.class.st
@@ -43,37 +43,37 @@ FAMIXModelQueriesTest >> setUp [
 	model add: stubNamespace
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllClasses [
 	self assert: model allClasses size equals: 4
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllModelClasses [
 	self assert: model allModelPureClasses size equals: 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllModelNamespaces [
 	self assert: model allModelNamespaces size equals: 2
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllModelTypes [
 	self assert: model allModelTypes size equals: 2
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllNamespaces [
 	self assert: model allNamespaces size equals: 3
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllTypes [
 	self assert: model allTypes size equals: 5
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 FAMIXModelQueriesTest >> testAllWithTypeOfGroupClass [
 	self assert: (model allWithType: FAMIXClass ofGroupClass: FAMIXTypeGroup) size equals: 4
 ]

--- a/src/Famix-Deprecated/MSEImporter.class.st
+++ b/src/Famix-Deprecated/MSEImporter.class.st
@@ -1,8 +1,15 @@
 Class {
 	#name : #MSEImporter,
 	#superclass : #FMImporter,
-	#category : #'Moose-Core'
+	#category : #'Famix-Deprecated'
 }
+
+{ #category : #testing }
+MSEImporter class >> isDeprecated [
+	"Use FMImporter instead with the option #autorizeDandlingReferencesAtEnd."
+
+	^ true
+]
 
 { #category : #parsing }
 MSEImporter >> endDocument [

--- a/src/Famix-Java-Tests/FamixJavaMethodTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaMethodTest.class.st
@@ -12,12 +12,12 @@ FamixJavaMethodTest >> setUp [
 	method := FamixJavaMethod new
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixJavaMethodTest >> testDefaultIsStub [
 	self deny: method isStub
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixJavaMethodTest >> testIsNotStubWhenParentIsNotStub [
 	| aClass |
 	aClass := FamixJavaClass new.
@@ -27,7 +27,7 @@ FamixJavaMethodTest >> testIsNotStubWhenParentIsNotStub [
 	self deny: method isStub
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixJavaMethodTest >> testIsStubWhenParentIsStub [
 	| aClass |
 	aClass := FamixJavaClass new.
@@ -37,7 +37,7 @@ FamixJavaMethodTest >> testIsStubWhenParentIsStub [
 	self assert: method isStub
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixJavaMethodTest >> testSettingIsStub [
 	method isStub: true.
 	self assert: method isStub

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorAliasTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorAliasTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Tests'
 }
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBehaviorAliasTest >> testAsIncompletePropertyWithoutRelation [
 
 	| named |
@@ -16,7 +16,7 @@ FmxMBBehaviorAliasTest >> testAsIncompletePropertyWithoutRelation [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBehaviorAliasTest >> testClassPropertyWithType [
 
 	"test if we can create typed property in a class alias"
@@ -38,7 +38,7 @@ FmxMBBehaviorAliasTest >> testClassPropertyWithType [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBehaviorAliasTest >> testTraitName [
 
 	"trivial test of alias #traitName"
@@ -51,7 +51,7 @@ FmxMBBehaviorAliasTest >> testTraitName [
 	self assert: alias traitName equals: #TNamed
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBehaviorAliasTest >> testTraitPropertyWithType [
 
 	| named generated method |
@@ -70,7 +70,7 @@ FmxMBBehaviorAliasTest >> testTraitPropertyWithType [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBehaviorAliasTest >> testUseTraitInsteadOfTraitName [
 
 	"test usage of a trait instead of a trait name in the alias creation"

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderRelationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderRelationTest.class.st
@@ -51,7 +51,7 @@ FmxMBBuilderRelationTest >> resetBuilder [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBuilderRelationTest >> testClassRelations [
 
 	self checkArrow: #- from: 'FMOne' to: 'FMOne' containerFrom: false containerTo: false forTraits: false.
@@ -74,7 +74,7 @@ FmxMBBuilderRelationTest >> testClassRelations [
 	
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBuilderRelationTest >> testOneToOneTraitsRelation [
 
 	| tClass tComment generatedTClass generatedTComment |
@@ -103,7 +103,7 @@ FmxMBBuilderRelationTest >> testOneToOneTraitsRelation [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBBuilderRelationTest >> testTraitRelations [
 
 	self checkArrow: #- from: 'FMOne' to: 'FMOne' containerFrom: false containerTo: false forTraits: true.

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -112,7 +112,7 @@ FmxMBGeneratorCleaningStrategyTest >> tearDown [
 	super tearDown.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningCleaning [
 	generator withoutCleaning cleaningStrategy cleanBeforeGeneration: generator.
 	self class environment
@@ -144,7 +144,7 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningCleaning [
 	self class environment at: #TFmxCleanerTestAddedTrait ifPresent: [ :class | self assert: class package name equals: self packageName ] ifAbsent: [ self fail ]
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningGeneration [
 	generator generateWithoutCleaning.
 
@@ -183,7 +183,7 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateNoCleaningGeneration [
 	self class environment at: #TFmxCleanerTestAddedTrait ifPresent: [ :class | self assert: class package name equals: self packageName ] ifAbsent: [ self fail ]
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningCleaning [
 	generator withCleaning cleaningStrategy cleanBeforeGeneration: generator.
 	self should: [ self class environment at: #FmxTestCleaningStrategyFmxTestEntity ] raise: KeyNotFound.
@@ -195,7 +195,7 @@ FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningCleaning [
 	self assert: (self class methodDict at: #extensionsMethodForTest ifPresent: [ false ] ifAbsent: [ true ])
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorCleaningStrategyTest >> testGenerateTotalCleaningGeneration [
 	generator generateWithCleaning.
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorRemoteAccessorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorRemoteAccessorTest.class.st
@@ -21,7 +21,7 @@ FmxMBGeneratorRemoteAccessorTest >> setUp [
 	entityB := FamixGenerateRemoteAccessorTestResource current entityB
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanRemoveManyRelationFromEntityA [
 	entityA manyB add: entityB.
 	entityA manyB removeAll.
@@ -33,7 +33,7 @@ FmxMBGeneratorRemoteAccessorTest >> testCanRemoveManyRelationFromEntityA [
 	self assert: entityB oneA equals: nil.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanRemoveMultiMultiRelationFromEntityA [
 	entityA manyManyB add: entityB.
 	entityA manyManyB removeAll.
@@ -45,7 +45,7 @@ FmxMBGeneratorRemoteAccessorTest >> testCanRemoveMultiMultiRelationFromEntityA [
 	self assert: entityB manyManyA isEmpty.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanRemoveMultiMultiRelationFromEntityB [
 	entityB manyManyA add: entityA.
 	entityB manyManyA removeAll.
@@ -57,7 +57,7 @@ FmxMBGeneratorRemoteAccessorTest >> testCanRemoveMultiMultiRelationFromEntityB [
 	self assert: entityB manyManyA isEmpty.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanRemoveOneRelationFromEntityB [
 	entityB oneA: entityA.
 	entityB oneA: nil.
@@ -65,7 +65,7 @@ FmxMBGeneratorRemoteAccessorTest >> testCanRemoveOneRelationFromEntityB [
 	self assert: entityB oneA equals: nil.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanRemoveRelationFromEntityA [
 	entityA relationToB: entityB.
 	entityA relationToB: nil.
@@ -73,7 +73,7 @@ FmxMBGeneratorRemoteAccessorTest >> testCanRemoveRelationFromEntityA [
 	self assert: entityB relationToA equals: nil.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanRemoveRelationFromEntityB [
 	entityB relationToA: entityA.
 	entityB relationToA: nil.
@@ -81,14 +81,14 @@ FmxMBGeneratorRemoteAccessorTest >> testCanRemoveRelationFromEntityB [
 	self assert: entityA relationToB equals: nil.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanSetRelationFromEntityA [
 	entityA relationToB: entityB.
 	self assert: entityA relationToB equals: entityB. 
 	self assert: entityB relationToA equals: entityA.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FmxMBGeneratorRemoteAccessorTest >> testCanSetRelationFromEntityB [
 	entityB relationToA: entityA.
 	self assert: entityB relationToA equals: entityA. 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
@@ -36,7 +36,7 @@ FmxMBImportingContextTest >> setUp [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBImportingContextTest >> testDefineImport [
 
 	| localMethod |
@@ -47,13 +47,13 @@ FmxMBImportingContextTest >> testDefineImport [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBImportingContextTest >> testGeneratedContextClass [
 	self assert: generatedContext notNil.
 	self assert: generatedContext superclass name equals: #FmxImportingContext
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBImportingContextTest >> testNotGenerated [
 
 	builder := FamixMetamodelBuilder forTesting.
@@ -71,7 +71,7 @@ FmxMBImportingContextTest >> testNotGenerated [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBImportingContextTest >> testNotGeneratedForEmptyBuilder [
 
 	builder := FamixMetamodelBuilder forTesting.
@@ -84,7 +84,7 @@ FmxMBImportingContextTest >> testNotGeneratedForEmptyBuilder [
 
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBImportingContextTest >> testRequirements [
 	| localMethod |
 	self assert: (generatedVariable classSide methodNamed: #requirements) isNil.
@@ -95,7 +95,7 @@ FmxMBImportingContextTest >> testRequirements [
 	self assert: (localMethod sourceCode includesSubstring: '^ { TstMethod. TstVariable }')
 ]
 
-{ #category : #initialization }
+{ #category : #tests }
 FmxMBImportingContextTest >> testShouldImport [
 
 	| localMethod |

--- a/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
@@ -71,7 +71,7 @@ FamixAbstractFileAnchorTest >> testLineCountWithCRLF [
 	self assert: anchor lineCount equals: 17
 ]
 
-{ #category : #accessing }
+{ #category : #tests }
 FamixAbstractFileAnchorTest >> testSourceText [
 	^ self subclassResponsibility
 ]

--- a/src/Famix-Test2-Tests/FamixTest2Test.class.st
+++ b/src/Famix-Test2-Tests/FamixTest2Test.class.st
@@ -47,7 +47,7 @@ FamixTest2Test >> setUp [
 	i5 superclass: c3; subclass: c5.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest2Test >> testInheritances [
 
 	self assertCollection: (c1 subInheritances collect: #subclass) hasSameElements: { c2. c3 }.

--- a/src/Famix-Test3-Tests/FamixTest3Test.class.st
+++ b/src/Famix-Test3-Tests/FamixTest3Test.class.st
@@ -98,35 +98,35 @@ FamixTest3Test >> setUp [
 	model addAll: {c1 . c2 . m1 . m2 . pt1 . pt2. ref1. ref2. inv1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAllClients [
 	self assertCollection: self pt1 allClients hasSameElements: {self m1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAllClientsAtScope [
 	self assertCollection: (self pt1 allClientsAtScope: FamixTClass) hasSameElements: {self c1}.
 	self assertCollection: (self pt1 allClientsAtScope: FamixTest3Class) hasSameElements: {self c1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAllProviders [
 	self assertCollection: self m1 allProviders hasSameElements: {self c1 . self pt1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAllProvidersAtScope [
 	self assertCollection: (self m1 allProvidersAtScope: FamixTClass) hasSameElements: {self c1 . self pt1}.
 	self assertCollection: (self m1 allProvidersAtScope: FamixTest3Class) hasSameElements: {self c1 . self pt1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAtScope [
 	self assertCollection: (self m1 atScope: FamixTClass) hasSameElements: {self c1}.
 	self assertCollection: (self m1 atScope: FamixTest3Class) hasSameElements: {self c1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAtScopeOnQueryResult [
 	| mooseQueryResult |
 	mooseQueryResult := MooseObjectQueryResult on: self c1 withAll: {self m1 . self m2 . self pt1 . self pt2}.
@@ -135,28 +135,28 @@ FamixTest3Test >> testAtScopeOnQueryResult [
 	self assertCollection: (mooseQueryResult atScope: FamixTest3Class) hasSameElements: {self c1 . self c2}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testAtScopeWithNonMatchingEntitiesDo [
 	self checkAtScopeWithNonMatchingEntitiesDoWith: FamixTClass.
 	self checkAtScopeWithNonMatchingEntitiesDoWith: FamixTest3Class
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testChildrenTypes [
 	self assertCollection: self c1 childrenTypes hasSameElements: {FamixTAttribute . FamixTMethod. FamixTest3Method}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testIncomingReferences [
 	self assertCollection: self pt1 incomingReferences hasSameElements: {self ref1}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testParentTypes [
 	self assertCollection: self m1 parentTypes hasSameElements: {FamixTWithMethods . FamixTest3Class}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTest3Test >> testQueryIncomingDependencies [
 	self assertCollection: self pt1 queryIncomingDependencies hasSameElements: {self ref1}
 ]

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
@@ -56,7 +56,7 @@ FamixTestComposedMetamodels >> setUp [
 	
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testGenerationOfComposedMetamodel [
 	| aGenerator env |
 	aGenerator := FamixTestComposedGenerator new beForTesting generate.
@@ -68,7 +68,7 @@ FamixTestComposedMetamodels >> testGenerationOfComposedMetamodel [
 				includesSubstring: '<FMProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>')
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testImplicitManyToManyRemote [
 
 	c4 customEntities4: {c14}.
@@ -76,7 +76,7 @@ FamixTestComposedMetamodels >> testImplicitManyToManyRemote [
 	self assertCollection: c14 customEntities4 hasSameElements: {c4}.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testImplicitManyToOneRemote [
 
 	c3 customEntity3: c13.
@@ -85,7 +85,7 @@ FamixTestComposedMetamodels >> testImplicitManyToOneRemote [
 	self assertCollection: c13 customEntities3 hasSameElements: {c3}.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testImplicitOneToManyRemote [
 
 	c2 customEntities2: {c12}.
@@ -94,7 +94,7 @@ FamixTestComposedMetamodels >> testImplicitOneToManyRemote [
 	self assert: c12 customEntity2 equals: c2.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testImplicitOneToOneRemote [
 
 	c1 customEntity1: c11.
@@ -103,7 +103,7 @@ FamixTestComposedMetamodels >> testImplicitOneToOneRemote [
 	self assert: c11 customEntity1 equals: c1.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testManyToManyRemote [
 
 	c4 c24s: {c24}.
@@ -112,7 +112,7 @@ FamixTestComposedMetamodels >> testManyToManyRemote [
 	self assertCollection: c24 c4s hasSameElements: {c4}.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testManyToOneRemote [
 
 	c3 c23: c23.
@@ -121,7 +121,7 @@ FamixTestComposedMetamodels >> testManyToOneRemote [
 	self assertCollection: c23 c3s hasSameElements: {c3}.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testOneToManyRemote [
 
 	c2 c22s: {c22}.
@@ -130,7 +130,7 @@ FamixTestComposedMetamodels >> testOneToManyRemote [
 	self assert: c22 c2 equals: c2.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testOneToOneRemote [
 
 	c1 c21: c21.
@@ -139,7 +139,7 @@ FamixTestComposedMetamodels >> testOneToOneRemote [
 	self assert: c21 c1 equals: c1.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testRemoteManyToManyRemote [
 
 	c14 c24s: {c24}.
@@ -148,7 +148,7 @@ FamixTestComposedMetamodels >> testRemoteManyToManyRemote [
 	self assertCollection: c24 c14s hasSameElements: {c14}.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testRemoteManyToOneRemote [
 
 	c13 c23: c23.
@@ -157,7 +157,7 @@ FamixTestComposedMetamodels >> testRemoteManyToOneRemote [
 	self assertCollection: c23 c13s hasSameElements: {c13}.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testRemoteOneToManyRemote [
 
 	c12 c22s: {c22}.
@@ -166,7 +166,7 @@ FamixTestComposedMetamodels >> testRemoteOneToManyRemote [
 	self assert: c22 c12 equals: c12.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodels >> testRemoteOneToOneRemote [
 
 	c11 c21: c21.

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsBuilding.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsBuilding.class.st
@@ -50,7 +50,7 @@ FamixTestComposedMetamodelsBuilding >> setUp [
 	methodNode isRemote: true
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneNonRemote [
 
 	| source generatedMethod |
@@ -76,7 +76,7 @@ FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneNonRemote [
 	self assert: generatedMethod package name equals: #TstComposed.
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodelsBuilding >> testOneRemoteToOneRemote [
 
 	| source generatedMethod |

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsWithMooseQuery.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodelsWithMooseQuery.class.st
@@ -27,21 +27,21 @@ FamixTestComposedMetamodelsWithMooseQuery >> setUp [
 	model addAll: {association . c15 . c25}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodelsWithMooseQuery >> testAllIncomingAssociationTypes [
 	self assertCollection: c15 allIncomingAssociationTypes hasSameElements: {FamixTestComposedAssociation}.
 
 	self assertEmpty: c25 allIncomingAssociationTypes
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodelsWithMooseQuery >> testAllOutgoingAssociationTypes [
 	self assertEmpty: c15 allOutgoingAssociationTypes.
 
 	self assertCollection: c25 allOutgoingAssociationTypes hasSameElements: {FamixTestComposedAssociation}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodelsWithMooseQuery >> testQueries [
 	self assertCollection: (c15 queryAll: #in) hasSameElements: {association}.
 	self assertEmpty: (c25 queryAll: #in).
@@ -53,7 +53,7 @@ FamixTestComposedMetamodelsWithMooseQuery >> testQueries [
 	self assertCollection: (c25 queryAll: #out) opposites hasSameElements: {c15}
 ]
 
-{ #category : #running }
+{ #category : #tests }
 FamixTestComposedMetamodelsWithMooseQuery >> testSimpleAssociation [
 	self assert: association c15 equals: c15.
 	self assert: association c25 equals: c25

--- a/src/Merlin/ButtonPartTest.class.st
+++ b/src/Merlin/ButtonPartTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Merlin-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ButtonPartTest >> testEnableAndDisable [
 
 	| buttonPart |
@@ -15,7 +15,7 @@ ButtonPartTest >> testEnableAndDisable [
 	self deny: buttonPart buttonEnabled.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ButtonPartTest >> testLabel [
 
 	| buttonPart |

--- a/src/Merlin/CheckboxPartTest.class.st
+++ b/src/Merlin/CheckboxPartTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Merlin-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 CheckboxPartTest >> testSelectedAndNotSelected [
 
 	| checkboxPart |

--- a/src/Merlin/DropListPartTest.class.st
+++ b/src/Merlin/DropListPartTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Merlin-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 DropListPartTest >> testSelectedIndex [
 
 	|dropListPart|

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -110,8 +110,8 @@ MooseModel class >> importFrom: aStream filteredBy: anImportingContext [
 MooseModel class >> importFrom: aStream withMetamodel: aMetamodel [
 	| model importer areWarningsEnabled |
 	model := FMModel withMetamodel: aMetamodel.
-	importer := MSEImporter new.
-	importer model: model.
+	importer := FMImporter model: model.
+	importer autorizeDandlingReferencesAtEnd.
 	importer stream: aStream.
 
 	"We are currently updating the meta models and most parsers are not up to date.
@@ -136,7 +136,8 @@ MooseModel class >> importFrom: aStream withMetamodel: aMetamodel filteredBy: an
 	"famixElementNames := anImportingContext fullNamesOfEntitiesToBeExtracted ."
 
 	model := FMModel withMetamodel: aMetamodel.
-	importer := MSEImporter model: model.
+	importer := FMImporter model: model.
+	importer autorizeDandlingReferencesAtEnd.
 	importer stream: aStream.
 	importerFilter := FMImporterFilter on: importer filtering: famixElementNames.
 	importerFilter run.
@@ -147,9 +148,9 @@ MooseModel class >> importFrom: aStream withMetamodel: aMetamodel filteredBy: an
 { #category : #'import-export' }
 MooseModel class >> importFrom: aStream withMetamodel: aMetamodel translationDictionary: translationDict [
 	| model importer |
-	model := FMModel withMetamodel: aMetamodel.
-	importer := MSEImporter new.
-	importer repository: model.
+	model := FMModel withMetamodel: aMetamodel.	
+	importer := FMImporter model: model.
+	importer autorizeDandlingReferencesAtEnd.
 	importer stream: aStream.
 	importer nameTranslator: translationDict.
 	importer run.

--- a/src/Moose-Tests-RoassalPaintings/MooseFameViewTest.class.st
+++ b/src/Moose-Tests-RoassalPaintings/MooseFameViewTest.class.st
@@ -4,13 +4,13 @@ Class {
 	#category : #'Moose-Tests-RoassalPaintings-FameView'
 }
 
-{ #category : #ui }
+{ #category : #tests }
 MooseFameViewTest >> testOpenOn [
 
 	self shouldnt: [ MooseFameView new open delete ] raise: Error
 ]
 
-{ #category : #ui }
+{ #category : #tests }
 MooseFameViewTest >> testViewFamixCore [
 
 	self shouldnt: [ MooseFameView new viewFamixCore delete ] raise: Error

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
@@ -25,7 +25,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> model [
 
 ]
 
-{ #category : #passed }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAllClassInNamespaceAreCreated [
 	"self debug: #testAllClassInNamespaceAreCreated"
 	
@@ -34,7 +34,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAllClassInNamespa
 	]
 ]
 
-{ #category : #passed }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAttributInRoot [
 	"self debug: #testAttributInRoot"
 	| theRoot |
@@ -44,7 +44,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAttributInRoot [
 	self assert: (theRoot attributes inject: false into: [:bool : method | bool or: [method name = #'CIV#mz']])
 ]
 
-{ #category : #passed }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassAttributeHasInstanceScope [
 	"self debug:#testClassAttributeHasInstanceScope"
 
@@ -55,7 +55,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassAttributeHas
 	self assert: attribute belongsTo equals: theRoot
 ]
 
-{ #category : #'new to put in VW' }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassMetaclassInstanceVariableAndShared [
 	"self debug: #testClassMetaclassInstanceVariableAndShared"
 
@@ -75,7 +75,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassMetaclassIns
 	self deny: insMetaclassVar isSharedVariable
 ]
 
-{ #category : #'new to put in VW' }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testConflictingInstanceVarNames [
 	"self debug: #testConflictingInstanceVarNames"
 
@@ -103,7 +103,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testInstanceAndClassS
 	self assert: node classSide identicalTo: nil
 ]
 
-{ #category : #'new to put in VW' }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassAttributeHasClassScope [
 	"self debug: #testMetaclassAttributeHasClassScope"
 
@@ -114,7 +114,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassAttribut
 	self assert: attribute belongsTo equals: theRoot
 ]
 
-{ #category : #passed }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassMethodHasClassScope [
 	"self debug: #testMetaclassMethodHasClassScope"
 
@@ -128,7 +128,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassMethodHa
 	self assert: classMethod belongsTo equals: theRoot
 ]
 
-{ #category : #passed }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMethodInRoot [
 	"self debug: #testMethodInRoot"
 	
@@ -161,7 +161,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testReferencesInRoot 
 		equals: 2
 ]
 
-{ #category : #'new to put in VW' }
+{ #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testSharedVariableReification [
 	"self debug: #testSharedVariableReification"
 

--- a/src/Moose-Tests-SmalltalkImporter-Core/MooseSmalltalkImporterSubclassesTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MooseSmalltalkImporterSubclassesTest.class.st
@@ -43,7 +43,7 @@ MooseSmalltalkImporterSubclassesTest >> setUp [
 										mergeClassAndMetaclass ; yourself).
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 MooseSmalltalkImporterSubclassesTest >> testDoNotImportSubClasses [
 	self pharoImporterTask
 		importingContext:
@@ -57,7 +57,7 @@ MooseSmalltalkImporterSubclassesTest >> testDoNotImportSubClasses [
 	self deny: ((model allClasses collect: #name) includes: 'SubRootModelTwo')
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 MooseSmalltalkImporterSubclassesTest >> testImportSubClasses [
 self pharoImporterTask
 		importingContext:

--- a/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
@@ -178,7 +178,7 @@ LANImporterTest >> testEntityUniquelyNamed [
 			(classes entityNamed: LANNode class mooseName) isNil not
 ]
 
-{ #category : #errors }
+{ #category : #tests }
 LANImporterTest >> testHierarchyRoot [ 
 	self assert: (self model entityNamed: LANNode mooseName) isHierarchyRoot. 
 	self deny: ((self model entityNamed: LANNode mooseName) 
@@ -286,14 +286,14 @@ LANImporterTest >> testIsClassAbstract [
 	
 ]
 
-{ #category : #errors }
+{ #category : #tests }
 LANImporterTest >> testLonely [
 	| lonely |
 	lonely := self model allModelClasses select: [ :each | each isLonelyWithin: self model allModelClasses ].
 	self assert: lonely size equals: 8
 ]
 
-{ #category : #errors }
+{ #category : #tests }
 LANImporterTest >> testMethodOverriding [ 
 	 
 	self assert: (self model entityNamed: (LANOutputServer>>#canOutput) mooseName) isOverriding. 
@@ -421,7 +421,7 @@ LANImporterTest >> testStubClassesCreation [
 	self assert: (self model allClasses select: [ :each | each isStub not ]) size equals: 22
 ]
 
-{ #category : #errors }
+{ #category : #tests }
 LANImporterTest >> testSubClassHierarchy [
 	self assert: (self model entityNamed: LANNode mooseName) subclassHierarchy size equals: 4.
 	self assert: (self model entityNamed: LANNode mooseName) withSubclassHierarchy size equals: 5


### PR DESCRIPTION
Improve FMImporter making MSEImporter obsolete. (Importer should be independant of the format in Fame. It makes no sense to have a MSEImporter)