### PR TITLE
introduce-unavailable-metric

### DIFF
--- a/src/Moose-Core/Magnitude.extension.st
+++ b/src/Moose-Core/Magnitude.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Magnitude }
+
+{ #category : #'*Moose-Core' }
+Magnitude >> addUnavailableMetric: aClass [
+	^ aClass
+]

--- a/src/Moose-Core/MooseUnavailableMetric.class.st
+++ b/src/Moose-Core/MooseUnavailableMetric.class.st
@@ -1,0 +1,43 @@
+"
+Description
+--------------------
+
+I am an object to represent an unavailable metric.
+
+This can happen if a model is missing a metric we cannot compute or if a computation ended in error.
+"
+Class {
+	#name : #MooseUnavailableMetric,
+	#superclass : #Object,
+	#category : #'Moose-Core'
+}
+
+{ #category : #arithmetic }
+MooseUnavailableMetric class >> + something [
+	^ something addUnavailableMetric: self
+]
+
+{ #category : #arithmetic }
+MooseUnavailableMetric class >> - aClass [ 
+	^ self
+]
+
+{ #category : #arithmetic }
+MooseUnavailableMetric class >> <= anObject [
+	^ false
+]
+
+{ #category : #arithmetic }
+MooseUnavailableMetric class >> adaptToNumber: anInteger andSend: aString [
+	^ self
+]
+
+{ #category : #arithmetic }
+MooseUnavailableMetric class >> addUnavailableMetric: aSYNUnavailableMetric [ 
+	^ self
+]
+
+{ #category : #arithmetic }
+MooseUnavailableMetric class >> asString [
+	^ 'unavailable'
+]


### PR DESCRIPTION
Introduce unavailable metric.

It is a metric aimed to be used when there is an error in a computation or when a metric is missing. 

It currently has no usage in Moose but I need it for projects that will soon be in Moose.