### PR TITLE
Clean-and-comment-verveineJ-tests

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -49,6 +49,10 @@ BaselineOfFamix >> baseline: spec [
 	
 				package: 'Famix-Compatibility-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-Compatibility-Entities' with: [ spec requires: #('BasicTraits' 'Famix-Smalltalk-Utils') ];
+				package: 'Famix-Compatibility-Tests-C' with: [ spec requires: #('Famix-Compatibility-Entities') ];
+				package: 'Famix-Compatibility-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'Moose-Tests-SmalltalkImporter-LAN' 'Moose-Tests-SmalltalkImporter-KGB') ];
+				package: 'Famix-Compatibility-Tests-Extensions' with: [ spec requires: #('Famix-Compatibility-Entities' 'PackageBlueprintTestResources' 'Moose-TestResources-LCOM' 'Moose-Tests-Core') ];
+				package: 'Famix-VerveineJ-Tests' with: [ spec requires: #('Moose-Tests-Core' 'Famix-Compatibility-Entities') ];
 
 				package: 'Famix-PharoSmalltalk-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-PharoSmalltalk-Entities' with: [ spec requires: #('Famix-Smalltalk-Utils' 'BasicTraits') ];
@@ -67,16 +71,15 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Moose-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'TestModels') ];
 				package: 'Famix-Groups-Tests' with: [ spec requires: #('Famix-Groups' 'Moose-Tests-Core') ];
 				package: 'Moose-GenericImporters-Tests' with: [ spec requires: #('Moose-GenericImporter') ];
+				
 				package: 'Famix-Smalltalk-Utils-Tests' with: [ spec requires: #('Famix-Smalltalk-Utils' 'ReferenceTestResources') ];
 				package: 'Moose-Tests-SmalltalkImporter-LAN' with: [ spec requires: #('Moose-Tests-SmalltalkImporter-Core' 'Moose-TestResources-LAN') ];
 				package: 'Moose-Tests-SmalltalkImporter-Core' with: [ spec requires: #('Moose-Tests-Core' 'Moose-SmalltalkImporter' 'ReferenceTestResources') ];
 				package: 'Moose-Tests-SmalltalkImporter-KGB' with: [ spec requires: #('KGBTestResources' 'Moose-Tests-SmalltalkImporter-Core') ];
-				package: 'Famix-Compatibility-Tests-C' with: [ spec requires: #('Famix-Compatibility-Entities') ];
-				package: 'Famix-Compatibility-Tests-Java' with: [ spec requires: #('Moose-Tests-Core') ];
-				package: 'Famix-Compatibility-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'Moose-Tests-SmalltalkImporter-LAN' 'Moose-Tests-SmalltalkImporter-KGB') ];
-				package: 'Famix-Compatibility-Tests-Extensions' with: [ spec requires: #('Famix-Compatibility-Entities' 'PackageBlueprintTestResources' 'Moose-TestResources-LCOM' 'Moose-Tests-Core') ];
+
 				package: 'Famix-TestGenerators' with: [ spec requires: #('Basic') ];
 				package: 'Famix-MetamodelBuilder-Tests' with: [ spec requires: #('Famix-TestGenerators') ];
+				
 				package: 'Famix-Test1-Entities' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-Test1-Tests' with: [ spec requires: #('Famix-Test1-Entities') ];
 				package: 'Famix-Test2-Entities' with: [ spec requires: #('BasicTraits') ];

--- a/src/Famix-Compatibility-Tests-Java/package.st
+++ b/src/Famix-Compatibility-Tests-Java/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Famix-Compatibility-Tests-Java' }

--- a/src/Famix-VerveineJ-Tests/VerveineJModelTest.class.st
+++ b/src/Famix-VerveineJ-Tests/VerveineJModelTest.class.st
@@ -4,15 +4,18 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : #'Famix-Compatibility-Tests-Java'
+	#category : #'Famix-VerveineJ-Tests'
 }
+
+{ #category : #accessing }
+VerveineJModelTest class >> resources [
+	^ {VerveineJTestResource}
+]
 
 { #category : #running }
 VerveineJModelTest >> setUp [
 	super setUp.
-	model := FAMIXModel new.
-	model importFromMSEStream: VerveineJTestResource new mse readStream
-	
+	model := VerveineJTestResource current model
 ]
 
 { #category : #tests }

--- a/src/Famix-VerveineJ-Tests/VerveineJTestResource.class.st
+++ b/src/Famix-VerveineJ-Tests/VerveineJTestResource.class.st
@@ -1,13 +1,17 @@
 Class {
 	#name : #VerveineJTestResource,
 	#superclass : #MooseModelTestResource,
-	#category : #'Famix-Compatibility-Tests-Java'
+	#category : #'Famix-VerveineJ-Tests'
 }
 
 { #category : #hook }
 VerveineJTestResource >> importModel [
-
 	model importFromMSEStream: self mse readStream
+]
+
+{ #category : #setup }
+VerveineJTestResource >> modelClass [
+	^ FAMIXModel
 ]
 
 { #category : #private }

--- a/src/Famix-VerveineJ-Tests/package.st
+++ b/src/Famix-VerveineJ-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-VerveineJ-Tests' }

--- a/src/Moose-Tests-Core/MooseModelTestResource.class.st
+++ b/src/Moose-Tests-Core/MooseModelTestResource.class.st
@@ -29,3 +29,9 @@ MooseModelTestResource >> setUp [
 	model := self modelClass new.
 	self importModel
 ]
+
+{ #category : #'as yet unclassified' }
+MooseModelTestResource >> tearDown [
+	model := nil.
+	super tearDown
+]


### PR DESCRIPTION
Test resources should have a tear down + add comment to VerveineJ tests + rename package