### PR TITLE
2152-model-property-of-MooseEntity-should-be-an-instance-variable-instead-of-in-the-privateCache

### DIFF
--- a/src/Moose-Core/MooseDevelopmentState.class.st
+++ b/src/Moose-Core/MooseDevelopmentState.class.st
@@ -138,17 +138,6 @@ MooseDevelopmentState >> flushProperties [
 ]
 
 { #category : #testing }
-MooseDevelopmentState >> hasMooseModel [
-	| each | 
-	1 to: attributes size 
-		do: [ :n |
-			each := attributes at: n.
-			each key = #privateModel ifTrue: [ ^true ] ].
-	^false
-
-]
-
-{ #category : #testing }
 MooseDevelopmentState >> includesKey: selector [ 
 	 
 	^propertyCache includesKey: selector

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -28,6 +28,9 @@ YourEntity>>yourExtendingAttribute
 Class {
 	#name : #MooseEntity,
 	#superclass : #MooseObject,
+	#instVars : [
+		'mooseModel'
+	],
 	#classInstVars : [
 		'cache'
 	],
@@ -142,14 +145,19 @@ MooseEntity >> localMooseModel [
 { #category : #accessing }
 MooseEntity >> mooseModel [
 	"Answers the model containing the current entity"
-	^ self privateState model
+
+	^ mooseModel
 ]
 
 { #category : #accessing }
-MooseEntity >> mooseModel: aMooseModel [ 
-	 
-	aMooseModel add: self. 
-	self privateState model: aMooseModel
+MooseEntity >> mooseModel: aMooseModel [
+	aMooseModel add: self.
+	self privateSetMooseModel: aMooseModel
+]
+
+{ #category : #private }
+MooseEntity >> privateSetMooseModel: aMooseModel [
+	mooseModel := aMooseModel
 ]
 
 { #category : #testing }

--- a/src/Moose-Core/MooseEntityState.class.st
+++ b/src/Moose-Core/MooseEntityState.class.st
@@ -65,13 +65,11 @@ MooseEntityState >> cacheAt: name put: value [
 ]
 
 { #category : #'initialize-release' }
-MooseEntityState >> clone: newOwner [ 
-	 
-	| newState | 
-	newState := self copy. 
-	newState initialize: newOwner. 
-	newState model: nil. 
-	^newState
+MooseEntityState >> clone: newOwner [
+	| newState |
+	newState := self copy.
+	newState initialize: newOwner.
+	^ newState
 ]
 
 { #category : #'accessing-common attributes' }
@@ -120,11 +118,6 @@ MooseEntityState >> flushProperties [
 ]
 
 { #category : #testing }
-MooseEntityState >> hasMooseModel [
-	^self subclassResponsibility
-]
-
-{ #category : #testing }
 MooseEntityState >> includesKey: selector [ 
 	 
 	self subclassResponsibility
@@ -145,19 +138,6 @@ MooseEntityState >> isStub [
 MooseEntityState >> isStub: boolean [ 
 	 
 	^self attributeAt: #privateIsStub put: boolean
-]
-
-{ #category : #'accessing-common attributes' }
-MooseEntityState >> model [ 
-	 
-	^self 
-		attributeAt: #privateModel 
-		ifAbsent: [MooseModel ownerOf: self entity]
-]
-
-{ #category : #'accessing-common attributes' }
-MooseEntityState >> model: anObject [
-	^ self attributeAt: #privateModel put: anObject
 ]
 
 { #category : #'accessing-properties' }

--- a/src/Moose-Core/MooseMemoryEfficientState.class.st
+++ b/src/Moose-Core/MooseMemoryEfficientState.class.st
@@ -95,14 +95,6 @@ MooseMemoryEfficientState >> flushProperties [
 ]
 
 { #category : #testing }
-MooseMemoryEfficientState >> hasMooseModel [
-	1 to: attributes size do: [ :n | 
-		(attributes at: n) key = #privateModel
-			ifTrue: [ ^ true ] ].
-	^ false
-]
-
-{ #category : #testing }
 MooseMemoryEfficientState >> includesKey: selector [
 	^ propertyCache includesKey: selector
 ]

--- a/src/Moose-Core/MooseMinimalState.class.st
+++ b/src/Moose-Core/MooseMinimalState.class.st
@@ -87,11 +87,6 @@ MooseMinimalState >> flushProperties [
 ]
 
 { #category : #testing }
-MooseMinimalState >> hasMooseModel [
-	^false
-]
-
-{ #category : #testing }
 MooseMinimalState >> includesKey: selector [ 
 	" *** This method was defined by SCG.Moose.EntityState as a subclass responsibility. 
 	Replace its body with a proper implementation. *** " 
@@ -116,12 +111,6 @@ MooseMinimalState >> isStub [
 MooseMinimalState >> isStub: boolean [ 
 	 
 	[boolean == false] assert
-]
-
-{ #category : #'accessing-common attributes' }
-MooseMinimalState >> model: anObject [ 
-	 
-	
 ]
 
 { #category : #error }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -501,7 +501,7 @@ MooseModel >> mooseDescriptionFor: class [
 MooseModel >> mooseModel [
 	"Answer the containing moose model of self, if any."
 
-	^ self privateState attributeAt: #privateModel ifAbsent: [ MooseModel ownerOf: self ]
+	^ self privateState attributeAt: #privateModel ifAbsent: [ nil ]
 ]
 
 { #category : #accessing }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -500,7 +500,8 @@ MooseModel >> mooseDescriptionFor: class [
 { #category : #accessing }
 MooseModel >> mooseModel [
 	"Answer the containing moose model of self, if any."
-	^ self privateState model
+
+	^ self privateState attributeAt: #privateModel ifAbsent: [ MooseModel ownerOf: self ]
 ]
 
 { #category : #accessing }
@@ -514,8 +515,9 @@ MooseModel >> name: aStringOrSymbol [
 	| oldName |
 	oldName := name.
 	name := aStringOrSymbol.
-	(oldName notNil and: [oldName ~= name]) ifTrue: [ 
-		self announcer announce: (MooseEntityRenamed new oldName: oldName) ]
+	(oldName notNil and: [ oldName ~= name ])
+		ifTrue: [ self resetMooseName.
+			self announcer announce: (MooseEntityRenamed new oldName: oldName) ]
 ]
 
 { #category : #'Famix-Extensions' }
@@ -535,6 +537,11 @@ MooseModel >> numberOfLinesOfCodePerClass [
 	^ self
 		lookUpPropertyNamed: #numberOfLinesOfCodePerClass
 		computedAs: [ self numberOfLinesOfCode / self numberOfClasses ]
+]
+
+{ #category : #accessing }
+MooseModel >> privateSetMooseModel: aMooseModel [
+	self privateState attributeAt: #privateModel put: aMooseModel
 ]
 
 { #category : #actions }

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -190,6 +190,11 @@ MooseObject >> gtDisplayOn: aStream [
 	self mooseNameOn: aStream
 ]
 
+{ #category : #testing }
+MooseObject >> hasMooseModel [
+	^ self mooseModel isNotNil
+]
+
 { #category : #initialization }
 MooseObject >> initialize [
 	super initialize.
@@ -216,8 +221,7 @@ MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
 
 { #category : #accessing }
 MooseObject >> metamodel [
-
-	^ self privateModelOrNil
+	^ self mooseModel
 		ifNil: [ super metamodel ]
 		ifNotNil: [ :aModel | aModel metamodel ]
 
@@ -250,7 +254,7 @@ MooseObject >> mooseName [
 	Do not override this method.
 	Instead, use mooseNameOn: to customize the result."
 
-	self privateState hasMooseModel
+	self hasMooseModel
 		ifFalse: [ "do not cache yet"
 			| stream |
 			stream := (String new: 64) writeStream.
@@ -306,16 +310,9 @@ MooseObject >> privateClearMooseName [
 	self privateState removeProperty: #mooseName
 ]
 
-{ #category : #accessing }
-MooseObject >> privateModelOrNil [
-
-	^ self privateState attributeAt: #privateModel ifAbsent: [ nil ]
-]
-
 { #category : #private }
-MooseObject >> privateSetMooseModel: aMooseModel [ 
-	 
-	self privateState model: aMooseModel
+MooseObject >> privateSetMooseModel: aMooseModel [
+	"Do nothing in Object"
 ]
 
 { #category : #private }
@@ -398,7 +395,7 @@ MooseObject >> removeFromModel [
 MooseObject >> resetMooseName [
 	"If needed I reset my moose name in the MooseModel. I return true if my MooseName was updated and false if it was not."
 
-	(self hasUniqueMooseNameInModel and: [ self privateState hasMooseModel ]) ifFalse: [ ^ false ].
+	(self hasUniqueMooseNameInModel and: [ self hasMooseModel ]) ifFalse: [ ^ false ].
 
 	self mooseModel resetMooseNameFor: self.
 

--- a/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Tests-Core/MooseAbstractGroupTest.class.st
@@ -316,11 +316,11 @@ MooseAbstractGroupTest >> testIndexOf [
 
 { #category : #tests }
 MooseAbstractGroupTest >> testIntersection [
-	| group2 el1 el2 el3 el4 |
+	| group2 el1 el2 el3 |
 	group add: (el1 := MooseEntity new).
 	group add: (el2 := MooseEntity new).
 	group add: (el3 := MooseEntity new).
-	group2 := self actualClass with: (el4 := MooseEntity new).
+	group2 := self actualClass with: MooseEntity new.
 	self assertEmpty: (group intersection: group2).
 	self assertEmpty: (group intersection: self actualClass new).
 	self assertCollection: (group intersection: group) hasSameElements: {el1 . el2 . el3}.


### PR DESCRIPTION
Make mooseModel a variable in MooseEntity to speed up its search. 

Fixes #2152