### PR TITLE
Revert "CleaningTraitsAgain"

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaNamedEntity,
 	#superclass : #FamixJavaSourcedEntity,
-	#traits : 'FamixTNamed + FamixTPackageable + FamixTWithAnnotationInstances + TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'FamixTNamed classTrait + FamixTPackageable classTrait + FamixTWithAnnotationInstances classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
+	#traits : 'FamixTInvocationsReceiver + FamixTNamed + FamixTPackageable + FamixTWithAnnotationInstances + TDependencyQueries + TEntityMetaLevelDependency',
+	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamed classTrait + FamixTPackageable classTrait + FamixTWithAnnotationInstances classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -195,6 +195,7 @@ FamixJavaGenerator >> defineHierarchy [
 	localVariable --|> #TLocalVariable.
 
 	namedEntity --|> #TPackageable.
+	namedEntity --|> #TInvocationsReceiver.
 	namedEntity --|> #TWithAnnotationInstances.
 
 	namespace --|> scopingEntity.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStNamedEntity,
 	#superclass : #FamixStSourcedEntity,
-	#traits : 'FamixTNamed + FamixTPackageable + FamixTWithAnnotationInstances + TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'FamixTNamed classTrait + FamixTPackageable classTrait + FamixTWithAnnotationInstances classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
+	#traits : 'FamixTInvocationsReceiver + FamixTNamed + FamixTPackageable + FamixTWithAnnotationInstances + TDependencyQueries + TEntityMetaLevelDependency',
+	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamed classTrait + FamixTPackageable classTrait + FamixTWithAnnotationInstances classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -124,6 +124,7 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	method --|> #TMethod.
 
 	namedEntity --|> #TPackageable.
+	namedEntity --|> #TInvocationsReceiver.
 	namedEntity --|> #TWithAnnotationInstances.
 
 	namespace --|> scopingEntity.

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -30,6 +30,8 @@ FamixTSourceEntity >> isStub [
 
 { #category : #accessing }
 FamixTSourceEntity >> isStub: anObject [
+
 	<generated>
 	isStub := anObject
+
 ]


### PR DESCRIPTION
Reverts moosetechnology/Moose#2033


We can not do anything like this.
We discussed w/ Anne and it should be reverted.

FamixGenerator is not an OO generator, it can be used for a lot of other things (AST/UI/SQL/Manage Collection of things).

Moreover, it has a huge impact w/ hasUniqueMooseNameInModel