### PR TITLE
Compute-requirements-dynamically

### DIFF
--- a/src/Fame-Core/FMMetaModel.class.st
+++ b/src/Fame-Core/FMMetaModel.class.st
@@ -31,15 +31,20 @@ Class {
 }
 
 { #category : #accessing }
+FMMetaModel >> allImplementingClasses [
+	^ self classes collect: #implementingClass
+]
+
+{ #category : #accessing }
 FMMetaModel >> classes [
 	^ self elements select: [ :each | each isFM3Class ]
 ]
 
 { #category : #accessing }
-FMMetaModel >> concreteClasses [
-	"Return all the FM3 classes whose implementing class is a class and not a trait."
+FMMetaModel >> concreteImplementingClasses [
+	"Return all the real classes that are a class and not a trait."
 
-	^ self classes reject: [ :fm3Class | fm3Class implementingClass isTrait ]
+	^ self allImplementingClasses reject: #isTrait
 ]
 
 { #category : #initialization }

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
@@ -15,13 +15,6 @@ FAMIXAnnotationInstance class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAnnotationInstance class >> requirements [
-
-	<generated>
-	^ { FAMIXNamedEntity }
-]
-
 { #category : #accessing }
 FAMIXAnnotationInstance >> mooseNameOn: aStream [
 	self annotationType notNil ifTrue: [

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
@@ -15,13 +15,6 @@ FAMIXAnnotationInstanceAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAnnotationInstanceAttribute class >> requirements [
-
-	<generated>
-	^ { FAMIXAnnotationInstance }
-]
-
 { #category : #'as yet unclassified' }
 FAMIXAnnotationInstanceAttribute >> name [ 
 	^ self annotationTypeAttribute notNil 

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationType.class.st
@@ -15,13 +15,6 @@ FAMIXAnnotationType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAnnotationType class >> requirements [
-
-	<generated>
-	^ { FAMIXContainerEntity }
-]
-
 { #category : #'accessing-query' }
 FAMIXAnnotationType >> annotatedEntities [
 	^ self instances collect: [:each | each annotatedEntity ]

--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -18,13 +18,6 @@ FAMIXAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXAttribute class >> requirements [
-
-	<generated>
-	^ { FAMIXType }
-]
-
 { #category : #'Famix-Smalltalk' }
 FAMIXAttribute >> beInstanceVariable [
 

--- a/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXEnumValue.class.st
@@ -14,10 +14,3 @@ FAMIXEnumValue class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FAMIXEnumValue class >> requirements [
-
-	<generated>
-	^ { FAMIXEnum }
-]

--- a/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
@@ -15,13 +15,6 @@ FAMIXFunction class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXFunction class >> requirements [
-
-	<generated>
-	^ { FAMIXContainerEntity }
-]
-
 { #category : #accessing }
 FAMIXFunction >> container [
 	^ self functionOwner

--- a/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXGlobalVariable.class.st
@@ -15,13 +15,6 @@ FAMIXGlobalVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXGlobalVariable class >> requirements [
-
-	<generated>
-	^ { FAMIXScopingEntity }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXGlobalVariable >> isPrivate [
 	^ self isPublic not

--- a/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXImplicitVariable.class.st
@@ -15,13 +15,6 @@ FAMIXImplicitVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXImplicitVariable class >> requirements [
-
-	<generated>
-	^ { FAMIXBehaviouralEntity }
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXImplicitVariable >> isSelf [
 	^ self name = #self

--- a/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXLocalVariable.class.st
@@ -15,13 +15,6 @@ FAMIXLocalVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXLocalVariable class >> requirements [
-
-	<generated>
-	^ { FAMIXBehaviouralEntity }
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXLocalVariable >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -18,13 +18,6 @@ FAMIXMethod class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXMethod class >> requirements [
-
-	<generated>
-	^ { FAMIXType }
-]
-
 { #category : #accessing }
 FAMIXMethod class >> shouldSearchForSmalltalkCodeInImage [
 	^ ShouldSearchForSmalltalkCodeInImage ifNil: [ ShouldSearchForSmalltalkCodeInImage := true ]

--- a/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamedEntity.class.st
@@ -20,13 +20,6 @@ FAMIXNamedEntity class >> belongsToMethod [
 	^ self compiledMethodAt: #belongsTo ifAbsent: nil
 ]
 
-{ #category : #meta }
-FAMIXNamedEntity class >> requirements [
-
-	<generated>
-	^ { FAMIXPackage }
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXNamedEntity >> stubFormattedName [
 	 ^ self isStub 

--- a/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameter.class.st
@@ -15,13 +15,6 @@ FAMIXParameter class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXParameter class >> requirements [
-
-	<generated>
-	^ { FAMIXBehaviouralEntity }
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXParameter >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -15,13 +15,6 @@ FAMIXScopingEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXScopingEntity class >> requirements [
-
-	<generated>
-	^ { FAMIXScopingEntity }
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FAMIXScopingEntity >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -15,13 +15,6 @@ FAMIXType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FAMIXType class >> requirements [
-
-	<generated>
-	^ { FAMIXContainerEntity }
-]
-
 { #category : #'Famix-Extensions-navigation' }
 FAMIXType >> accessTo: aFAMIXPackageOrFAMIXClass [ 
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -15,13 +15,6 @@ FamixJavaAnnotationInstance class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAnnotationInstance class >> requirements [
-
-	<generated>
-	^ { FamixJavaNamedEntity }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationInstance >> mooseNameOn: aStream [
 	self annotationType notNil ifTrue: [

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -15,13 +15,6 @@ FamixJavaAnnotationInstanceAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAnnotationInstanceAttribute class >> requirements [
-
-	<generated>
-	^ { FamixJavaAnnotationInstance }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationInstanceAttribute >> name [ 
 	^ self annotationTypeAttribute notNil 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -15,13 +15,6 @@ FamixJavaAnnotationType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaAnnotationType class >> requirements [
-
-	<generated>
-	^ { FamixJavaContainerEntity }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationType >> annotatedEntities [
 	^ self instances collect: [:each | each annotatedEntity ]

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -14,10 +14,3 @@ FamixJavaEnumValue class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixJavaEnumValue class >> requirements [
-
-	<generated>
-	^ { FamixJavaEnum }
-]

--- a/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaGlobalVariable.class.st
@@ -15,13 +15,6 @@ FamixJavaGlobalVariable class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaGlobalVariable class >> requirements [
-
-	<generated>
-	^ { FamixJavaScopingEntity }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaGlobalVariable >> isPrivate [
 	^ self isPublic not

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -15,13 +15,6 @@ FamixJavaMethod class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaMethod class >> requirements [
-
-	<generated>
-	^ { FamixJavaType }
-]
-
 { #category : #'Famix-Extensions-metrics-support' }
 FamixJavaMethod >> accessedAttributes [
 	

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -15,13 +15,6 @@ FamixJavaNamedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaNamedEntity class >> requirements [
-
-	<generated>
-	^ { FamixJavaPackage }
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaNamedEntity >> stubFormattedName [
 	 ^ self isStub 

--- a/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaScopingEntity.class.st
@@ -15,13 +15,6 @@ FamixJavaScopingEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaScopingEntity class >> requirements [
-
-	<generated>
-	^ { FamixJavaScopingEntity }
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixJavaScopingEntity >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -15,13 +15,6 @@ FamixJavaType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixJavaType class >> requirements [
-
-	<generated>
-	^ { FamixJavaContainerEntity }
-]
-
 { #category : #'Famix-Java' }
 FamixJavaType >> allAnnotationInstances [
 	| result |

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -143,18 +143,6 @@ FamixMetamodelBuilder >> configuration: anObject [
 ]
 
 { #category : #accessing }
-FamixMetamodelBuilder >> containerRequirementsOf: aClass [
-
-	|  usedBehaviors |
-	
-	usedBehaviors := aClass containerProperties collect: [ :e | e otherSide relatedEntity].
-	^ usedBehaviors flatCollect: [:aBehavior |
-		aBehavior isMetamodelTrait
-			ifTrue: [ self classes select: [ :e | e hasTraitGeneralization: aBehavior ]]
-			ifFalse: [ {aBehavior} ]]
-]
-
-{ #category : #accessing }
 FamixMetamodelBuilder >> doNotGenerateCurrent [
 
 	self classes do: [ :each | each willGenerate: false ].
@@ -455,7 +443,6 @@ FamixMetamodelBuilder >> parentBuilderPackageName [
 
 { #category : #generating }
 FamixMetamodelBuilder >> prepareGeneration [
-	self resolveRequirementsFromContainers.
 	self registerPackages.
 
 	self traitsWithSubBuildersTraits do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
@@ -500,16 +487,6 @@ FamixMetamodelBuilder >> relations [
 FamixMetamodelBuilder >> relations: anObject [
 	<ignoreForCoverage>
 	relations := anObject
-]
-
-{ #category : #generating }
-FamixMetamodelBuilder >> resolveRequirementsFromContainers [
-
-	self classes do: [ :each |
-		| req |
-		req := self containerRequirementsOf: each.
-		each requires: (self containerRequirementsOf: each) ].
-
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : #FmxMBClass,
 	#superclass : #FmxMBBehavior,
 	#instVars : [
-		'classGeneralization',
-		'requirements'
+		'classGeneralization'
 	],
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
@@ -31,12 +30,6 @@ FmxMBClass >> allClassGeneralizations [
 { #category : #accessing }
 FmxMBClass >> allLocalTraits [
 	^ self traitsFromRelations , super allLocalTraits
-]
-
-{ #category : #accessing }
-FmxMBClass >> allRequirementNames [ 
-
-	^ (self requirements asSet collect: #fullName) sorted
 ]
 
 { #category : #accessing }
@@ -166,9 +159,7 @@ FmxMBClass >> generate [
 	self generateAnnotationIn: aClass as: self name superclass: nil.
 	
 	self generateTestingMethodsIn: aClass.
-	self generateRootMetamodelMethodIn: aClass. 	
-
-	self generateRequirementsFor: aClass.
+	self generateRootMetamodelMethodIn: aClass.
 
 	self generateMethodsMadeByTraitsFor: aClass.
 	self generateMethodsToRemoveFromTraitCompositionFor: aClass.
@@ -195,19 +186,6 @@ FmxMBClass >> generateRemotes [
 	self realClass: aClass.
 
 	self generateRemoteAccessors
-]
-
-{ #category : #generating }
-FmxMBClass >> generateRequirementsFor: aClass [
-	self allRequirementNames
-		ifNotEmpty: [ :requirementNames | 
-			aClass classSide
-				compile:
-					('requirements
-
-	<generated>
-	^ \{ {1} \}' format: {(requirementNames joinUsing: '. ')})
-				classified: #meta ]
 ]
 
 { #category : #generating }
@@ -247,12 +225,6 @@ FmxMBClass >> hasTraitGeneralization: aTrait [
 	^ self traitGeneralizations includes: aTrait 
 ]
 
-{ #category : #initialization }
-FmxMBClass >> initialize [
-	super initialize.
-	requirements := Set new
-]
-
 { #category : #testing }
 FmxMBClass >> isContainerOfClassThatUses: aTrait [
 
@@ -280,18 +252,6 @@ FmxMBClass >> isRoot [
 FmxMBClass >> relatedOwnerTraitName [
 
 	^ 'TWith', self pluralPropertyName capitalized
-]
-
-{ #category : #accessing }
-FmxMBClass >> requirements [
-
-	^ requirements 
-]
-
-{ #category : #accessing }
-FmxMBClass >> requires: collectionOfClasses [
-
-	requirements addAll: collectionOfClasses
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
@@ -122,37 +122,6 @@ FmxMBBuilderTest >> testClassesThatUse [
 ]
 
 { #category : #tests }
-FmxMBBuilderTest >> testContainerRequirementsOf [
-
-	| class method function |
-	
-	class := 	builder newClassNamed: #Class.
-	method := builder newClassNamed: #Method.
-	function := builder newClassNamed: #Function.
-	
-	class <>-* method.
-	
-	self assert: (builder containerRequirementsOf: class) isEmpty.	
-	self assert: (builder containerRequirementsOf: function) isEmpty.
-	self assert: (builder containerRequirementsOf: method) asArray equals: { class }.	
-]
-
-{ #category : #tests }
-FmxMBBuilderTest >> testContainerRequirementsOfTrait [
-
-	| class tClass method |
-	
-	class := 	builder newClassNamed: #Class.
-	tClass := builder newTraitNamed: #TClass.
-	method := builder newClassNamed: #Method.
-	
-	class --|> tClass.
-	tClass <>-* method.
-
-	self assert: (builder containerRequirementsOf: method) asArray equals: { class }.	
-]
-
-{ #category : #tests }
 FmxMBBuilderTest >> testDoNotGenerateCurrent [
 	
 	builder newClassNamed: #Behavior.	
@@ -286,24 +255,6 @@ FmxMBBuilderTest >> testParentBuilder [
 	childBuilder parentBuilder: parentBuilder.
 	self assert: childBuilder parentBuilderPackageName equals: 'ParentBuilderPackage'
 
-]
-
-{ #category : #tests }
-FmxMBBuilderTest >> testResolveRequirementsFromContainers [
-
-	| class method function |
-	
-	class := 	builder newClassNamed: #Class.
-	method := builder newClassNamed: #Method.
-	function := builder newClassNamed: #Function.
-	
-	class <>-* method.
-	
-	builder resolveRequirementsFromContainers.
-	
-	self assert: (class requirements) isEmpty.	
-	self assert: (function requirements) isEmpty.
-	self assert: (method requirements) asArray equals: { class }.	
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
@@ -22,9 +22,7 @@ FmxMBImportingContextTest >> setUp [
 
 	access := builder newClassNamed: #Access.	
 	variable := builder newClassNamed: #Variable.	
-	method := builder newClassNamed: #Method.	
-		
-	access requires: { method. variable }.
+	method := builder newClassNamed: #Method.
 
 	builder generate.
 		
@@ -60,9 +58,7 @@ FmxMBImportingContextTest >> testNotGenerated [
 
 	access := builder newClassNamed: #Access.	
 	variable := builder newClassNamed: #Variable.	
-	method := builder newClassNamed: #Method.	
-		
-	access requires: { method. variable }.
+	method := builder newClassNamed: #Method.
 
 	builder generate.
 		
@@ -82,17 +78,6 @@ FmxMBImportingContextTest >> testNotGeneratedForEmptyBuilder [
 	generatedContext := builder testingEnvironment ask classNamed: #TstImportingContext.
 	self assert: generatedContext isNil.
 
-]
-
-{ #category : #tests }
-FmxMBImportingContextTest >> testRequirements [
-	| localMethod |
-	self assert: (generatedVariable classSide methodNamed: #requirements) isNil.
-	self assert: (generatedMethod classSide methodNamed: #requirements) isNil.
-
-	localMethod := generatedAccess classSide methodNamed: #requirements.
-	self assert: (localMethod sourceCode includesSubstring: '<generated>').
-	self assert: (localMethod sourceCode includesSubstring: '^ { TstMethod. TstVariable }')
 ]
 
 { #category : #tests }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -15,13 +15,6 @@ FamixStAnnotationInstance class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAnnotationInstance class >> requirements [
-
-	<generated>
-	^ { FamixStNamedEntity }
-]
-
 { #category : #accessing }
 FamixStAnnotationInstance >> name [
 	^ String

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -15,13 +15,6 @@ FamixStAnnotationInstanceAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAnnotationInstanceAttribute class >> requirements [
-
-	<generated>
-	^ { FamixStAnnotationInstance }
-]
-
 { #category : #accessing }
 FamixStAnnotationInstanceAttribute >> name [ 
 	^ self annotationTypeAttribute notNil 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -15,13 +15,6 @@ FamixStAnnotationType class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAnnotationType class >> requirements [
-
-	<generated>
-	^ { FamixStContainerEntity }
-]
-
 { #category : #compatibility }
 FamixStAnnotationType >> directSubclasses [
 	^ OrderedCollection new

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -18,13 +18,6 @@ FamixStAttribute class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStAttribute class >> requirements [
-
-	<generated>
-	^ { FamixStAnnotationType }
-]
-
 { #category : #'Famix-Implementation' }
 FamixStAttribute >> beSharedVariable [
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -14,10 +14,3 @@ FamixStGlobalVariable class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixStGlobalVariable class >> requirements [
-
-	<generated>
-	^ { FamixStScopingEntity }
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -15,13 +15,6 @@ FamixStNamedEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStNamedEntity class >> requirements [
-
-	<generated>
-	^ { FamixStPackage }
-]
-
 { #category : #'Famix-Extensions' }
 FamixStNamedEntity >> stubFormattedName [
 	 ^ self isStub 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStScopingEntity.class.st
@@ -15,13 +15,6 @@ FamixStScopingEntity class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixStScopingEntity class >> requirements [
-
-	<generated>
-	^ { FamixStScopingEntity }
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixStScopingEntity >> abstractness [
 	"Abstractness is the ratio between the number of abstract classes and the total number of classes in a package, in the range [0, 1]. 0 means the package is fully concrete, 1 it is fully abstract."

--- a/src/Famix-Test3-Entities/FamixTest3Type.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Type.class.st
@@ -14,10 +14,3 @@ FamixTest3Type class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #meta }
-FamixTest3Type class >> requirements [
-
-	<generated>
-	^ { FamixTest3PrimitiveType }
-]

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -16,13 +16,6 @@ FamixTest4Book class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4Book class >> requirements [
-
-	<generated>
-	^ { FamixTest4Person }
-]
-
 { #category : #accessing }
 FamixTest4Book >> person [
 	"Relation named: #person type: #FamixTest4Person opposite: #books"

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -16,13 +16,6 @@ FamixTest4Principal class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4Principal class >> requirements [
-
-	<generated>
-	^ { FamixTest4School }
-]
-
 { #category : #accessing }
 FamixTest4Principal >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #principal"

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -16,13 +16,6 @@ FamixTest4Room class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4Room class >> requirements [
-
-	<generated>
-	^ { FamixTest4School }
-]
-
 { #category : #accessing }
 FamixTest4Room >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #rooms"

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -17,13 +17,6 @@ FamixTest4Student class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4Student class >> requirements [
-
-	<generated>
-	^ { FamixTest4School }
-]
-
 { #category : #adding }
 FamixTest4Student >> addTeacher: anObject [
 	<generated>

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -17,13 +17,6 @@ FamixTest4Teacher class >> annotation [
 	^self
 ]
 
-{ #category : #meta }
-FamixTest4Teacher class >> requirements [
-
-	<generated>
-	^ { FamixTest4School }
-]
-
 { #category : #adding }
 FamixTest4Teacher >> addStudent: anObject [
 	<generated>

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -184,9 +184,15 @@ MooseEntity class >> mooseDev [
 
 { #category : #accessing }
 MooseEntity class >> requirements [
-	"Used by Famix generator."
+	| metamodelClasses usedBehaviors |
+	metamodelClasses := self metamodel concreteImplementingClasses.
 
-	^ {}
+	usedBehaviors := (self allDeclaredPropertiesIn: self metamodel) select: #isContainer thenCollect: [ :p | p opposite implementingClass ].
+
+	^ (usedBehaviors flatCollect: [ :aBehavior |
+			aBehavior isTrait
+				ifTrue: [ metamodelClasses select: [ :each | each isComposedBy: aBehavior ] ]
+				ifFalse: [ {aBehavior} ] ]) asSet
 ]
 
 { #category : #private }

--- a/src/Moose-Finder/FMMetaModel.extension.st
+++ b/src/Moose-Finder/FMMetaModel.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #FMMetaModel }
-
-{ #category : #'*Moose-Finder' }
-FMMetaModel >> allImplementingClasses [
-	^ self classes collect: #implementingClass
-]

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -151,9 +151,7 @@ TEntityMetaLevelDependency classSide >> privateChildrenTypesIn: aMetamodel [
 	| childrenImplementingClasses childrenUsers |
 	childrenImplementingClasses := ((self allDeclaredPropertiesIn: aMetamodel) select: #isChildrenProperty) collect: #implementingType.
 
-	childrenUsers := aMetamodel concreteClasses
-		select: [ :e | e implementingClass allGeneratedTraits includesAny: childrenImplementingClasses ]
-		thenCollect: #implementingClass.
+	childrenUsers := aMetamodel concreteImplementingClasses select: [ :e | e allGeneratedTraits includesAny: childrenImplementingClasses ].
 
 	^ (childrenImplementingClasses , childrenUsers) asSet asArray	"<== This could later be #removeDuplicates but it is currently broken on arrays. See https://github.com/pharo-project/pharo/issues/4850"
 ]
@@ -188,11 +186,9 @@ TEntityMetaLevelDependency classSide >> privateParentTypesIn: aMetamodel [
 	| containerImplementingClasses containerUsers |
 	containerImplementingClasses := (self allDeclaredPropertiesIn: aMetamodel) select: #isContainer thenCollect: #implementingType.
 
-	containerUsers := aMetamodel concreteClasses
-		select: [ :e | e implementingClass allGeneratedTraits includesAny: containerImplementingClasses ]
-		thenCollect: #implementingClass.
+	containerUsers := aMetamodel concreteImplementingClasses select: [ :e | e allGeneratedTraits includesAny: containerImplementingClasses ].
 
-	^ (containerImplementingClasses , containerUsers) asSet asArray "<== This could later be #removeDuplicates but it is currently broken on arrays. See https://github.com/pharo-project/pharo/issues/4850"
+	^ (containerImplementingClasses , containerUsers) asSet asArray	"<== This could later be #removeDuplicates but it is currently broken on arrays. See https://github.com/pharo-project/pharo/issues/4850"
 ]
 
 { #category : #private }


### PR DESCRIPTION
Compute requirements dynamically instead of generating them. This simplify the generator and is not that costly dynamically.