### PR TITLE
Add removeAll to MooseModel

### DIFF
--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -590,6 +590,20 @@ MooseModel >> remove: anElement [
 ]
 
 { #category : #'entity collection' }
+MooseModel >> removeAll [
+	"It may look ineficient.
+	However, it allows to remove all entities correctly. 
+	Setting the mooseModel of all entities at nil.
+	And we can iterate over the same collection (ie entityStorage)."
+	self entities
+		do: [ :anElement | 
+			anElement privateSetMooseModel: nil.
+			self privateState flushGroups.
+			self announcer announce: (MooseEntityRemoved new entity: anElement) ].
+	self entityStorage removeAll
+]
+
+{ #category : #'entity collection' }
 MooseModel >> removeAll: collection [ 
 	 collection do: [:each | self remove: each]. 
 ]

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -158,6 +158,20 @@ MooseModelTest >> testReferenceModel [
 ]
 
 { #category : #tests }
+MooseModelTest >> testRemoveAllEntity [
+	| mooseModel entity1 entity2 |
+	mooseModel := self actualClass new.
+	entity1 := MooseEntity new.
+	entity2 := MooseEntity new.
+	mooseModel add: entity1.
+	mooseModel add: entity2.
+	mooseModel removeAll.
+	self assert: mooseModel isEmpty.
+	self assert: entity1 mooseModel isNil.
+	self assert: entity2 mooseModel isNil
+]
+
+{ #category : #tests }
 MooseModelTest >> testRemoveAnnouncement [
 	| entity announcedEntity |
 	entity := MooseEntity new.
@@ -166,6 +180,17 @@ MooseModelTest >> testRemoveAnnouncement [
 	self assert: announcedEntity isNil.
 	group remove: entity.
 	self assert: announcedEntity identicalTo: entity
+]
+
+{ #category : #tests }
+MooseModelTest >> testRemoveEntity [
+	| mooseModel entity |
+	mooseModel := self actualClass new.
+	entity := MooseEntity new.
+	mooseModel add: entity.
+	mooseModel remove: entity.
+	self assert: mooseModel isEmpty.
+	self assert: entity mooseModel isNil
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Old behavior 

```
model := FASTJavaModel new name: #test2; yourself.
entity := FASTJavaMethodEntity new.

model add: entity.
model size = 1. "true"
entity mooseModel name. "#test2"

model removeAll. "an OrderedCollection()"
model size = 0. "true"

entity mooseModel. "a FASTJavaModel #test(0)"
```
expected behavior

```
model := FASTJavaModel new name: #test2; yourself.
entity := FASTJavaMethodEntity new.

model add: entity.
model size = 1. "true"
entity mooseModel name. "#test2"

model removeAll. "an OrderedCollection()"
model size = 0. "true"

entity mooseModel. "nil"
```