### PR TITLE
2186-FAMIXAttributemooseNameOn-should-be-moved-to-FamixTAttribute

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -76,16 +76,6 @@ FAMIXAttribute >> isSharedVariable [
 ]
 
 { #category : #'Famix-Implementation' }
-FAMIXAttribute >> mooseNameOn: aStream [ 
-	| parent |
-	parent := self belongsTo.
-	parent ifNotNil: 
-		[ parent mooseNameOn: aStream.
-		aStream nextPut: $. ].
-	self name ifNotNil: [ aStream nextPutAll: self name ].
-]
-
-{ #category : #'Famix-Implementation' }
 FAMIXAttribute >> printOn: aStream [ 
 	| parent |
 	parent := self belongsTo.

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -56,16 +56,6 @@ FamixJavaAttribute >> initialize [
 
 ]
 
-{ #category : #printing }
-FamixJavaAttribute >> mooseNameOn: aStream [ 
-	| parent |
-	parent := self belongsTo.
-	parent ifNotNil: 
-		[ parent mooseNameOn: aStream.
-		aStream nextPut: $. ].
-	self name ifNotNil: [ aStream nextPutAll: self name ].
-]
-
 { #category : #'as yet unclassified' }
 FamixJavaAttribute >> printOn: aStream [ 
 	| parent |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -67,13 +67,3 @@ FamixStAttribute >> isSharedVariable [
 
 	^ self propertyNamed: #sharedVariable ifNil: [false]
 ]
-
-{ #category : #'Famix-Implementation' }
-FamixStAttribute >> mooseNameOn: aStream [ 
-	| parent |
-	parent := self belongsTo.
-	parent ifNotNil: 
-		[ parent mooseNameOn: aStream.
-		aStream nextPut: $. ].
-	self name ifNotNil: [ aStream nextPutAll: self name ].
-]

--- a/src/Famix-Tagging-Tests-Entities/FamixTagTestAttribute.class.st
+++ b/src/Famix-Tagging-Tests-Entities/FamixTagTestAttribute.class.st
@@ -14,12 +14,3 @@ FamixTagTestAttribute class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #printing }
-FamixTagTestAttribute >> mooseNameOn: aStream [
-	self parentType
-		ifNotNil: [ :parent | 
-			parent mooseNameOn: aStream.
-			aStream nextPut: $. ].
-	self name ifNotNil: [ aStream nextPutAll: self name ]
-]

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -8,6 +8,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 
@@ -25,6 +26,15 @@ FamixTAttribute >> isAttribute [
 
 	<generated>
 	^ true
+]
+
+{ #category : #printing }
+FamixTAttribute >> mooseNameOn: aStream [
+	self parentType
+		ifNotNil: [ :parent | 
+			parent mooseNameOn: aStream.
+			aStream nextPut: $. ].
+	self name ifNotNil: [ aStream nextPutAll: self name ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Remove duplicated code for moose name on attributes.

Fixes #2186 