### PR TITLE
Rename-Element-to-Entity

### DIFF
--- a/src/Fame-Deprecated/FMFutureElement.class.st
+++ b/src/Fame-Deprecated/FMFutureElement.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FMFutureElement,
+	#superclass : #FMFutureEntity,
+	#category : #'Fame-Deprecated'
+}
+
+{ #category : #testing }
+FMFutureElement class >> isDeprecated [
+	^ true
+]

--- a/src/Fame-Deprecated/FMFutureEntity.extension.st
+++ b/src/Fame-Deprecated/FMFutureEntity.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #FMFutureElement }
+Extension { #name : #FMFutureEntity }
 
 { #category : #'*Fame-Deprecated' }
-FMFutureElement >> current [
+FMFutureEntity >> current [
 	self deprecated: 'Use #currentProperty instead' transformWith: '`@receiver current' -> '`@receiver currentProperty'.
 	^ self currentProperty
 ]

--- a/src/Fame-Deprecated/FMMSEParser.extension.st
+++ b/src/Fame-Deprecated/FMMSEParser.extension.st
@@ -7,6 +7,12 @@ FMMSEParser >> Attribute [
 ]
 
 { #category : #'*Fame-Deprecated' }
+FMMSEParser >> Element [
+	self deprecated: 'Use #Entity instead.' transformWith: '``@object Element' -> '``@object Entity'.
+	^ self Entity
+]
+
+{ #category : #'*Fame-Deprecated' }
 FMMSEParser >> client [
 	self deprecated: 'Use #importer instead' transformWith: '`@receiver client' -> '`@receiver importer'.
 	^ self importer

--- a/src/Fame-Deprecated/FMModelExporter.extension.st
+++ b/src/Fame-Deprecated/FMModelExporter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FMModelExporter }
+
+{ #category : #'*Fame-Deprecated' }
+FMModelExporter >> exportElement: arg1 [ 
+	self deprecated: 'Use #exportEntity: instead.' transformWith: '``@object exportElement: ``@arg1 ' -> '``@object exportEntity: ``@arg1 '.
+	^ self exportEntity: arg1 
+]

--- a/src/Fame-Deprecated/FMTImportExportStructure.extension.st
+++ b/src/Fame-Deprecated/FMTImportExportStructure.extension.st
@@ -7,13 +7,31 @@ FMTImportExportStructure >> beginAttribute: arg1 [
 ]
 
 { #category : #'*Fame-Deprecated' }
+FMTImportExportStructure >> beginElement: arg1 [ 
+	self deprecated: 'Use #beginEntity: instead.' transformWith: '``@object beginElement: ``@arg1 ' -> '``@object beginEntity: ``@arg1 '.
+	^ self beginEntity: arg1 
+]
+
+{ #category : #'*Fame-Deprecated' }
 FMTImportExportStructure >> endAttribute: arg1 [ 
 	self deprecated: 'Use #endProperty: instead.' transformWith: '``@object endAttribute: ``@arg1 ' -> '``@object endProperty: ``@arg1 '.
 	^ self endProperty: arg1 
 ]
 
 { #category : #'*Fame-Deprecated' }
+FMTImportExportStructure >> endElement: arg1 [ 
+	self deprecated: 'Use #endEntity: instead.' transformWith: '``@object endElement: ``@arg1 ' -> '``@object endEntity: ``@arg1 '.
+	^ self endEntity: arg1 
+]
+
+{ #category : #'*Fame-Deprecated' }
 FMTImportExportStructure >> inAttribute: arg1 do: arg2 [ 
 	self deprecated: 'Use #inProperty:do: instead.' transformWith: '``@object inAttribute: ``@arg1 do: ``@arg2 ' -> '``@object inProperty: ``@arg1 do: ``@arg2 '.
 	^ self inProperty: arg1 do: arg2 
+]
+
+{ #category : #'*Fame-Deprecated' }
+FMTImportExportStructure >> inElement: arg1 do: arg2 [ 
+	self deprecated: 'Use #inEntity:do: instead.' transformWith: '``@object inElement: ``@arg1 do: ``@arg2 ' -> '``@object inEntity: ``@arg1 do: ``@arg2 '.
+	^ self inEntity: arg1 do: arg2 
 ]

--- a/src/Fame-ImportExport/FMFutureEntity.class.st
+++ b/src/Fame-ImportExport/FMFutureEntity.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #FMFutureElement,
+	#name : #FMFutureEntity,
 	#superclass : #FMFuture,
 	#instVars : [
 		'instance',
@@ -10,23 +10,23 @@ Class {
 }
 
 { #category : #adding }
-FMFutureElement >> addToPropertyValues: anObject [
+FMFutureEntity >> addToPropertyValues: anObject [
 	self currentProperty addToValues: anObject
 ]
 
 { #category : #parsing }
-FMFutureElement >> beginProperty: aString [
+FMFutureEntity >> beginProperty: aString [
 	self assert: currentProperty isNil.
 	currentProperty := FMFutureProperty in: self named: aString
 ]
 
 { #category : #accessing }
-FMFutureElement >> currentProperty [
+FMFutureEntity >> currentProperty [
 	^ currentProperty
 ]
 
 { #category : #parsing }
-FMFutureElement >> endProperty [
+FMFutureEntity >> endProperty [
 	"A well formated MSE file should end a property with 0 dangling references and we could assert it. But removing the assertiong makes the parser tolerant so some defects in MSE files."
 
 	currentProperty maybeEnd.
@@ -34,18 +34,18 @@ FMFutureElement >> endProperty [
 ]
 
 { #category : #accessing }
-FMFutureElement >> importer [
+FMFutureEntity >> importer [
 	^ importer
 ]
 
 { #category : #initialization }
-FMFutureElement >> in: anImporter named: aString [
+FMFutureEntity >> in: anImporter named: aString [
 	importer := anImporter.
 	metaDescription := importer metamodel elementNamed: aString.
 	instance := metaDescription createInstance
 ]
 
 { #category : #accessing }
-FMFutureElement >> instance [
+FMFutureEntity >> instance [
 	^ instance
 ]

--- a/src/Fame-ImportExport/FMFutureProperty.class.st
+++ b/src/Fame-ImportExport/FMFutureProperty.class.st
@@ -15,12 +15,12 @@ FMFutureProperty >> addToValues: anObject [
 
 { #category : #accessing }
 FMFutureProperty >> importer [
-	^ self parentElement importer
+	^ self parentEntity importer
 ]
 
 { #category : #initialization }
-FMFutureProperty >> in: aFutureElement named: aString [
-	parentElement := aFutureElement.
+FMFutureProperty >> in: aFutureEntity named: aString [
+	parentElement := aFutureEntity.
 	metaDescription := parentElement metaDescription propertyNamed: aString ifAbsent: [ aString ]
 ]
 
@@ -47,13 +47,13 @@ FMFutureProperty >> numberOfDanglingReferences [
 ]
 
 { #category : #accessing }
-FMFutureProperty >> parentElement [
+FMFutureProperty >> parentEntity [
 	^ parentElement
 ]
 
 { #category : #parsing }
 FMFutureProperty >> referenceNumber: serial [
-	self addToValues: (self importer elementAt: serial ifAbsent: [ self importer dangling: (FMDanglingReference with: self) to: serial ])
+	self addToValues: (self importer entityAt: serial ifAbsent: [ self importer dangling: (FMDanglingReference with: self) to: serial ])
 ]
 
 { #category : #parsing }

--- a/src/Fame-ImportExport/FMImporter.class.st
+++ b/src/Fame-ImportExport/FMImporter.class.st
@@ -5,14 +5,14 @@ Class {
 	#classTraits : 'FMTImportExportStructure classTrait',
 	#instVars : [
 		'stack',
-		'elements',
 		'model',
 		'stream',
 		'reminderDict',
 		'serialDict',
 		'translationUnit',
 		'ensureNoDandlingReferences',
-		'numberOfDanglingReferences'
+		'numberOfDanglingReferences',
+		'entities'
 	],
 	#category : #'Fame-ImportExport-Importers'
 }
@@ -46,26 +46,26 @@ FMImporter >> autorizeDandlingReferencesAtEnd [
 { #category : #parsing }
 FMImporter >> beginDocument [
 	stack := Stack new.
-	elements := OrderedCollection new.
+	entities := OrderedCollection new.
 	serialDict := IdentityDictionary new.
 	reminderDict := IdentityDictionary new.
 	numberOfDanglingReferences := 0
 ]
 
 { #category : #parsing }
-FMImporter >> beginElement: name [
+FMImporter >> beginEntity: name [
 	| translatedName |
 	translatedName := self translationUnit translate: name.
-	stack push: (FMFutureElement in: self named: translatedName)
+	stack push: (FMFutureEntity in: self named: translatedName)
 ]
 
 { #category : #parsing }
 FMImporter >> beginProperty: name [
-	self currentElement beginProperty: name
+	self currentEntity beginProperty: name
 ]
 
 { #category : #accessing }
-FMImporter >> currentElement [
+FMImporter >> currentEntity [
 	^ stack top
 ]
 
@@ -76,36 +76,31 @@ FMImporter >> dangling: reference to: serial [
 	^ reference
 ]
 
-{ #category : #accessing }
-FMImporter >> elementAt: aSerial ifAbsent: aBlock [
-	^ serialDict at: aSerial ifAbsent: aBlock
-]
-
-{ #category : #accessing }
-FMImporter >> elements [
-	^ elements
-]
-
 { #category : #parsing }
 FMImporter >> endDocument [
 	self assert: stack isEmpty.
 	stack := nil.
 	ensureNoDandlingReferences ifTrue: [ numberOfDanglingReferences isZero ifFalse: [ FMUnresolvedDanglingReferences signal ] ].
-	model addAll: elements
+	model addAll: entities
 ]
 
 { #category : #parsing }
-FMImporter >> endElement: name [
-	| future element |
+FMImporter >> endEntity: name [
+	| future entity |
 	future := stack pop.
-	element := future instance.
-	elements add: element.
-	stack ifNotEmpty: [ self currentElement addToPropertyValues: element ]
+	entity := future instance.
+	entities add: entity.
+	stack ifNotEmpty: [ self currentEntity addToPropertyValues: entity ]
 ]
 
 { #category : #parsing }
 FMImporter >> endProperty: name [
-	self currentElement endProperty
+	self currentEntity endProperty
+]
+
+{ #category : #accessing }
+FMImporter >> entityAt: aSerial ifAbsent: aBlock [
+	^ serialDict at: aSerial ifAbsent: aBlock
 ]
 
 { #category : #accessing }
@@ -137,17 +132,17 @@ FMImporter >> model: aModel [
 
 { #category : #parsing }
 FMImporter >> primitive: value [
-	self currentElement addToPropertyValues: value
+	self currentEntity addToPropertyValues: value
 ]
 
 { #category : #parsing }
 FMImporter >> referenceName: name [
-	self currentElement addToPropertyValues: (model elementNamed: name)
+	self currentEntity addToPropertyValues: (model elementNamed: name)
 ]
 
 { #category : #parsing }
 FMImporter >> referenceNumber: serial [
-	self currentElement currentProperty referenceNumber: serial
+	self currentEntity currentProperty referenceNumber: serial
 ]
 
 { #category : #running }
@@ -160,7 +155,7 @@ FMImporter >> run [
 
 { #category : #parsing }
 FMImporter >> serial: serial [
-	self assign: self currentElement instance to: serial
+	self assign: self currentEntity instance to: serial
 ]
 
 { #category : #accessing }

--- a/src/Fame-ImportExport/FMImporterFilter.class.st
+++ b/src/Fame-ImportExport/FMImporterFilter.class.st
@@ -25,10 +25,10 @@ FMImporterFilter >> beginDocument [
 ]
 
 { #category : #parsing }
-FMImporterFilter >> beginElement: name [
+FMImporterFilter >> beginEntity: name [
 	(filter includes: name)
 		ifTrue: [ shouldSkip := false.
-			parserClient beginElement: name ]
+			parserClient beginEntity: name ]
 		ifFalse: [ shouldSkip := true ]
 ]
 
@@ -43,8 +43,8 @@ FMImporterFilter >> endDocument [
 ]
 
 { #category : #parsing }
-FMImporterFilter >> endElement: name [
-	shouldSkip ifFalse: [ parserClient endElement: name ]
+FMImporterFilter >> endEntity: name [
+	shouldSkip ifFalse: [ parserClient endEntity: name ]
 ]
 
 { #category : #parsing }

--- a/src/Fame-ImportExport/FMMSEParser.class.st
+++ b/src/Fame-ImportExport/FMMSEParser.class.st
@@ -18,7 +18,7 @@ FMMSEParser >> Document [
 	"Matches a document node (returns a boolean)."
 
 	"Document := EOF { openDocument; closeDocument }
-		| OPEN { openDocument } Element* CLOSE { closeDocument }"
+		| OPEN { openDocument } Entity* CLOSE { closeDocument }"
 
 	self tWHITESPACE.
 	self atEnd
@@ -26,7 +26,7 @@ FMMSEParser >> Document [
 		ifFalse: [ self tOPEN
 				ifFalse: [ ^ self syntaxError ].
 			importer beginDocument.
-			[ self Element ] whileTrue.
+			[ self Entity ] whileTrue.
 			self tCLOSE
 				ifFalse: [ ^ self syntaxError ] ].
 	importer endDocument.
@@ -35,10 +35,10 @@ FMMSEParser >> Document [
 ]
 
 { #category : #expressions }
-FMMSEParser >> Element [
-	"Matches an element node (returns boolean)."
+FMMSEParser >> Entity [
+	"Matches an entity node (returns boolean)."
 
-	"Element := OPEN n:FULLNAME { beginElement(n) } Serial? Property* CLOSE { endElement(n) }"
+	"Entity := OPEN n:FULLNAME { beginElement(n) } Serial? Property* CLOSE { endElement(n) }"
 
 	| pos name |
 	pos := self position.
@@ -46,7 +46,7 @@ FMMSEParser >> Element [
 	name := self tFULLNAME.
 	name ifNil: [ ^ self backtrack: pos ].
 	importer
-		inElement: name
+		inEntity: name
 		do: [ self Serial.
 			[ self Property ] whileTrue.
 			self tCLOSE ifFalse: [ ^ self syntaxError ] ].
@@ -220,9 +220,9 @@ FMMSEParser >> String [
 FMMSEParser >> Value [
 	"Matchs a value (returns true)."
 
-	"Value := Reference | Primitive | Element"
+	"Value := Reference | Primitive | Entity"
 
-	^ self Primitive or: [ self Reference or: [ self Reference2 or: [ self Element ] ] ]
+	^ self Primitive or: [ self Reference or: [ self Reference2 or: [ self Entity ] ] ]
 ]
 
 { #category : #testing }

--- a/src/Fame-ImportExport/FMMSEPrinter.class.st
+++ b/src/Fame-ImportExport/FMMSEPrinter.class.st
@@ -11,7 +11,7 @@ FMMSEPrinter >> beginDocument [
 ]
 
 { #category : #parsing }
-FMMSEPrinter >> beginElement: name [
+FMMSEPrinter >> beginEntity: name [
 
 	indent := indent + 1.
 	self crTabs.
@@ -36,7 +36,7 @@ FMMSEPrinter >> endDocument [
 ]
 
 { #category : #parsing }
-FMMSEPrinter >> endElement: name [
+FMMSEPrinter >> endEntity: name [
 
 	stream nextPut: $).
 	indent := indent - 1

--- a/src/Fame-ImportExport/FMModelExporter.class.st
+++ b/src/Fame-ImportExport/FMModelExporter.class.st
@@ -19,16 +19,16 @@ FMModelExporter class >> new [
 
 { #category : #exporting }
 FMModelExporter >> export: aCollectionOfElements [
-	printer inDocumentDo: [ aCollectionOfElements do: [ :each | self exportElement: each ] ]
+	printer inDocumentDo: [ aCollectionOfElements do: [ :each | self exportEntity: each ] ]
 ]
 
 { #category : #exporting }
-FMModelExporter >> exportElement: each [
+FMModelExporter >> exportEntity: each [
 	| meta |
 	meta := model metaDescriptionOf: each.
 
 	printer
-		inElement: meta fullName
+		inEntity: meta fullName
 		do: [ printer serial: (self indexOf: each).
 			(self sortedPropertiesOf: meta) do: [ :property | self exportProperty: property for: each ] ].
 
@@ -58,7 +58,7 @@ FMModelExporter >> exportProperty: property withAll: values [
 						ifTrue: [ printer primitive: each ]
 						ifFalse: [
 							property isChildrenProperty
-								ifTrue: [ self exportElement: each ]
+								ifTrue: [ self exportEntity: each ]
 								ifFalse: [
 									(FM3Constant constants includes: each)
 										ifTrue: [ printer referenceName: each name ]

--- a/src/Fame-ImportExport/FMTImportExportStructure.trait.st
+++ b/src/Fame-ImportExport/FMTImportExportStructure.trait.st
@@ -9,7 +9,7 @@ FMTImportExportStructure >> beginDocument [
 ]
 
 { #category : #parsing }
-FMTImportExportStructure >> beginElement: name [
+FMTImportExportStructure >> beginEntity: name [
 	^ self explicitRequirement
 ]
 
@@ -24,7 +24,7 @@ FMTImportExportStructure >> endDocument [
 ]
 
 { #category : #parsing }
-FMTImportExportStructure >> endElement: name [
+FMTImportExportStructure >> endEntity: name [
 	^ self explicitRequirement
 ]
 
@@ -41,10 +41,10 @@ FMTImportExportStructure >> inDocumentDo: aBlock [
 ]
 
 { #category : #parsing }
-FMTImportExportStructure >> inElement: aString do: aBlock [
-	self beginElement: aString.
+FMTImportExportStructure >> inEntity: aString do: aBlock [
+	self beginEntity: aString.
 	aBlock value.
-	self endElement: aString
+	self endEntity: aString
 ]
 
 { #category : #parsing }

--- a/src/Fame-ImportExport/FMXMLPrinter.class.st
+++ b/src/Fame-ImportExport/FMXMLPrinter.class.st
@@ -13,7 +13,7 @@ FMXMLPrinter >> beginDocument [
 ]
 
 { #category : #parsing }
-FMXMLPrinter >> beginElement: name [
+FMXMLPrinter >> beginEntity: name [
 
 	stream nextPut: $>.
 	indent := indent + 1.
@@ -45,7 +45,7 @@ FMXMLPrinter >> endDocument [
 ]
 
 { #category : #parsing }
-FMXMLPrinter >> endElement: name [
+FMXMLPrinter >> endEntity: name [
 
 	stream nextPut: $>.
 	self crTabs.

--- a/src/Fame-Tests/FMDebugImporter.class.st
+++ b/src/Fame-Tests/FMDebugImporter.class.st
@@ -15,8 +15,8 @@ FMDebugImporter >> beginDocument [
 ]
 
 { #category : #parsing }
-FMDebugImporter >> beginElement: name [ 
-	a := a copyWith: (Array with:   #beginElement: with: name)
+FMDebugImporter >> beginEntity: name [ 
+	a := a copyWith: (Array with:   #beginEntity: with: name)
 ]
 
 { #category : #parsing }
@@ -35,8 +35,8 @@ FMDebugImporter >> endDocument [
 ]
 
 { #category : #parsing }
-FMDebugImporter >> endElement: name [ 
-	a := a copyWith: (Array with: #endElement: with: name)
+FMDebugImporter >> endEntity: name [ 
+	a := a copyWith: (Array with: #endEntity: with: name)
 ]
 
 { #category : #parsing }

--- a/src/Fame-Tests/FMImporterTest.class.st
+++ b/src/Fame-Tests/FMImporterTest.class.st
@@ -125,7 +125,7 @@ FMImporterTest >> testResolvingMultiArgs [
 	| importer pack ref2 ref4 ref5 model |
 	importer := (FMImporter model: FMMetaModel new)
 		beginDocument;
-		beginElement: 'FM3.Package';
+		beginEntity: 'FM3.Package';
 		serial: 3;
 		beginProperty: 'name';
 		primitive: 'MyPackage';
@@ -136,8 +136,8 @@ FMImporterTest >> testResolvingMultiArgs [
 		referenceNumber: 2;
 		referenceNumber: 5;
 		endProperty: 'classes';
-		endElement: 'FM3.Package';
-		beginElement: 'FM3.Class';
+		endEntity: 'FM3.Package';
+		beginEntity: 'FM3.Class';
 		serial: 2;
 		beginProperty: 'name';
 		primitive: 'MyName2';
@@ -145,8 +145,8 @@ FMImporterTest >> testResolvingMultiArgs [
 		beginProperty: 'superclass';
 		referenceNumber: 5;
 		endProperty: 'superclass';
-		endElement: 'FM3.Class';
-		beginElement: 'FM3.Class';
+		endEntity: 'FM3.Class';
+		beginEntity: 'FM3.Class';
 		serial: 4;
 		beginProperty: 'superclass';
 		referenceNumber: 2;
@@ -154,13 +154,13 @@ FMImporterTest >> testResolvingMultiArgs [
 		beginProperty: 'name';
 		primitive: 'MyName4';
 		endProperty: 'name';
-		endElement: 'FM3.Class';
-		beginElement: 'FM3.Class';
+		endEntity: 'FM3.Class';
+		beginEntity: 'FM3.Class';
 		serial: 5;
 		beginProperty: 'name';
 		primitive: 'MyName5';
 		endProperty: 'name';
-		endElement: 'FM3.Class';
+		endEntity: 'FM3.Class';
 		endDocument;
 		yourself.
 	model := importer model.

--- a/src/Fame-Tests/FMMSEParserTest.class.st
+++ b/src/Fame-Tests/FMMSEParserTest.class.st
@@ -493,66 +493,6 @@ FMMSEParserTest >> testBacktrack [
 ]
 
 { #category : #tests }
-FMMSEParserTest >> testElement [
-	a := #(#(#beginElement: 'Foo') #(#endElement: 'Foo')).
-	r reset.
-	p fromString: '(Foo)'.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd.
-	r reset.
-	p fromString: '(  Foo  )  '.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd
-]
-
-{ #category : #tests }
-FMMSEParserTest >> testElementWithID [
-	a := #(#(#beginElement: 'Foo') #(#serial: 42) #(#endElement: 'Foo')).
-	r reset.
-	p fromString: '(Foo(id:42))'.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd.
-	r reset.
-	p fromString: '(  Foo  (  id:  42  )  )  '.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd
-]
-
-{ #category : #tests }
-FMMSEParserTest >> testElementWithPropertys [
-	a := #(#(#beginElement: 'Foo') #(#beginProperty: 'name') #(#endProperty: 'name') #(#beginProperty: 'count') #(#endProperty: 'count') #(#endElement: 'Foo')).
-	r reset.
-	p fromString: '(Foo(name)(count))'.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd.
-	r reset.
-	p fromString: '(  Foo  (  name  )  (  count  )  )  '.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd
-]
-
-{ #category : #tests }
-FMMSEParserTest >> testElementWithPropertysAndID [
-	a := #(#(#beginElement: 'Foo') #(#serial: 42) #(#beginProperty: 'name') #(#endProperty: 'name') #(#beginProperty: 'count') #(#endProperty: 'count') #(#endElement: 'Foo')).
-	r reset.
-	p fromString: '(Foo(id:42)(name)(count))'.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd.
-	r reset.
-	p fromString: '(  Foo  (  id:  42  )  (  name  )  (  count  )  )  '.
-	p Element.
-	self assert: r contents equals: a.
-	self assert: p atEnd
-]
-
-{ #category : #tests }
 FMMSEParserTest >> testEmptyDocument [
 	p fromString: ''.
 	p Document.
@@ -565,6 +505,66 @@ FMMSEParserTest >> testEmptyExportString [
 	p fromString: ''.
 	p Document.
 	self assert: r exportString equals: '()'
+]
+
+{ #category : #tests }
+FMMSEParserTest >> testEntity [
+	a := #(#(#beginEntity: 'Foo') #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '(Foo)'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '(  Foo  )  '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMMSEParserTest >> testEntityWithID [
+	a := #(#(#beginEntity: 'Foo') #(#serial: 42) #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '(Foo(id:42))'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '(  Foo  (  id:  42  )  )  '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMMSEParserTest >> testEntityWithPropertys [
+	a := #(#(#beginEntity: 'Foo') #(#beginProperty: 'name') #(#endProperty: 'name') #(#beginProperty: 'count') #(#endProperty: 'count') #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '(Foo(name)(count))'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '(  Foo  (  name  )  (  count  )  )  '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
+]
+
+{ #category : #tests }
+FMMSEParserTest >> testEntityWithPropertysAndID [
+	a := #(#(#beginEntity: 'Foo') #(#serial: 42) #(#beginProperty: 'name') #(#endProperty: 'name') #(#beginProperty: 'count') #(#endProperty: 'count') #(#endEntity: 'Foo')).
+	r reset.
+	p fromString: '(Foo(id:42)(name)(count))'.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd.
+	r reset.
+	p fromString: '(  Foo  (  id:  42  )  (  name  )  (  count  )  )  '.
+	p Entity.
+	self assert: r contents equals: a.
+	self assert: p atEnd
 ]
 
 { #category : #tests }
@@ -843,8 +843,8 @@ FMMSEParserTest >> testPropertyWithBoolean [
 ]
 
 { #category : #tests }
-FMMSEParserTest >> testPropertyWithElements [
-	a := #(#(#beginProperty: 'name') #(#beginElement: 'Foo') #(#endElement: 'Foo') #(#beginElement: 'Bar') #(#endElement: 'Bar') #(#endProperty: 'name')).
+FMMSEParserTest >> testPropertyWithEntitys [
+	a := #(#(#beginProperty: 'name') #(#beginEntity: 'Foo') #(#endEntity: 'Foo') #(#beginEntity: 'Bar') #(#endEntity: 'Bar') #(#endProperty: 'name')).
 	r reset.
 	p fromString: '(name(Foo)(Bar))'.
 	p Property.

--- a/src/Fame-Tests/FMModelScripter.class.st
+++ b/src/Fame-Tests/FMModelScripter.class.st
@@ -53,7 +53,7 @@ FMModelScripter >> document: body [
 FMModelScripter >> element: elementName with: body [
 	"Addes an element with body (which is a block)."
 
-	client inElement: elementName do: [ body value ]
+	client inEntity: elementName do: [ body value ]
 ]
 
 { #category : #DSL }

--- a/src/Famix-Deprecated/MSEImporter.class.st
+++ b/src/Famix-Deprecated/MSEImporter.class.st
@@ -17,5 +17,5 @@ MSEImporter >> endDocument [
 	
 	self assert: [ stack isEmpty ].
 	stack := nil.
-	model addAll: elements.
+	model addAll: entities.
 ]

--- a/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
@@ -20,7 +20,7 @@ FamixSourceAnchorTest >> actualClass [
 ]
 
 { #category : #tests }
-FamixSourceAnchorTest >> testElement [
+FamixSourceAnchorTest >> testEntity [
 	| anchor m1 m2 |
 	anchor := self actualClass new.
 	m1 := FamixTest1Method named: 'method1'.

--- a/src/Famix-Tests/TFamixTSourceAnchorTest.trait.st
+++ b/src/Famix-Tests/TFamixTSourceAnchorTest.trait.st
@@ -9,7 +9,7 @@ Trait {
 }
 
 { #category : #tests }
-TFamixTSourceAnchorTest >> testElement [
+TFamixTSourceAnchorTest >> testEntity [
 element := MooseEntity new copyWithTalent: FamixTWithSourceAnchor. 
 element class initializeSlots: element.
 model add: element.


### PR DESCRIPTION
Rename Element into Entity in FMImporter.

Element has a connotation of been a FM3Element. The importer is clearer if we call it an Entity instead of an Element.