### PR TITLE
Make-XXXEntity-the-default-superclass

### DIFF
--- a/src/Famix-BasicInfrastructure/FamixBasicInfrastructureGenerator.class.st
+++ b/src/Famix-BasicInfrastructure/FamixBasicInfrastructureGenerator.class.st
@@ -2,14 +2,14 @@ Class {
 	#name : #FamixBasicInfrastructureGenerator,
 	#superclass : #FamixMetamodelGenerator,
 	#instVars : [
-		'entity',
-		'sourceAnchor',
-		'sourceLanguage',
-		'sourcedEntity',
-		'comment',
-		'namedEntity',
-		'sourceTextAnchor',
-		'unknownSourceLanguage'
+		'#entity => FamixDeprecatedSlot message: \'This variable should not be used anymore. XXXEntity is now the default root and you don\'\'t need to declare you inherit from it. If you wish to add property to it, get the class with `self ensureClassNamed: #Entity`.\'',
+		'#sourceAnchor',
+		'#sourceLanguage',
+		'#sourcedEntity',
+		'#comment',
+		'#namedEntity',
+		'#sourceTextAnchor',
+		'#unknownSourceLanguage'
 	],
 	#category : #'Famix-BasicInfrastructure'
 }
@@ -26,29 +26,24 @@ FamixBasicInfrastructureGenerator class >> submetamodels [
 
 { #category : #definition }
 FamixBasicInfrastructureGenerator >> defineClasses [
-
 	super defineClasses.
 
-	entity := builder newClassNamed: #Entity.
 	sourceAnchor := builder newClassNamed: #SourceAnchor.
 	sourceLanguage := builder newClassNamed: #SourceLanguage.
 	unknownSourceLanguage := builder newClassNamed: #UnknownSourceLanguage.
 	sourcedEntity := builder newClassNamed: #SourcedEntity.
 	comment := builder newClassNamed: #Comment.
 	namedEntity := builder newClassNamed: #NamedEntity.
-	sourceTextAnchor := builder newClassNamed: #SourceTextAnchor.
-
+	sourceTextAnchor := builder newClassNamed: #SourceTextAnchor
 ]
 
 { #category : #definition }
 FamixBasicInfrastructureGenerator >> defineHierarchy [
-	sourceAnchor --|> entity.
+
 	sourceAnchor --|> #TSourceAnchor.
 
-	sourceLanguage --|> entity.
 	sourceLanguage --|> #TSourceLanguage.
 
-	sourcedEntity --|> entity.
 	sourcedEntity --|> #TSourceEntity.
 	sourcedEntity --|> #TWithComments.
 

--- a/src/Famix-BasicInfrastructure/FamixDeprecatedSlot.class.st
+++ b/src/Famix-BasicInfrastructure/FamixDeprecatedSlot.class.st
@@ -1,0 +1,76 @@
+"
+Description
+--------------------
+
+I am a slot used when the usage of an instance variable should be deprecated.
+
+Examples
+--------------------
+
+	FamixMetamodelGenerator subclass: #FamixBasicInfrastructureGenerator
+	slots: { #entity => DeprecatedSlot message: 'Do not use'. 
+				#sourceAnchor. #sourceLanguage. #sourcedEntity. #comment. #namedEntity. #sourceTextAnchor. #unknownSourceLanguage }
+	classVariables: {  }
+	package: 'Famix-BasicInfrastructure'
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	message:		<aString>		The deprecation message to show.
+
+"
+Class {
+	#name : #FamixDeprecatedSlot,
+	#superclass : #IndexedSlot,
+	#instVars : [
+		'message'
+	],
+	#category : #'Famix-BasicInfrastructure'
+}
+
+{ #category : #accessing }
+FamixDeprecatedSlot class >> message: aString [
+	^ self new
+		message: aString;
+		yourself
+]
+
+{ #category : #accessing }
+FamixDeprecatedSlot >> message [
+	^ message
+]
+
+{ #category : #accessing }
+FamixDeprecatedSlot >> message: anObject [
+	message := anObject
+]
+
+{ #category : #printing }
+FamixDeprecatedSlot >> printOn: aStream [
+	aStream
+		store: self name;
+		nextPutAll: ' => ';
+		nextPutAll: self class name.
+	aStream
+		nextPutAll: ' message: ';
+		store: self message
+]
+
+{ #category : #'meta-object-protocol' }
+FamixDeprecatedSlot >> read: anObject [
+	FamixSlotDeprecation new
+		context: thisContext;
+		explanation: self message;
+		signal.
+	super read: anObject
+]
+
+{ #category : #'meta-object-protocol' }
+FamixDeprecatedSlot >> write: aValue to: anObject [
+	FamixSlotDeprecation new
+		context: thisContext;
+		explanation: self message;
+		signal.
+	super write: aValue to: anObject
+]

--- a/src/Famix-BasicInfrastructure/FamixSlotDeprecation.class.st
+++ b/src/Famix-BasicInfrastructure/FamixSlotDeprecation.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #FamixSlotDeprecation,
+	#superclass : #Deprecation,
+	#category : #'Famix-BasicInfrastructure'
+}
+
+{ #category : #accessing }
+FamixSlotDeprecation >> messageText [
+	^ String
+		streamContents: [ :str | 
+			self shouldTransform ifTrue: [ str nextPutAll: 'Automatic deprecation code rewrite: ' ].
+			str
+				nextPutAll: 'The instance variable ';
+				nextPutAll: context receiver name;
+				nextPutAll: ' accessed in ';
+				nextPutAll: context sender method name;
+				nextPutAll: ' has been deprecated. ';
+				nextPutAll: explanationString ]
+]

--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FAMIXAccess,
-	#superclass : #MooseEntity,
+	#superclass : #FAMIXEntity,
 	#traits : 'FamixTAccess',
 	#classTraits : 'FamixTAccess classTrait',
 	#category : #'Famix-Compatibility-Entities-Entities'
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FAMIXAccess class >> annotation [
 
-	<FMClass: #Access super: #MooseEntity>
+	<FMClass: #Access super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
@@ -20,13 +20,6 @@ FAMIXAccess class >> fromMethod [
 	^ self lookupSelector: #accessor
 ]
 
-{ #category : #meta }
-FAMIXAccess class >> metamodel [
-
-	<generated>
-	^ FAMIXModel metamodel
-]
-
 { #category : #'Moose-Query-Extensions' }
 FAMIXAccess class >> toMethod [
 	^ self lookupSelector: #variable
@@ -35,104 +28,6 @@ FAMIXAccess class >> toMethod [
 { #category : #testing }
 FAMIXAccess >> isAccess [
 	^true
-]
-
-{ #category : #testing }
-FAMIXAccess >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXAccess >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInclude.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FAMIXInclude,
-	#superclass : #MooseEntity,
+	#superclass : #FAMIXEntity,
 	#traits : 'FamixTFileInclude',
 	#classTraits : 'FamixTFileInclude classTrait',
 	#category : #'Famix-Compatibility-Entities-Entities'
@@ -9,120 +9,8 @@ Class {
 { #category : #meta }
 FAMIXInclude class >> annotation [
 
-	<FMClass: #Include super: #MooseEntity>
+	<FMClass: #Include super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FAMIXInclude class >> metamodel [
-
-	<generated>
-	^ FAMIXModel metamodel
-]
-
-{ #category : #testing }
-FAMIXInclude >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInclude >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInheritance.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FAMIXInheritance,
-	#superclass : #MooseEntity,
+	#superclass : #FAMIXEntity,
 	#traits : 'FamixTInheritance',
 	#classTraits : 'FamixTInheritance classTrait',
 	#category : #'Famix-Compatibility-Entities-Entities'
@@ -9,121 +9,16 @@ Class {
 { #category : #meta }
 FAMIXInheritance class >> annotation [
 
-	<FMClass: #Inheritance super: #MooseEntity>
+	<FMClass: #Inheritance super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FAMIXInheritance class >> metamodel [
-
-	<generated>
-	^ FAMIXModel metamodel
 ]
 
 { #category : #'Moose-Hismo' }
 FAMIXInheritance >> historicalUniqueName [
 	
 	^(self subclass mooseName , '->' , self superclass mooseName) asSymbol
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInheritance >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FAMIXInvocation,
-	#superclass : #MooseEntity,
+	#superclass : #FAMIXEntity,
 	#traits : 'FamixTHasSignature + FamixTInvocation',
 	#classTraits : 'FamixTHasSignature classTrait + FamixTInvocation classTrait',
 	#category : #'Famix-Compatibility-Entities-Entities'
@@ -9,17 +9,10 @@ Class {
 { #category : #meta }
 FAMIXInvocation class >> annotation [
 
-	<FMClass: #Invocation super: #MooseEntity>
+	<FMClass: #Invocation super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FAMIXInvocation class >> metamodel [
-
-	<generated>
-	^ FAMIXModel metamodel
 ]
 
 { #category : #'Famix-Extensions' }
@@ -91,107 +84,9 @@ FAMIXInvocation >> isASureInvocation [
 			[invoRVar class = FAMIXClass or: [invoRVar isImplicitVariable and: [invoRVar isSelf or: [invoRVar isSuper]]]]
 ]
 
-{ #category : #testing }
-FAMIXInvocation >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isInheritance [
-
-	<generated>
-	^ false
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXInvocation >> isInvocation [ 	
 	^true
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXInvocation >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FAMIXReference,
-	#superclass : #MooseEntity,
+	#superclass : #FAMIXEntity,
 	#traits : 'FamixTReference',
 	#classTraits : 'FamixTReference classTrait',
 	#category : #'Famix-Compatibility-Entities-Entities'
@@ -9,115 +9,10 @@ Class {
 { #category : #meta }
 FAMIXReference class >> annotation [
 
-	<FMClass: #Reference super: #MooseEntity>
+	<FMClass: #Reference super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FAMIXReference class >> metamodel [
-
-	<generated>
-	^ FAMIXModel metamodel
-]
-
-{ #category : #testing }
-FAMIXReference >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXReference >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXTraitUsage.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FAMIXTraitUsage,
-	#superclass : #MooseEntity,
+	#superclass : #FAMIXEntity,
 	#traits : 'FamixTTraitUsage',
 	#classTraits : 'FamixTTraitUsage classTrait',
 	#category : #'Famix-Compatibility-Entities-Entities'
@@ -9,120 +9,8 @@ Class {
 { #category : #meta }
 FAMIXTraitUsage class >> annotation [
 
-	<FMClass: #TraitUsage super: #MooseEntity>
+	<FMClass: #TraitUsage super: #FAMIXEntity>
 	<package: #FAMIX>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FAMIXTraitUsage class >> metamodel [
-
-	<generated>
-	^ FAMIXModel metamodel
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isFunction [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FAMIXTraitUsage >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-Compatibility-Generator/FamixCompatibilityGenerator.class.st
+++ b/src/Famix-Compatibility-Generator/FamixCompatibilityGenerator.class.st
@@ -177,8 +177,6 @@ FamixCompatibilityGenerator >> defineClasses [
 FamixCompatibilityGenerator >> defineHierarchy [
 
 	super defineHierarchy.
-
-	entity <|-- exception.
 	
 	access --|> #TAccess.
 

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixJavaAccess,
-	#superclass : #MooseEntity,
+	#superclass : #FamixJavaEntity,
 	#traits : 'FamixTAccess',
 	#classTraits : 'FamixTAccess classTrait',
 	#category : #'Famix-Java-Entities-Entities'
@@ -9,108 +9,10 @@ Class {
 { #category : #meta }
 FamixJavaAccess class >> annotation [
 
-	<FMClass: #Access super: #MooseEntity>
+	<FMClass: #Access super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixJavaAccess class >> metamodel [
-
-	<generated>
-	^ FamixJavaModel metamodel
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaAccess >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixJavaInheritance,
-	#superclass : #MooseEntity,
+	#superclass : #FamixJavaEntity,
 	#traits : 'FamixTInheritance',
 	#classTraits : 'FamixTInheritance classTrait',
 	#category : #'Famix-Java-Entities-Entities'
@@ -9,114 +9,16 @@ Class {
 { #category : #meta }
 FamixJavaInheritance class >> annotation [
 
-	<FMClass: #Inheritance super: #MooseEntity>
+	<FMClass: #Inheritance super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixJavaInheritance class >> metamodel [
-
-	<generated>
-	^ FamixJavaModel metamodel
 ]
 
 { #category : #'as yet unclassified' }
 FamixJavaInheritance >> historicalUniqueName [
 	
 	^(self subclass mooseName , '->' , self superclass mooseName) asSymbol
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInheritance >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixJavaInvocation,
-	#superclass : #MooseEntity,
+	#superclass : #FamixJavaEntity,
 	#traits : 'FamixTHasSignature + FamixTInvocation',
 	#classTraits : 'FamixTHasSignature classTrait + FamixTInvocation classTrait',
 	#category : #'Famix-Java-Entities-Entities'
@@ -9,17 +9,10 @@ Class {
 { #category : #meta }
 FamixJavaInvocation class >> annotation [
 
-	<FMClass: #Invocation super: #MooseEntity>
+	<FMClass: #Invocation super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixJavaInvocation class >> metamodel [
-
-	<generated>
-	^ FamixJavaModel metamodel
 ]
 
 { #category : #'as yet unclassified' }
@@ -92,99 +85,8 @@ FamixJavaInvocation >> isASureInvocation [
 ]
 
 { #category : #testing }
-FamixJavaInvocation >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
 FamixJavaInvocation >> isInvocation [ 	
 	^true
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaInvocation >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixJavaReference,
-	#superclass : #MooseEntity,
+	#superclass : #FamixJavaEntity,
 	#traits : 'FamixTReference',
 	#classTraits : 'FamixTReference classTrait',
 	#category : #'Famix-Java-Entities-Entities'
@@ -9,108 +9,10 @@ Class {
 { #category : #meta }
 FamixJavaReference class >> annotation [
 
-	<FMClass: #Reference super: #MooseEntity>
+	<FMClass: #Reference super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixJavaReference class >> metamodel [
-
-	<generated>
-	^ FamixJavaModel metamodel
-]
-
-{ #category : #testing }
-FamixJavaReference >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isPrimitiveType [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixJavaReference >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -99,7 +99,9 @@ FamixJavaGenerator >> defineClasses [
 
 { #category : #definition }
 FamixJavaGenerator >> defineComments [
-	entity comment: 'file :=  ''ArgoUML-0.34.mse'' asFileReference readStream.
+	(builder ensureClassNamed: #Entity)
+		comment:
+			'file :=  ''ArgoUML-0.34.mse'' asFileReference readStream.
 
 dictionary := Dictionary newFrom: (
 	FamixJavaEntity withAllSubclasses collect: [ :c | 
@@ -118,11 +120,8 @@ model.'
 
 { #category : #definition }
 FamixJavaGenerator >> defineHierarchy [
-
 	super defineHierarchy.
 
-	entity <|-- exception.
-	
 	access --|> #TAccess.
 
 	annotationInstance --|> sourcedEntity.

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -126,6 +126,18 @@ FamixMetamodelBuilder >> ensureClassNamed: aString [
 	^ self classes detect: [ :each | each name = aString ] ifNone: [ self newClassNamed: aString ]
 ]
 
+{ #category : #generating }
+FamixMetamodelBuilder >> ensureEntityClassIsTheCommonSuperclass [
+	"All classes should have a common superclass called Entity. Here we ensure it is created and used."
+
+	self classes iterator
+		| #isRoot selectIt
+		| #isMetamodelClassGroup rejectIt
+		| [ :class | class name = #Entity ] rejectIt
+		| [ :class | class --|> (self ensureClassNamed: #Entity) ] doIt
+		> NullAddableObject
+]
+
 { #category : #initialization }
 FamixMetamodelBuilder >> ensureLocalTraitNamed: aString [
 	<ignoreForMutations: #(ReplaceAndWithEqvMutantOperator)>
@@ -415,6 +427,7 @@ FamixMetamodelBuilder >> parentBuilderPackageName [
 FamixMetamodelBuilder >> prepareGeneration [
 	self registerPackages.
 
+	self ensureEntityClassIsTheCommonSuperclass.
 	self traitsWithSubBuildersTraits do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
 	self classes do: [ :each | self testingSelectorsMapping at: each put: each testingSelectors ].
 	self traits do: [ :each | each generate ].

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -265,6 +265,12 @@ FmxMBBehavior >> isMetamodelClass [
 ]
 
 { #category : #testing }
+FmxMBBehavior >> isMetamodelClassGroup [
+
+	^ false
+]
+
+{ #category : #testing }
 FmxMBBehavior >> isMetamodelTrait [
 
 	^ false

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClassGroup.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClassGroup.class.st
@@ -39,6 +39,11 @@ FmxMBClassGroup >> innerClass: anObject [
 	innerClass := anObject
 ]
 
+{ #category : #testing }
+FmxMBClassGroup >> isMetamodelClassGroup [
+	^ true
+]
+
 { #category : #'settings - default' }
 FmxMBClassGroup >> name [
 	"I am override to avoid the presence of the T in the generated class"

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
@@ -35,16 +35,16 @@ FmxMBClassTest >> newEntityNamed: aString [
 
 { #category : #'tests - settings' }
 FmxMBClassTest >> testBasicSuperclass [
-
-	"check if a new class has correct superclass (the default one)"
+	"check if a new class has correct superclass (Entity for most of them. The default one for Entity.)"
 
 	| generated |
-	
-	builder newClassNamed: #Comment.	
+	builder newClassNamed: #Comment.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
-	self assert: generated superclass name equals: builder configuration defaultBasicSuperclassName.
+	self assert: generated superclass name equals: #TstEntity.
 
+	generated := builder testingEnvironment ask classNamed: 'TstEntity'.
+	self assert: generated superclass name equals: builder configuration defaultBasicSuperclassName
 ]
 
 { #category : #'tests - settings' }
@@ -178,17 +178,15 @@ FmxMBClassTest >> testCustomPackageForUserClassesChanged [
 
 { #category : #'tests - settings' }
 FmxMBClassTest >> testCustomSuperclass [
-
 	"test if a custom basic superclass can correctly set"
 
 	| generated |
-	
 	builder configuration basicSuperclassName: #BasicSuperclass.
-	builder newClassNamed: #Comment.
-	builder generate.
-	generated := builder testingEnvironment ask classNamed: 'TstComment'.
-	self assert: generated superclass name equals: 'BasicSuperclass'.
 
+	builder newClassNamed: #Entity.
+	builder generate.
+	generated := builder testingEnvironment ask classNamed: 'TstEntity'.
+	self assert: generated superclass name equals: 'BasicSuperclass'
 ]
 
 { #category : #tests }
@@ -235,6 +233,27 @@ FmxMBClassTest >> testEmptyComment [
 ]
 
 { #category : #tests }
+FmxMBClassTest >> testEntityClass [
+	"check expected parameters of a newely generated entity class"
+
+	| generated method |
+	builder newClassNamed: #Entity.
+	builder generate.
+	generated := builder testingEnvironment ask classNamed: 'TstEntity'.
+	self assert: generated isNotNil.
+	self assert: generated isClass.
+	self assert: generated superclass name equals: 'MooseEntity'.
+	self assertEmpty: generated slots.
+	self assertEmpty: generated instanceSide localSelectors.
+	self assertCollection: generated classSide localSelectors sorted equals: #(annotation metamodel).
+
+	method := generated classSide methodNamed: #annotation.
+	self assert: (method sourceCode includesSubstring: '<FMClass: #Entity super: #MooseEntity>').
+	self assert: (method sourceCode includesSubstring: '<generated>').
+	self assert: (method sourceCode includesSubstring: '<package: #Tst>')
+]
+
+{ #category : #tests }
 FmxMBClassTest >> testMultipleClasses [
 
 	"trivial test if we can generate several different classes"
@@ -258,29 +277,26 @@ FmxMBClassTest >> testSimpleClass [
 	builder newClassNamed: #Comment.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
-	self assert: generated notNil.
+	self assert: generated isNotNil.
 	self assert: generated isClass.
-	self assert: generated superclass name equals: 'MooseEntity'.
-	self assert: generated slots isEmpty.
-	self assert: generated instanceSide localSelectors isEmpty.
-	self assertCollection: generated classSide localSelectors sorted equals: #(annotation #metamodel)
+	self assert: generated superclass name equals: 'TstEntity'.
+	self assertEmpty: generated slots.
+	self assertEmpty: generated instanceSide localSelectors.
+	self assertCollection: generated classSide localSelectors sorted equals: #(annotation)
 ]
 
 { #category : #tests }
 FmxMBClassTest >> testSimpleClassAnnotation [
-
 	"test correct generation of class annotations"
 
 	| generated method |
-		
-	builder newClassNamed: #Comment.	
+	builder newClassNamed: #Comment.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
 	method := generated classSide methodNamed: #annotation.
-	self assert: (method sourceCode includesSubstring: '<FMClass: #Comment super: #MooseEntity>').
+	self assert: (method sourceCode includesSubstring: '<FMClass: #Comment super: #TstEntity>').
 	self assert: (method sourceCode includesSubstring: '<generated>').
-	self assert: (method sourceCode includesSubstring: '<package: #Tst>').
-
+	self assert: (method sourceCode includesSubstring: '<package: #Tst>')
 ]
 
 { #category : #'tests - names' }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -6,9 +6,9 @@ Class {
 
 { #category : #tests }
 FmxMBGeneratorTest >> testBuilderWithDefinitions [
-
 	builder := FamixTest1Generator builderWithDefinitions.
-	self assert: (builder classNamed: #Entity) notNil.
+	builder prepareGeneration.
+	self assert: (builder classNamed: #Entity) isNotNil
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTestingMethodsTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTestingMethodsTest.class.st
@@ -7,8 +7,6 @@ Class {
 		'entity',
 		'trait',
 		'traited',
-		'generatedRoot1',
-		'generatedRoot2',
 		'generatedEntity',
 		'generatedTNamed',
 		'generatedNamed',
@@ -25,12 +23,11 @@ FmxMBTestingMethodsTest >> setUp [
 	
 	root1 := builder newClassNamed: #Root1.	
 	root2 := builder newClassNamed: #Root2.	
-	entity := builder newClassNamed: #Entity.
+	entity := builder ensureClassNamed: #Entity.
 	trait := builder newTraitNamed: #TNamedEntity.
 	traited := builder newClassNamed: #Named.
-	traitedRoot := builder newClassNamed: #TraitedRoot.
-	
-	root1 <|-- entity.
+	traitedRoot := builder newTraitNamed: #TraitedRoot.
+
 	root1 <|-- traited.
 	trait <|-- traited.
 	trait <|-- traitedRoot.
@@ -39,9 +36,7 @@ FmxMBTestingMethodsTest >> setUp [
 	trait withTesting.
 	
 	builder generate.
-	
-	generatedRoot1 := builder testingEnvironment ask classNamed: 'TstRoot1'.
-	generatedRoot2 := builder testingEnvironment ask classNamed: 'TstRoot2'.
+
 	generatedEntity := builder testingEnvironment ask classNamed: 'TstEntity'.
 	generatedTNamed := builder testingEnvironment ask classNamed: 'TstTNamedEntity'.
 	generatedNamed := builder testingEnvironment ask classNamed: 'TstNamed'.
@@ -63,11 +58,11 @@ FmxMBTestingMethodsTest >> testRoots [
 
 	"all roots should have testing messages with negative answer"
 
-	(generatedRoot1 methodNamed: #isEntity) sourceCode includesSubstring: '^ false'.	
-	(generatedRoot1 methodNamed: #isNamedEntity) sourceCode includesSubstring: '^ false'.
+	(generatedEntity methodNamed: #isEntity) sourceCode includesSubstring: '^ false'.	
+	(generatedEntity methodNamed: #isNamedEntity) sourceCode includesSubstring: '^ false'.
 	
-	(generatedRoot2 methodNamed: #isEntity) sourceCode includesSubstring: '^ false'.	
-	(generatedRoot2 methodNamed: #isNamedEntity) sourceCode includesSubstring: '^ false'.
+	(generatedEntity methodNamed: #isEntity) sourceCode includesSubstring: '^ false'.	
+	(generatedEntity methodNamed: #isNamedEntity) sourceCode includesSubstring: '^ false'.
 ]
 
 { #category : #tests }
@@ -88,9 +83,7 @@ FmxMBTestingMethodsTest >> testTraited [
 
 { #category : #tests }
 FmxMBTestingMethodsTest >> testTraitedRoot [
-
 	"a testing method should not be generated if it is provided by a trait"
-	
-	(generatedTraitedRoot methodNamed: #isEntity) sourceCode includesSubstring: '^ false'.	
-	self assert: (generatedTraitedRoot localMethodNamed: #isNamed ifAbsent: [nil]) isNil.
+
+	self assert: (generatedTraitedRoot localMethodNamed: #isNamed ifAbsent: [ nil ]) isNil
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixStAccess,
-	#superclass : #MooseEntity,
+	#superclass : #FamixStEntity,
 	#traits : 'FamixTAccess',
 	#classTraits : 'FamixTAccess classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
@@ -9,101 +9,10 @@ Class {
 { #category : #meta }
 FamixStAccess class >> annotation [
 
-	<FMClass: #Access super: #MooseEntity>
+	<FMClass: #Access super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixStAccess class >> metamodel [
-
-	<generated>
-	^ FamixStModel metamodel
-]
-
-{ #category : #testing }
-FamixStAccess >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStAccess >> isType [
-
-	<generated>
-	^ false
 ]
 
 { #category : #printing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixStInheritance,
-	#superclass : #MooseEntity,
+	#superclass : #FamixStEntity,
 	#traits : 'FamixTInheritance',
 	#classTraits : 'FamixTInheritance classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
@@ -9,99 +9,8 @@ Class {
 { #category : #meta }
 FamixStInheritance class >> annotation [
 
-	<FMClass: #Inheritance super: #MooseEntity>
+	<FMClass: #Inheritance super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixStInheritance class >> metamodel [
-
-	<generated>
-	^ FamixStModel metamodel
-]
-
-{ #category : #testing }
-FamixStInheritance >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInheritance >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixStInvocation,
-	#superclass : #MooseEntity,
+	#superclass : #FamixStEntity,
 	#traits : 'FamixTHasSignature + FamixTInvocation',
 	#classTraits : 'FamixTHasSignature classTrait + FamixTInvocation classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
@@ -9,17 +9,10 @@ Class {
 { #category : #meta }
 FamixStInvocation class >> annotation [
 
-	<FMClass: #Invocation super: #MooseEntity>
+	<FMClass: #Invocation super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixStInvocation class >> metamodel [
-
-	<generated>
-	^ FamixStModel metamodel
 ]
 
 { #category : #'instance creation' }
@@ -55,88 +48,4 @@ FamixStInvocation >> isASureInvocation [
 	invoRVar := self receiver.
 	^(invoRVar notNil) and: 
 			[invoRVar class = FamixStClass or: [invoRVar isImplicitVariable and: [invoRVar isSelf or: [invoRVar isSuper]]]]
-]
-
-{ #category : #testing }
-FamixStInvocation >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStInvocation >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixStReference,
-	#superclass : #MooseEntity,
+	#superclass : #FamixStEntity,
 	#traits : 'FamixTReference',
 	#classTraits : 'FamixTReference classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
@@ -9,99 +9,8 @@ Class {
 { #category : #meta }
 FamixStReference class >> annotation [
 
-	<FMClass: #Reference super: #MooseEntity>
+	<FMClass: #Reference super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixStReference class >> metamodel [
-
-	<generated>
-	^ FamixStModel metamodel
-]
-
-{ #category : #testing }
-FamixStReference >> isAccess [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isImplicitVariable [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isInheritance [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isNamespace [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isPackage [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixStReference >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -66,7 +66,6 @@ FamixPharoSmalltalkGenerator >> defineClasses [
 
 { #category : #initialization }
 FamixPharoSmalltalkGenerator >> defineHierarchy [
-
 	super defineHierarchy.
 
 	access --|> #TAccess.

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest1Association,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest1Entity,
 	#traits : 'FamixTAssociation',
 	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Test1-Entities-Entities'
@@ -9,50 +9,8 @@ Class {
 { #category : #meta }
 FamixTest1Association class >> annotation [
 
-	<FMClass: #Association super: #MooseEntity>
+	<FMClass: #Association super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest1Association class >> metamodel [
-
-	<generated>
-	^ FamixTest1Model metamodel
-]
-
-{ #category : #testing }
-FamixTest1Association >> isAttribute [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Association >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Association >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Association >> isStructuralEntity [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest1Association >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest2Inheritance,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest2Entity,
 	#traits : 'FamixTInheritance',
 	#classTraits : 'FamixTInheritance classTrait',
 	#category : #'Famix-Test2-Entities-Entities'
@@ -9,36 +9,8 @@ Class {
 { #category : #meta }
 FamixTest2Inheritance class >> annotation [
 
-	<FMClass: #Inheritance super: #MooseEntity>
+	<FMClass: #Inheritance super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest2Inheritance class >> metamodel [
-
-	<generated>
-	^ FamixTest2Model metamodel
-]
-
-{ #category : #testing }
-FamixTest2Inheritance >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Inheritance >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest2Inheritance >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest3Invocation,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest3Entity,
 	#traits : 'FamixTInvocation',
 	#classTraits : 'FamixTInvocation classTrait',
 	#category : #'Famix-Test3-Entities-Entities'
@@ -9,50 +9,8 @@ Class {
 { #category : #meta }
 FamixTest3Invocation class >> annotation [
 
-	<FMClass: #Invocation super: #MooseEntity>
+	<FMClass: #Invocation super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest3Invocation class >> metamodel [
-
-	<generated>
-	^ FamixTest3Model metamodel
-]
-
-{ #category : #testing }
-FamixTest3Invocation >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Invocation >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Invocation >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Invocation >> isReference [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Invocation >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Reference.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Reference.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest3Reference,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest3Entity,
 	#traits : 'FamixTReference',
 	#classTraits : 'FamixTReference classTrait',
 	#category : #'Famix-Test3-Entities-Entities'
@@ -9,50 +9,8 @@ Class {
 { #category : #meta }
 FamixTest3Reference class >> annotation [
 
-	<FMClass: #Reference super: #MooseEntity>
+	<FMClass: #Reference super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest3Reference class >> metamodel [
-
-	<generated>
-	^ FamixTest3Model metamodel
-]
-
-{ #category : #testing }
-FamixTest3Reference >> isAssociation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Reference >> isClass [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Reference >> isInvocation [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Reference >> isMethod [
-
-	<generated>
-	^ false
-]
-
-{ #category : #testing }
-FamixTest3Reference >> isType [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-Test5-Entities/FamixTest5AnnotationType1.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5AnnotationType1.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest5AnnotationType1,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest5Entity,
 	#traits : 'FamixTAnnotationType',
 	#classTraits : 'FamixTAnnotationType classTrait',
 	#category : #'Famix-Test5-Entities-Entities'
@@ -9,15 +9,8 @@ Class {
 { #category : #meta }
 FamixTest5AnnotationType1 class >> annotation [
 
-	<FMClass: #AnnotationType1 super: #MooseEntity>
+	<FMClass: #AnnotationType1 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest5AnnotationType1 class >> metamodel [
-
-	<generated>
-	^ FamixTest5Model metamodel
 ]

--- a/src/Famix-Test5-Entities/FamixTest5AnnotationType2.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5AnnotationType2.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest5AnnotationType2,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest5Entity,
 	#traits : 'FamixTAnnotationType',
 	#classTraits : 'FamixTAnnotationType classTrait',
 	#category : #'Famix-Test5-Entities-Entities'
@@ -9,15 +9,8 @@ Class {
 { #category : #meta }
 FamixTest5AnnotationType2 class >> annotation [
 
-	<FMClass: #AnnotationType2 super: #MooseEntity>
+	<FMClass: #AnnotationType2 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest5AnnotationType2 class >> metamodel [
-
-	<generated>
-	^ FamixTest5Model metamodel
 ]

--- a/src/Famix-Test5-Entities/FamixTest5Entity.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5Entity.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #FamixTest5Entity,
+	#superclass : #MooseEntity,
+	#category : #'Famix-Test5-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest5Entity class >> annotation [
+
+	<FMClass: #Entity super: #MooseEntity>
+	<package: #'Famix-Test5-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #meta }
+FamixTest5Entity class >> metamodel [
+
+	<generated>
+	^ FamixTest5Model metamodel
+]

--- a/src/Famix-Test5-Entities/FamixTest5WithAnnotationType1.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5WithAnnotationType1.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest5WithAnnotationType1,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest5Entity,
 	#traits : 'FamixTWithAnnotationTypes',
 	#classTraits : 'FamixTWithAnnotationTypes classTrait',
 	#category : #'Famix-Test5-Entities-Entities'
@@ -9,15 +9,8 @@ Class {
 { #category : #meta }
 FamixTest5WithAnnotationType1 class >> annotation [
 
-	<FMClass: #WithAnnotationType1 super: #MooseEntity>
+	<FMClass: #WithAnnotationType1 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest5WithAnnotationType1 class >> metamodel [
-
-	<generated>
-	^ FamixTest5Model metamodel
 ]

--- a/src/Famix-Test5-Entities/FamixTest5WithAnnotationType2.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5WithAnnotationType2.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTest5WithAnnotationType2,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTest5Entity,
 	#traits : 'FamixTWithAnnotationTypes',
 	#classTraits : 'FamixTWithAnnotationTypes classTrait',
 	#category : #'Famix-Test5-Entities-Entities'
@@ -9,15 +9,8 @@ Class {
 { #category : #meta }
 FamixTest5WithAnnotationType2 class >> annotation [
 
-	<FMClass: #WithAnnotationType2 super: #MooseEntity>
+	<FMClass: #WithAnnotationType2 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTest5WithAnnotationType2 class >> metamodel [
-
-	<generated>
-	^ FamixTest5Model metamodel
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -1,23 +1,16 @@
 Class {
 	#name : #FamixTestComposedCustomEntity1,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTestComposedEntity,
 	#category : #'Famix-TestComposedMetamodel-Entities-Entities'
 }
 
 { #category : #meta }
 FamixTestComposedCustomEntity1 class >> annotation [
 
-	<FMClass: #CustomEntity1 super: #MooseEntity>
+	<FMClass: #CustomEntity1 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTestComposedCustomEntity1 class >> metamodel [
-
-	<generated>
-	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }
@@ -71,11 +64,4 @@ FamixTestComposedCustomEntity1 >> customEntity1Group [
 	<generated>
 	<navigation: 'CustomEntity1'>
 	^ MooseGroup with: self customEntity1
-]
-
-{ #category : #testing }
-FamixTestComposedCustomEntity1 >> isAssociation [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -1,23 +1,16 @@
 Class {
 	#name : #FamixTestComposedCustomEntity2,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTestComposedEntity,
 	#category : #'Famix-TestComposedMetamodel-Entities-Entities'
 }
 
 { #category : #meta }
 FamixTestComposedCustomEntity2 class >> annotation [
 
-	<FMClass: #CustomEntity2 super: #MooseEntity>
+	<FMClass: #CustomEntity2 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTestComposedCustomEntity2 class >> metamodel [
-
-	<generated>
-	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #adding }
@@ -64,11 +57,4 @@ FamixTestComposedCustomEntity2 >> customEntities2: anObject [
 
 	<generated>
 	self customEntities2 value: anObject
-]
-
-{ #category : #testing }
-FamixTestComposedCustomEntity2 >> isAssociation [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -1,23 +1,16 @@
 Class {
 	#name : #FamixTestComposedCustomEntity3,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTestComposedEntity,
 	#category : #'Famix-TestComposedMetamodel-Entities-Entities'
 }
 
 { #category : #meta }
 FamixTestComposedCustomEntity3 class >> annotation [
 
-	<FMClass: #CustomEntity3 super: #MooseEntity>
+	<FMClass: #CustomEntity3 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTestComposedCustomEntity3 class >> metamodel [
-
-	<generated>
-	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #accessing }
@@ -50,11 +43,4 @@ FamixTestComposedCustomEntity3 >> customEntity3: anObject [
 
 	<generated>
 	self privateState attributeAt: #customEntity3 put: (FMMultivalueLink on: self update: #customEntities3 from: self customEntity3 to: anObject).
-]
-
-{ #category : #testing }
-FamixTestComposedCustomEntity3 >> isAssociation [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -1,23 +1,16 @@
 Class {
 	#name : #FamixTestComposedCustomEntity4,
-	#superclass : #MooseEntity,
+	#superclass : #FamixTestComposedEntity,
 	#category : #'Famix-TestComposedMetamodel-Entities-Entities'
 }
 
 { #category : #meta }
 FamixTestComposedCustomEntity4 class >> annotation [
 
-	<FMClass: #CustomEntity4 super: #MooseEntity>
+	<FMClass: #CustomEntity4 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #meta }
-FamixTestComposedCustomEntity4 class >> metamodel [
-
-	<generated>
-	^ FamixTestComposedModel metamodel
 ]
 
 { #category : #adding }
@@ -64,11 +57,4 @@ FamixTestComposedCustomEntity4 >> customEntities4: anObject [
 
 	<generated>
 	self customEntities4 value: anObject
-]
-
-{ #category : #testing }
-FamixTestComposedCustomEntity4 >> isAssociation [
-
-	<generated>
-	^ false
 ]

--- a/src/Famix-TestGenerators/FamixTest4Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest4Generator.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #FamixTest4Generator,
 	#superclass : #FamixMetamodelGenerator,
 	#instVars : [
-		'entity',
 		'book',
 		'person',
 		'principal',
@@ -43,10 +42,8 @@ FamixTest4Generator >> adoptBuilder: aBuilder [
 
 { #category : #definition }
 FamixTest4Generator >> defineClasses [
-
 	super defineClasses.
 
-	entity := builder newClassNamed: #Entity.
 	book := builder newClassNamed: #Book.
 	person := builder newClassNamed: #Person.
 	principal := builder newClassNamed: #Principal.
@@ -55,32 +52,25 @@ FamixTest4Generator >> defineClasses [
 	school := builder newClassNamed: #School.
 	room := builder newClassNamed: #Room.
 	classroom := builder newClassNamed: #Classroom.
-	cafeteria := builder newClassNamed: #Cafeteria.
-
-
+	cafeteria := builder newClassNamed: #Cafeteria
 ]
 
 { #category : #definition }
 FamixTest4Generator >> defineHierarchy [
 	super defineHierarchy.
 
-	book --|> entity.
-	person --|> entity.
 	principal --|> person.
 	student --|> person.
 	teacher --|> person.
-	school --|> entity.
-	room --|> entity.
 	classroom --|> room.
 	cafeteria --|> room
 ]
 
 { #category : #definition }
 FamixTest4Generator >> defineProperties [
-
 	super defineProperties.
 
-	entity property: #name type: #String.
+	(builder ensureClassNamed: #Entity) property: #name type: #String
 ]
 
 { #category : #definition }

--- a/src/Famix-TestGenerators/FamixTestComposedSubmetamodel1Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedSubmetamodel1Generator.class.st
@@ -50,12 +50,6 @@ FamixTestComposedSubmetamodel1Generator >> defineHierarchy [
 	method --|> namedEntity.
 	method --|> #TMethod.
 
-	customEntity1 --|> entity.
-	customEntity2 --|> entity.
-	customEntity3 --|> entity.
-	customEntity4 --|> entity.
-	customEntity5 --|> entity.
-
 	customEntity5 --|> #TEntityMetaLevelDependency.
 	customEntity5 --|> #TDependencyQueries
 ]

--- a/src/Famix-TestGenerators/FamixTestComposedSubmetamodel2Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedSubmetamodel2Generator.class.st
@@ -51,12 +51,6 @@ FamixTestComposedSubmetamodel2Generator >> defineHierarchy [
 	method --|> namedEntity.
 	method --|> #TMethod.
 
-	customEntity1 --|> entity.
-	customEntity2 --|> entity.
-	customEntity3 --|> entity.
-	customEntity4 --|> entity.
-	customEntity5 --|> entity.
-
 	customEntity5 --|> #TEntityMetaLevelDependency.
 	customEntity5 --|> #TDependencyQueries
 ]

--- a/src/Moose-Core/FamixDeprecatedSlot.class.st
+++ b/src/Moose-Core/FamixDeprecatedSlot.class.st
@@ -26,7 +26,7 @@ Class {
 	#instVars : [
 		'message'
 	],
-	#category : #'Famix-BasicInfrastructure'
+	#category : #'Moose-Core'
 }
 
 { #category : #accessing }

--- a/src/Moose-Core/FamixSlotDeprecation.class.st
+++ b/src/Moose-Core/FamixSlotDeprecation.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixSlotDeprecation,
 	#superclass : #Deprecation,
-	#category : #'Famix-BasicInfrastructure'
+	#category : #'Moose-Core'
 }
 
 { #category : #accessing }


### PR DESCRIPTION
Make XXXEntity the default super class

By convention, we are creating an entity XXXEntity for each MM.
Here I make things easier by making that the job of the generator.
The generator will set the root of each entities to a common class named Entity.

I also deprecate the now useless entity variable of FamixBasicInfrastructureGenerator.