### PR TITLE
resetMetamodel-should-update-the-metamodel-of-instances

### DIFF
--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -42,6 +42,17 @@ FmxMBGeneratorTest >> testResetMetamodel [
 ]
 
 { #category : #tests }
+FmxMBGeneratorTest >> testResetMetamodelSetNewMetamodelToInstances [
+	| model oldMetamodel metamodel |
+	model := FamixTest1Model new.
+	oldMetamodel := model metamodel.
+	self assert: model metamodel identicalTo: oldMetamodel.
+	metamodel := FamixTest1Model resetMetamodel.
+	self deny: model metamodel identicalTo: oldMetamodel.
+	self assert: model metamodel identicalTo: metamodel
+]
+
+{ #category : #tests }
 FmxMBGeneratorTest >> testSubmetamodles [
 
 	self assert: FamixMetamodelGenerator submetamodels isEmpty

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -220,6 +220,9 @@ MooseModel class >> resetMetamodel [
 
 	"MooseEntity has a cache for some infos. When we regenerate a MM we need to flush this cache."
 	metamodel classes do: [ :fm3Class | fm3Class implementingClass resetMooseEntityCache ].
+	
+	self allInstancesDo: [ :model | model updateMetamodelTo: metamodel ].
+
 	^ metamodel
 ]
 
@@ -425,7 +428,7 @@ MooseModel >> includesElementsOfType: aClass [
 	^ (self allWithType: aClass) isEmpty not
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 MooseModel >> initialize [
 	super initialize.
 	name := #noname.
@@ -608,4 +611,11 @@ MooseModel >> union: aGroup [
 	result := MooseGroup withAll: (self entities asSet union: aGroup entities asSet). 
 	result description: self description , '  and ' , aGroup description. 
 	^result
+]
+
+{ #category : #initialization }
+MooseModel >> updateMetamodelTo: aMetamodel [
+	self metamodel ifNil: [ ^ self ].
+
+	self metamodel: aMetamodel
 ]


### PR DESCRIPTION
When we reset a metamodel we should update the metamodel of the current instances.