### PR TITLE
Pharo-source-anchor-should-not-be-immediat

### DIFF
--- a/src/Famix-Groups-Tests/package.st
+++ b/src/Famix-Groups-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Famix-Groups-Tests' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStSourceAnchor,
 	#superclass : #FamixStEntity,
-	#traits : 'FamixTHasImmediateSource + FamixTSourceAnchor',
-	#classTraits : 'FamixTHasImmediateSource classTrait + FamixTSourceAnchor classTrait',
+	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
 	#instVars : [
 		'#pharoEntity'
 	],

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -140,9 +140,7 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	scopingEntity --|> #TWithClasses.
 
 	unknownVariable --|> namedEntity.
-	unknownVariable --|> #TStructuralEntity.
-
-	sourceAnchor --|> #THasImmediateSource.
+	unknownVariable --|> #TStructuralEntity
 	
 
 	

--- a/src/Famix-Tagging/FamixTagAssociation.class.st
+++ b/src/Famix-Tagging/FamixTagAssociation.class.st
@@ -180,7 +180,7 @@ FamixTagAssociation >> stonMapForTagModel: aTagModel [
 		yourself
 ]
 
-{ #category : #'*MooseTagging-Ston' }
+{ #category : #ston }
 FamixTagAssociation >> stonOn: stonWriter [
 	stonWriter writeObject: self do: [ stonWriter encodeMap: (self stonMapForTagModel: stonWriter tagModel) ]
 ]

--- a/src/Famix-Tagging/FamixTagAssociation.extension.st
+++ b/src/Famix-Tagging/FamixTagAssociation.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #FamixTagAssociation }
-
-{ #category : #'*MooseTagging-Ston' }
-FamixTagAssociation >> stonOn: stonWriter [
-	stonWriter writeObject: self do: [ stonWriter encodeMap: (self stonMapForTagModel: stonWriter tagModel) ]
-]

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -18,7 +18,6 @@ Trait {
 		'#referredType => FMOne type: #FamixTReferenceable opposite: #incomingReferences'
 	],
 	#traits : 'FamixTAssociation',
-	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Reference'
 }
 

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -18,6 +18,7 @@ Trait {
 		'#referredType => FMOne type: #FamixTReferenceable opposite: #incomingReferences'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Reference'
 }
 


### PR DESCRIPTION
Pharo source anchor is not immediat since it save a Pharo entity and not Pharo code.