### PR TITLE
Limit-number-of-new-FMMetaMetaModel-instances

### DIFF
--- a/src/Fame-Core/FMMetaMetaModel.class.st
+++ b/src/Fame-Core/FMMetaMetaModel.class.st
@@ -9,7 +9,11 @@ Class {
 
 { #category : #accessing }
 FMMetaMetaModel class >> default [
-	^ UniqueInstance ifNil: [ UniqueInstance := super new ]
+	^ UniqueInstance
+		ifNil: [ UniqueInstance := super new
+				metamodel;
+				beReadOnlyObject;
+				yourself ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Fame-Core/FMMetaMetaModel.class.st
+++ b/src/Fame-Core/FMMetaMetaModel.class.st
@@ -1,8 +1,32 @@
 Class {
 	#name : #FMMetaMetaModel,
 	#superclass : #FMMetaModel,
+	#classVars : [
+		'UniqueInstance'
+	],
 	#category : #'Fame-Core-Models'
 }
+
+{ #category : #accessing }
+FMMetaMetaModel class >> default [
+	^ UniqueInstance ifNil: [ UniqueInstance := super new ]
+]
+
+{ #category : #'instance creation' }
+FMMetaMetaModel class >> new [
+	^ self error: 'The FMMetaMetaModel should be accessed via the #default method. In case you need a new instance for tests purposes you can use #testMetaMetaModel.'
+]
+
+{ #category : #initialization }
+FMMetaMetaModel class >> reset [
+	<script>
+	UniqueInstance := nil
+]
+
+{ #category : #accessing }
+FMMetaMetaModel class >> testMetaMetaModel [
+	^ super new
+]
 
 { #category : #initialization }
 FMMetaMetaModel >> defaultMetamodel [

--- a/src/Fame-Core/FMMetaModel.class.st
+++ b/src/Fame-Core/FMMetaModel.class.st
@@ -49,7 +49,7 @@ FMMetaModel >> concreteImplementingClasses [
 
 { #category : #initialization }
 FMMetaModel >> defaultMetamodel [
-	^ FMMetaMetaModel new
+	^ FMMetaMetaModel default
 ]
 
 { #category : #accessing }

--- a/src/Fame-Tests/FM3ClassTest.class.st
+++ b/src/Fame-Tests/FM3ClassTest.class.st
@@ -89,7 +89,8 @@ FM3ClassTest >> testProperties [
 { #category : #tests }
 FM3ClassTest >> testPropertiesIsHot [
 	| class prop size |
-	class := metaMetamodel elementNamed: 'FM3.Class'.
+	"We use a new instance of FMMetaMetaModel since we will modify it."
+	class := FMMetaMetaModel testMetaMetaModel elementNamed: 'FM3.Class'.
 	prop := class properties anyOne.
 	size := class properties size.
 	self assert: class properties size equals: size.

--- a/src/Fame-Tests/FM3ElementTest.class.st
+++ b/src/Fame-Tests/FM3ElementTest.class.st
@@ -32,7 +32,7 @@ FM3ElementTest >> addUnamedOwnerTo: anElement [
 FM3ElementTest >> setUp [
 	super setUp.
 	element := self actualClass new.
-	metaMetamodel := FMMetaMetaModel new
+	metaMetamodel := FMMetaMetaModel default
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMCodeGenerationTest.class.st
+++ b/src/Fame-Tests/FMCodeGenerationTest.class.st
@@ -47,7 +47,7 @@ FMCodeGenerationTest >> testDefaultClass [
 FMCodeGenerationTest >> testFM3Generation [
 	self
 		shouldnt: [ FMDefaultCodeGenerator new
-				visit: FMMetaMetaModel new;
+				visit: FMMetaMetaModel default;
 				previewChangesIfShiftPressed ]
 		raise: Error
 ]

--- a/src/Fame-Tests/FMExporterTest.class.st
+++ b/src/Fame-Tests/FMExporterTest.class.st
@@ -8,7 +8,7 @@ Class {
 FMExporterTest >> testExportAsMSE [
 	| printer |
 	printer := FMMSEPrinter onString.
-	FMMetaMetaModel new exportWithPrinter: printer.
+	FMMetaMetaModel default exportWithPrinter: printer.
 	self assert: printer stream contents isString.
 	self assert: printer stream contents first equals: $(
 ]
@@ -17,7 +17,7 @@ FMExporterTest >> testExportAsMSE [
 FMExporterTest >> testExportAsXML [
 	| printer |
 	printer := FMXMLPrinter onString.
-	FMMetaMetaModel new exportWithPrinter: printer.
+	FMMetaMetaModel default exportWithPrinter: printer.
 	self assert: printer stream contents isString.
 	self assert: printer stream contents first equals: $<
 ]

--- a/src/Fame-Tests/FMLibraryExample.class.st
+++ b/src/Fame-Tests/FMLibraryExample.class.st
@@ -30,7 +30,7 @@ FMLibraryExample >> testBookstore [
 	self
 		assert: (metamodel elements detect: [ :each | each fullName = 'LIB.Library.books' ]) type
 		equals: (metamodel elements detect: [ :each | each fullName = 'LIB.Book' ]).
-	self assert: (metamodel elements detect: [ :each | each fullName = 'LIB.Person.name' ]) type equals: (FMMetaMetaModel new elementNamed: 'String').
+	self assert: (metamodel elements detect: [ :each | each fullName = 'LIB.Person.name' ]) type equals: (FMMetaMetaModel default elementNamed: 'String').
 	self assert: names size equals: 10
 ]
 

--- a/src/Fame-Tests/FMMetaMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaMetaModelTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 FMMetaMetaModelTest >> setUp [
 	super setUp.
-	metaMetaModel := FMMetaMetaModel new
+	metaMetaModel := FMMetaMetaModel default
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMPragmaProcessorTest.class.st
+++ b/src/Fame-Tests/FMPragmaProcessorTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 FMPragmaProcessorTest >> testAnnotationTypes [
 	| metaMetaModel package class property properties |
-	metaMetaModel := FMMetaMetaModel new.
+	metaMetaModel := FMMetaMetaModel default.
 	package := metaMetaModel elementNamed: 'FM3'.
 	class := package classNamed: 'Element'.
 	self assert: class isFM3Class.

--- a/src/Famix-Deprecated/FMMetaModel.extension.st
+++ b/src/Famix-Deprecated/FMMetaModel.extension.st
@@ -8,6 +8,6 @@ FMMetaModel >> at: aString [
 
 { #category : #'*Famix-Deprecated' }
 FMMetaModel class >> fm3 [
-	self deprecated: 'Use FMMetaMetaRepository instance instead' transformWith: 'FMMetaRepository fm3' -> 'FMMetaMetaRepository new'.
-	^ FMMetaMetaModel new
+	self deprecated: 'Use FMMetaMetaRepository instance instead' transformWith: 'FMMetaRepository fm3' -> 'FMMetaMetaRepository default'.
+	^ FMMetaMetaModel default
 ]


### PR DESCRIPTION
We should have only one FMMetaMetaModel in Fame since it's the description of Fame itself. Currently, we could not do it because a test was writing in it, but it is now fixed.