### PR TITLE
2150-TReference-should-not-use-source-and-target-as-main-association-method-name

### DIFF
--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1264,14 +1264,14 @@ FamixGenerator >> defineRelations [
 		*-*
 	((tWithParameterizedTypeUsers property: #arguments)).
 
-	((tReference property: #source)
+	((tReference property: #referencer)
 			comment: 'Source entity making the reference. from-side of the association';
 			source)
 		*-
 	((tWithReferences property: #outgoingReferences)
 			comment: 'References from this entity to other entities.').
 
-	((tReference property: #target)
+	((tReference property: #referredType)
 			comment: 'Target entity referenced. to-side of the association';
 			target)
 		*-

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -8,7 +8,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -14,10 +14,11 @@ Note that FAMIXReference was defined between two FAMIXContainerEntity entities. 
 Trait {
 	#name : #FamixTReference,
 	#instVars : [
-		'#source => FMOne type: #FamixTWithReferences opposite: #outgoingReferences',
-		'#target => FMOne type: #FamixTReferenceable opposite: #incomingReferences'
+		'#referencer => FMOne type: #FamixTWithReferences opposite: #outgoingReferences',
+		'#referredType => FMOne type: #FamixTReferenceable opposite: #incomingReferences'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Reference'
 }
 
@@ -43,35 +44,55 @@ FamixTReference >> isReference [
 ]
 
 { #category : #accessing }
-FamixTReference >> source [
-	"Relation named: #source type: #FamixTWithReferences opposite: #outgoingReferences"
+FamixTReference >> referencer [
+	"Relation named: #referencer type: #FamixTWithReferences opposite: #outgoingReferences"
 
 	<generated>
 	<FMComment: 'Source entity making the reference. from-side of the association'>
 	<source>
-	^ source
+	^ referencer
 ]
 
 { #category : #accessing }
-FamixTReference >> source: anObject [
+FamixTReference >> referencer: anObject [
 
 	<generated>
-	source := anObject
+	referencer := anObject
 ]
 
 { #category : #accessing }
-FamixTReference >> target [
-	"Relation named: #target type: #FamixTReferenceable opposite: #incomingReferences"
+FamixTReference >> referredType [
+	"Relation named: #referredType type: #FamixTReferenceable opposite: #incomingReferences"
 
 	<generated>
 	<FMComment: 'Target entity referenced. to-side of the association'>
 	<target>
-	^ target
+	^ referredType
 ]
 
 { #category : #accessing }
-FamixTReference >> target: anObject [
+FamixTReference >> referredType: anObject [
 
 	<generated>
-	target := anObject
+	referredType := anObject
+]
+
+{ #category : #accessing }
+FamixTReference >> source [
+	^ self referencer
+]
+
+{ #category : #accessing }
+FamixTReference >> source: aSource [
+	self referencer: aSource 
+]
+
+{ #category : #accessing }
+FamixTReference >> target [
+	^ referredType 
+]
+
+{ #category : #accessing }
+FamixTReference >> target: aTarget [
+	self referredType: aTarget 
 ]

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -1,7 +1,7 @@
 Trait {
 	#name : #FamixTReferenceable,
 	#instVars : [
-		'#incomingReferences => FMMany type: #FamixTReference opposite: #target'
+		'#incomingReferences => FMMany type: #FamixTReference opposite: #referredType'
 	],
 	#category : #'Famix-Traits-Reference'
 }
@@ -22,7 +22,7 @@ FamixTReferenceable >> addIncomingReference: aReference [
 
 { #category : #accessing }
 FamixTReferenceable >> incomingReferences [
-	"Relation named: #incomingReferences type: #FamixTReference opposite: #target"
+	"Relation named: #incomingReferences type: #FamixTReference opposite: #referredType"
 
 	<generated>
 	<FMComment: 'References to this entity by other entities.'>

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -1,7 +1,7 @@
 Trait {
 	#name : #FamixTWithReferences,
 	#instVars : [
-		'#outgoingReferences => FMMany type: #FamixTReference opposite: #source'
+		'#outgoingReferences => FMMany type: #FamixTReference opposite: #referencer'
 	],
 	#category : #'Famix-Traits-Reference'
 }
@@ -22,7 +22,7 @@ FamixTWithReferences >> addOutgoingReference: aReference [
 
 { #category : #accessing }
 FamixTWithReferences >> outgoingReferences [
-	"Relation named: #outgoingReferences type: #FamixTReference opposite: #source"
+	"Relation named: #outgoingReferences type: #FamixTReference opposite: #referencer"
 
 	<generated>
 	<FMComment: 'References from this entity to other entities.'>


### PR DESCRIPTION
Renaming #source and #target of TReference into #referencer and #referredType