### PR TITLE
Deprecate-dead-code

### DIFF
--- a/src/Famix-Deprecated/MooseAbstractGroup.extension.st
+++ b/src/Famix-Deprecated/MooseAbstractGroup.extension.st
@@ -19,3 +19,23 @@ MooseAbstractGroup >> entityNamed: aSymbol withType: aFamixType ifAbsent: aBlock
 
 	^ (self allWithType: aFamixType) entityNamed: aSymbol ifAbsent: aBlock
 ]
+
+{ #category : #'*Famix-Deprecated' }
+MooseAbstractGroup >> javaEntityNamed: aSymbol [
+	self
+		deprecated:
+			'This method is not used and will be removed from Moose in the next version. If you need id, move this method to your own project or open an issue on Moose explaining your usecase.'
+		on: '31/01/2020'
+		in: #Moose8.
+	^ self javaEntityNamed: aSymbol ifAbsent: [ nil ]
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseAbstractGroup >> javaEntityNamed: aMooseName ifAbsent: aBlock [
+	self
+		deprecated:
+			'This method is not used and will be removed from Moose in the next version. If you need id, move this method to your own project or open an issue on Moose explaining your usecase.'
+		on: '31/01/2020'
+		in: #Moose8.
+	^ self entityStorage at: aMooseName ifAbsent: [ self entityStorage at: '<Default Package>::' , aMooseName ifAbsent: aBlock ]
+]

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -492,21 +492,6 @@ MooseAbstractGroup >> iterator [
 	^ self entityStorage iterator
 ]
 
-{ #category : #'Famix-Java' }
-MooseAbstractGroup >> javaEntityNamed: aSymbol [ 
-	 
-	^self 
-		javaEntityNamed: aSymbol 
-		ifAbsent: [nil]
-]
-
-{ #category : #'Famix-Java' }
-MooseAbstractGroup >> javaEntityNamed: aMooseName ifAbsent: aBlock [
-	^ self entityStorage
-		at: aMooseName
-		ifAbsent: [ self entityStorage at: '<Default Package>::' , aMooseName ifAbsent: aBlock ]
-]
-
 { #category : #accessing }
 MooseAbstractGroup >> last [ 
 	 


### PR DESCRIPTION
Those methods are not used and do not make sense in the general MooseAbstractGroup.