### PR TITLE
Introduce-PharoEntitySourceAnchor

### DIFF
--- a/src/Famix-PharoSmalltalk-Entities/FamixStImportingContext.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImportingContext.class.st
@@ -119,6 +119,12 @@ FamixStImportingContext >> importParameter [
 ]
 
 { #category : #testing }
+FamixStImportingContext >> importPharoEntitySourceAnchor [
+	<generated>
+	^ self import: FamixStPharoEntitySourceAnchor
+]
+
+{ #category : #testing }
 FamixStImportingContext >> importReference [
 	<generated>
 	^ self import: FamixStReference
@@ -278,6 +284,12 @@ FamixStImportingContext >> shouldImportPackage [
 FamixStImportingContext >> shouldImportParameter [
 	<generated>
 	^ self shouldImport: FamixStParameter
+]
+
+{ #category : #testing }
+FamixStImportingContext >> shouldImportPharoEntitySourceAnchor [
+	<generated>
+	^ self shouldImport: FamixStPharoEntitySourceAnchor
 ]
 
 { #category : #testing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
@@ -1,0 +1,49 @@
+"
+Description
+--------------------
+
+A Pharo entity source anchor is an anchor poiting to a Pharo entity to get the source code.
+
+It uses a WeakSlot to let the entity be garbage collected in case we unload the code.
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	pharoEntity:		<aClassOrCompiledMethod>		The Pharo class or compiled method holding the source code.
+
+"
+Class {
+	#name : #FamixStPharoEntitySourceAnchor,
+	#superclass : #FamixStSourceAnchor,
+	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
+	#instVars : [
+		'#pharoEntity => WeakSlot'
+	],
+	#category : #'Famix-PharoSmalltalk-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixStPharoEntitySourceAnchor class >> annotation [
+
+	<FMClass: #PharoEntitySourceAnchor super: #FamixStSourceAnchor>
+	<package: #'Famix-PharoSmalltalk-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #accessing }
+FamixStPharoEntitySourceAnchor >> pharoEntity [
+	^ pharoEntity
+]
+
+{ #category : #accessing }
+FamixStPharoEntitySourceAnchor >> pharoEntity: anObject [
+	pharoEntity := anObject
+]
+
+{ #category : #accessing }
+FamixStPharoEntitySourceAnchor >> sourceText [
+	^ self pharoEntity ifNotNil: #definition  
+]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -3,9 +3,6 @@ Class {
 	#superclass : #FamixStEntity,
 	#traits : 'FamixTSourceAnchor',
 	#classTraits : 'FamixTSourceAnchor classTrait',
-	#instVars : [
-		'#pharoEntity'
-	],
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 
@@ -16,29 +13,4 @@ FamixStSourceAnchor class >> annotation [
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #initialization }
-FamixStSourceAnchor >> initialize [
-	super initialize.
-	pharoEntity := WeakArray new: 1.
-]
-
-{ #category : #accessing }
-FamixStSourceAnchor >> pharoEntity [
-	"pharoEntity var is a 1-element weak array"
-	
-	^ pharoEntity at: 1
-]
-
-{ #category : #accessing }
-FamixStSourceAnchor >> pharoEntity: anObject [
-	"point to object weakly"
-	
-	pharoEntity at: 1 put: anObject 
-]
-
-{ #category : #accessing }
-FamixStSourceAnchor >> sourceText [
-	^ self pharoEntity ifNotNil: #definition  
 ]

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -20,7 +20,8 @@ Class {
 		'parameter',
 		'reference',
 		'scopingEntity',
-		'unknownVariable'
+		'unknownVariable',
+		'pharoEntitySourceAnchor'
 	],
 	#category : #'Famix-PharoSmalltalk-Generator'
 }
@@ -53,6 +54,7 @@ FamixPharoSmalltalkGenerator >> defineClasses [
 	inheritance := builder newClassNamed: #Inheritance.
 	invocation := builder newClassNamed: #Invocation.
 	localVariable := builder newClassNamed: #LocalVariable.
+	pharoEntitySourceAnchor := builder newClassNamed: #PharoEntitySourceAnchor.
 	method := builder newClassNamed: #Method.
 	namespace := builder newClassNamed: #Namespace.
 	package := builder newClassNamed: #Package.
@@ -141,7 +143,10 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	scopingEntity --|> #TScopingEntity.
 	scopingEntity --|> #TWithTypes.
 	scopingEntity --|> #TWithClasses.
-
+	
+	pharoEntitySourceAnchor --|> sourceAnchor.
+	pharoEntitySourceAnchor --|> #TSourceAnchor.
+ 
 	unknownVariable --|> namedEntity.
 	unknownVariable --|> #TStructuralEntity
 	

--- a/src/Moose-SmalltalkImporter/AbstractSmalltalkMetamodelFactory.class.st
+++ b/src/Moose-SmalltalkImporter/AbstractSmalltalkMetamodelFactory.class.st
@@ -18,7 +18,7 @@ AbstractSmalltalkMetamodelFactory >> access [
 { #category : #accessing }
 AbstractSmalltalkMetamodelFactory >> anchor [
 
-	^ self entityNamed: #SourceAnchor
+	^ self entityNamed: #PharoEntitySourceAnchor
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Introduce PharoEntitySourceAnchor to be more explicit in the naming.

This still keeps FamixStSourceAnchor that should vanish in the future when we will remove FamixBasicInfrastructureGenerator usages.