### PR TITLE
Make-Import-code-clearer

### DIFF
--- a/src/Fame-ImportExport/FMDanglingReference.class.st
+++ b/src/Fame-ImportExport/FMDanglingReference.class.st
@@ -2,8 +2,8 @@ Class {
 	#name : #FMDanglingReference,
 	#superclass : #Object,
 	#instVars : [
-		'owner',
-		'position'
+		'position',
+		'parentProperty'
 	],
 	#category : #'Fame-ImportExport-Importers'
 }
@@ -11,21 +11,18 @@ Class {
 { #category : #'instance creation' }
 FMDanglingReference class >> with: aFutureAttribute [
 	^ self new
-		owner: aFutureAttribute;
+		parentProperty: aFutureAttribute;
 		yourself
 ]
 
-{ #category : #'initialize-release' }
-FMDanglingReference >> owner: aFutureAttribute [
-	owner := aFutureAttribute.
-	owner count: owner count + 1.
-	position := owner values size + 1
+{ #category : #initialization }
+FMDanglingReference >> parentProperty: aFutureProperty [
+	parentProperty := aFutureProperty.
+	position := parentProperty values size + 1
 ]
 
 { #category : #parsing }
 FMDanglingReference >> resolve: element [
 	self assert: element isNotNil.
-	owner values at: position put: element.
-	owner count: owner count - 1.
-	owner maybeEnd
+	parentProperty replaceDanglingReferenceAt: position by: element
 ]

--- a/src/Fame-ImportExport/FMFutureProperty.class.st
+++ b/src/Fame-ImportExport/FMFutureProperty.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'name',
 		'values',
-		'tally'
+		'numberOfDanglingReferences'
 	],
 	#category : #'Fame-ImportExport-Importers'
 }
@@ -15,18 +15,10 @@ FMFutureProperty class >> with: anImporter name: aString [
 	^self new with: anImporter name: aString
 ]
 
-{ #category : #accessing }
-FMFutureProperty >> count [
-	^ tally
-]
-
-{ #category : #accessing }
-FMFutureProperty >> count: aNumber [
-	tally := aNumber
-]
-
 { #category : #parsing }
 FMFutureProperty >> endProperty: aString [
+	"A well formated MSE file should end a property with 0 dangling references and we could assert it. But removing the assertiong makes the parser tolerant so some defects in MSE files."
+
 	self maybeEnd
 ]
 
@@ -38,8 +30,7 @@ FMFutureProperty >> importer [
 { #category : #parsing }
 FMFutureProperty >> maybeEnd [
 	| property |
-	"This makes the parser tolerant so some defects in MSE files."
-	tally isZero ifFalse: [ ^ self ].
+	numberOfDanglingReferences isZero ifFalse: [ ^ self ].
 
 	property := owner metaDescription
 		propertyNamed: name
@@ -51,7 +42,19 @@ FMFutureProperty >> maybeEnd [
 
 { #category : #parsing }
 FMFutureProperty >> referenceNumber: serial [
-	values add: (self importer index at: serial ifAbsent: [ self importer dangling: (FMDanglingReference with: self) to: serial ])
+	values
+		add:
+			(self importer index
+				at: serial
+				ifAbsent: [ self importer dangling: (FMDanglingReference with: self) to: serial.
+					numberOfDanglingReferences := numberOfDanglingReferences + 1 ])
+]
+
+{ #category : #parsing }
+FMFutureProperty >> replaceDanglingReferenceAt: anInteger by: anElement [
+	self values at: anInteger put: anElement.
+	numberOfDanglingReferences := numberOfDanglingReferences - 1.
+	self maybeEnd
 ]
 
 { #category : #accessing }
@@ -62,7 +65,7 @@ FMFutureProperty >> values [
 { #category : #'initialize-release' }
 FMFutureProperty >> with: aFutureElement name: aString [
 	super with: aFutureElement name: aString.
-	tally := 0.
+	numberOfDanglingReferences := 0.
 	name := aString.
 	values := OrderedCollection new
 ]


### PR DESCRIPTION
Rename generic variables to more concrete names + move code to class responsible for it.