### PR TITLE
Factorise-import-code

### DIFF
--- a/src/Famix-Test1-Tests/FmxImportingContextTest.class.st
+++ b/src/Famix-Test1-Tests/FmxImportingContextTest.class.st
@@ -51,7 +51,7 @@ source2b''))
 FmxImportingContextTest >> testImportingClasses [
 	self modelMSE
 		readStreamDo: [ :s | 
-			model := FamixTest1Model new
+			model := FamixTest1Model
 				importFromMSEStream: s
 				filteredBy:
 					(FamixTest1ImportingContext new
@@ -67,7 +67,7 @@ FmxImportingContextTest >> testImportingClasses [
 FmxImportingContextTest >> testImportingClassesAndMethods [
 	self modelMSE
 		readStreamDo: [ :s | 
-			model := FamixTest1Model new
+			model := FamixTest1Model
 				importFromMSEStream: s
 				filteredBy:
 					(FamixTest1ImportingContext new
@@ -84,7 +84,7 @@ FmxImportingContextTest >> testImportingClassesAndMethods [
 FmxImportingContextTest >> testImportingMethodsBringClassesAsRequirement [
 	self modelMSE
 		readStreamDo: [ :s | 
-			model := FamixTest1Model new
+			model := FamixTest1Model
 				importFromMSEStream: s
 				filteredBy:
 					(FamixTest1ImportingContext new

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -163,6 +163,13 @@ MooseModel class >> importFromMSEStream: aStream [
 ]
 
 { #category : #'import-export' }
+MooseModel class >> importFromMSEStream: aStream filteredBy: anImportingContext [
+	^ self new
+		importFromMSEStream: aStream filteredBy: anImportingContext;
+		yourself
+]
+
+{ #category : #'import-export' }
 MooseModel class >> importMetamodelFrom: aStream [
 	| mm generator |
 	mm := FMMetaModel new.
@@ -384,6 +391,13 @@ MooseModel >> flushProperties [
 ]
 
 { #category : #actions }
+MooseModel >> importFrom: aFMModel named: aString [
+	self silentlyAddAll: aFMModel elements.
+	self entityStorage forRuntime.
+	self name: aString
+]
+
+{ #category : #actions }
 MooseModel >> importFromMSEStream: aStream [
 	"Benchmarks
 	Time millisecondsToRun: [ MooseModel new importFromMSEStream: (StandardFileStream readOnlyFileNamed: 'network3.mse') ].
@@ -393,22 +407,14 @@ MooseModel >> importFromMSEStream: aStream [
 	 17560 -> simon_denier 9/21/2009 22:34 - removing metrics from MSE
 	"
 
-	| repository |
-	repository := self class importFrom: aStream withMetamodel: self metamodel.
-	self silentlyAddAll: repository elements.
-	self entityStorage forRuntime.
-	self name: (aStream localName removeSuffix: '.mse').
-	"aStream isFileStream
-		ifTrue: [ self rootFolder: aStream fullName asFileReference parent ]"
+	^ self importFrom: (self class importFrom: aStream withMetamodel: self metamodel) named: (aStream localName removeSuffix: '.mse')
 ]
 
 { #category : #actions }
 MooseModel >> importFromMSEStream: aStream filteredBy: anImportingContext [
-	
-	| repository |
-	repository := self class importFrom: aStream withMetamodel: self metamodel filteredBy: anImportingContext.
-	repository elements do: [ :e | self add: e ].
-	self entityStorage forRuntime
+	^ self
+		importFrom: (self class importFrom: aStream withMetamodel: self metamodel filteredBy: anImportingContext)
+		named: (aStream localName removeSuffix: '.mse')
 ]
 
 { #category : #testing }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -95,15 +95,12 @@ MooseModel class >> generateClassesFrom: aCollection inPackage: aString [
 
 { #category : #'import-export' }
 MooseModel class >> importFrom: aStream [
-	^ self importFrom: aStream withMetamodel: self meta
+	^ self importFrom: aStream withMetamodel: self metamodel
 ]
 
 { #category : #'import-export' }
-MooseModel class >> importFrom: aStream filteredBy: anImportingContext [ 
-	^self 
-		importFrom: aStream
-		withMetamodel: self meta
-		filteredBy: anImportingContext
+MooseModel class >> importFrom: aStream filteredBy: anImportingContext [
+	^ self importFrom: aStream withMetamodel: self metamodel filteredBy: anImportingContext
 ]
 
 { #category : #'import-export' }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -105,11 +105,22 @@ MooseModel class >> importFrom: aStream filteredBy: anImportingContext [
 
 { #category : #'import-export' }
 MooseModel class >> importFrom: aStream withMetamodel: aMetamodel [
+	"Here we build with the default importer"
+
+	^ self importFrom: aStream withMetamodel: aMetamodel customizingImporterWith: [ :importer | importer ]
+]
+
+{ #category : #'import-export' }
+MooseModel class >> importFrom: aStream withMetamodel: aMetamodel customizingImporterWith: aBlock [
+	"I import a MSE with its metamodel and return a FMModel from it. It is possible to customize the importer via a block"
+
 	| model importer areWarningsEnabled |
 	model := FMModel withMetamodel: aMetamodel.
-	importer := FMImporter model: model.
-	importer autorizeDandlingReferencesAtEnd.
-	importer stream: aStream.
+	importer := aBlock
+		value:
+			((FMImporter model: model) autorizeDandlingReferencesAtEnd
+				stream: aStream;
+				yourself).
 
 	"We are currently updating the meta models and most parsers are not up to date.
 	We disable warnings to avoid all deprecation warnings during the transition phase."
@@ -124,30 +135,24 @@ MooseModel class >> importFrom: aStream withMetamodel: aMetamodel [
 
 { #category : #'import-export' }
 MooseModel class >> importFrom: aStream withMetamodel: aMetamodel filteredBy: anImportingContext [
-	| model importer famixElementNames importerFilter |
-	famixElementNames := anImportingContext imports collect: [ :each | each mooseDescription fullName ].
+	"In the way to import a model we filter the entites we want to import via a FmxImportContext."
 
-	model := FMModel withMetamodel: aMetamodel.
-	importer := FMImporter model: model.
-	importer autorizeDandlingReferencesAtEnd.
-	importer stream: aStream.
-	importerFilter := FMImporterFilter on: importer filtering: famixElementNames.
-	importerFilter run.
-	model updateCache.
-	^ model
+	| famixElementNames |
+	famixElementNames := anImportingContext imports collect: [ :each | each mooseDescription fullName ].
+	^ self importFrom: aStream withMetamodel: aMetamodel customizingImporterWith: [ :importer | FMImporterFilter on: importer filtering: famixElementNames ]
 ]
 
 { #category : #'import-export' }
 MooseModel class >> importFrom: aStream withMetamodel: aMetamodel translationDictionary: translationDict [
-	| model importer |
-	model := FMModel withMetamodel: aMetamodel.	
-	importer := FMImporter model: model.
-	importer autorizeDandlingReferencesAtEnd.
-	importer stream: aStream.
-	importer nameTranslator: translationDict.
-	importer run.
-	model updateCache.
-	^ model
+	"In this case we use a translation dictionary to import model by updating the names from the MSE."
+
+	^ self
+		importFrom: aStream
+		withMetamodel: aMetamodel
+		customizingImporterWith: [ :importer | 
+			importer
+				nameTranslator: translationDict;
+				yourself ]
 ]
 
 { #category : #'import-export' }


### PR DESCRIPTION
Fix multiple problems with model importation:
- Factorize code for the import of a moose model
- Add a way to import easily by filtering the entities to import
- Use the metamodel of the selected model instead of the compatibility metamodel

Fixes #2097