### PR TITLE
Cut-dependency-between-Moose-Tests-Core-and-Compatibility-Entities

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -67,7 +67,7 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Moose-Query-Test' with: [ spec requires: #('Moose-Query' 'Famix-Java-Entities') ];
 				package: 'FamixTestGenerator' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-Tests' with: [ spec requires: #('BasicTraits' 'Talents') ];
-				package: 'Moose-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'TestModels') ];
+				package: 'Moose-Tests-Core' with: [ spec requires: #('TestModels') ];
 				package: 'Famix-Groups-Tests' with: [ spec requires: #('Famix-Groups' 'Moose-Tests-Core') ];
 				package: 'Moose-GenericImporters-Tests' with: [ spec requires: #('Moose-GenericImporter') ];
 				

--- a/src/Moose-Tests-Core/MooseGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseGroupTest.class.st
@@ -122,12 +122,12 @@ MooseGroupTest >> testInitialization [
 { #category : #tests }
 MooseGroupTest >> testNumberOfPackages [
 	self assert: group numberOfPackages equals: 0.
-	group add: FAMIXPackage new.
-	group add: FAMIXPackage new.
+	group add: (MooseEntity new copyWithTalent: FamixTPackage).
+	group add: (MooseEntity new copyWithTalent: FamixTPackage).
 	self assert: group numberOfPackages equals: 2.
 	group := MooseModel new.
-	group add: FAMIXNamespace new.
-	group add: FAMIXNamespace new.
+	group add: (MooseEntity new copyWithTalent: FamixTNamespace).
+	group add: (MooseEntity new copyWithTalent: FamixTNamespace).
 	self assert: group numberOfPackages equals: 0
 ]
 


### PR DESCRIPTION
Remove last dependency from Moose-Tests-Core to Compatibility entities.