### PR TITLE
2140-Enable-precedence-between-traits

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -479,10 +479,12 @@ FmxMBBehavior >> withGroup [
 
 { #category : #generalization }
 FmxMBBehavior >> withPrecedenceOf: aTrait [
-
 	self additionalProperties
 		at: #precedingTrait
-		put: (aTrait isSymbol ifTrue: [ prefix , aTrait ] ifFalse: [aTrait fullName])
+		put:
+			(aTrait isSymbol
+				ifTrue: [ (self builder getTraitNamed: aTrait) fullName ]
+				ifFalse: [ aTrait fullName ])
 ]
 
 { #category : #'testing selectors' }


### PR DESCRIPTION
It is better to use the builder to retrieve the name of the preceding Trait
Indeed, it allows using submetamodels traits as precedence

still fixing #2140