### PR TITLE
Fix-dependancy-between-with-Famix-and-Finder

### DIFF
--- a/src/Moose-Tests-Core/MooseModelRootTests.class.st
+++ b/src/Moose-Tests-Core/MooseModelRootTests.class.st
@@ -51,27 +51,15 @@ MooseModelRootTests >> testCreate [
 ]
 
 { #category : #tests }
-MooseModelRootTests >> testDelete [
-	model := self modelClass new.
-	self modelClass root add: model.
-	[ model delete ]
-		valueSupplyingAnswer:
-			{('Are you sure to want to delete ' , model mooseName printString
-				, '?').
-			true}.
-	self deny: (MooseModel root includes: model).
-	self deny: (self modelClass root includes: model)
-]
-
-{ #category : #tests }
-MooseModelRootTests >> testDeleteNonRegisteredModelRaisesError [
-	"Raise an error since it is not in the root"
-	self
-		should: [ [ self modelClass new delete ] valueSupplyingAnswer: true ]
-		raise: Error.
-]
-
-{ #category : #tests }
 MooseModelRootTests >> testModelRootPointsToMooseModelRootRoot [
 	self assert: self modelClass root equals: MooseModelRoot root
+]
+
+{ #category : #tests }
+MooseModelRootTests >> testRemove [
+	model := self modelClass new.
+	self modelClass root add: model.
+	model remove.
+	self deny: (MooseModel root includes: model).
+	self deny: (self modelClass root includes: model)
 ]

--- a/src/Moose-Tests-Finder/MooseModelRootTests.extension.st
+++ b/src/Moose-Tests-Finder/MooseModelRootTests.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : #MooseModelRootTests }
+
+{ #category : #'*Moose-Tests-Finder' }
+MooseModelRootTests >> testDelete [
+	model := self modelClass new.
+	self modelClass root add: model.
+	[ model delete ]
+		valueSupplyingAnswer:
+			{('Are you sure to want to delete ' , model mooseName printString
+				, '?').
+			true}.
+	self deny: (MooseModel root includes: model).
+	self deny: (self modelClass root includes: model)
+]
+
+{ #category : #'*Moose-Tests-Finder' }
+MooseModelRootTests >> testDeleteNonRegisteredModelRaisesError [
+	"Raise an error since it is not in the root"
+	self
+		should: [ [ self modelClass new delete ] valueSupplyingAnswer: true ]
+		raise: Error.
+]


### PR DESCRIPTION
Add test on MooseModel>>remove and move test about MooseModel>>delete to Moose-Tests-Finder.

This fix a dependency between Famix and Moose-Finder