### PR TITLE
use-better-version-of-methods-with-alias

### DIFF
--- a/src/Fame-Core/FM3Property.class.st
+++ b/src/Fame-Core/FM3Property.class.st
@@ -95,12 +95,12 @@ FM3Property >> getRawFrom: element [
 
 { #category : #testing }
 FM3Property >> hasImplementingSelector [
-	^ self implementingSelector notNil
+	^ self implementingSelector isNotNil
 ]
 
 { #category : #testing }
 FM3Property >> hasOpposite [
-	^opposite notNil
+	^ opposite isNotNil
 ]
 
 { #category : #accessing }
@@ -168,7 +168,7 @@ FM3Property >> isDerived: anObject [
 
 { #category : #accessing }
 FM3Property >> isExtension [
-	^ self package notNil
+	^ self package isNotNil
 ]
 
 { #category : #testing }

--- a/src/Fame-Core/FMMultivalueLink.class.st
+++ b/src/Fame-Core/FMMultivalueLink.class.st
@@ -51,11 +51,11 @@ FMMultivalueLink class >> on: element opposite: oppositeSelector [
 { #category : #'instance creation' }
 FMMultivalueLink class >> on: element update: selector from: old to: new [
 	"refresh the other side of the relations to reflect change in value"
-	
-	old ~= new ifTrue: [
-		old notNil ifTrue: [ (old perform: selector) unsafeRemove: element ].
-		new notNil ifTrue: [ (new perform: selector) unsafeAdd: element ]].
-	^new
+
+	old ~= new
+		ifTrue: [ old isNotNil ifTrue: [ (old perform: selector) unsafeRemove: element ].
+			new isNotNil ifTrue: [ (new perform: selector) unsafeAdd: element ] ].
+	^ new
 ]
 
 { #category : #copying }

--- a/src/Fame-Example/RPGHero.class.st
+++ b/src/Fame-Example/RPGHero.class.st
@@ -41,11 +41,12 @@ RPGHero >> talisman [
 
 { #category : #accessing }
 RPGHero >> talisman: aTreasure [
-	talisman ~= aTreasure ifTrue: [ | old |
-		old := talisman.
-		talisman := aTreasure.
-		old notNil ifTrue: [ old owner: nil ].
-		aTreasure notNil ifTrue: [ aTreasure owner: self ]]
+	talisman ~= aTreasure
+		ifTrue: [ | old |
+			old := talisman.
+			talisman := aTreasure.
+			old isNotNil ifTrue: [ old owner: nil ].
+			aTreasure isNotNil ifTrue: [ aTreasure owner: self ] ]
 ]
 
 { #category : #accessing }
@@ -57,9 +58,10 @@ RPGHero >> twin [
 
 { #category : #accessing }
 RPGHero >> twin: aHero [
-	twin ~= aHero ifTrue: [ | old |
-		old := twin.
-		twin := aHero.
-		old notNil ifTrue: [ old twin: nil ].
-		aHero notNil ifTrue: [ aHero twin: self ]]
+	twin ~= aHero
+		ifTrue: [ | old |
+			old := twin.
+			twin := aHero.
+			old isNotNil ifTrue: [ old twin: nil ].
+			aHero isNotNil ifTrue: [ aHero twin: self ] ]
 ]

--- a/src/Fame-Example/RPGTreasure.class.st
+++ b/src/Fame-Example/RPGTreasure.class.st
@@ -36,9 +36,10 @@ RPGTreasure >> owner [
 
 { #category : #accessing }
 RPGTreasure >> owner: aHero [
-	owner ~= aHero ifTrue: [ | old |
-		old := owner.
-		owner := aHero.
-		old notNil ifTrue: [ old talisman: nil ].
-		aHero notNil ifTrue: [ aHero talisman: self ]]
+	owner ~= aHero
+		ifTrue: [ | old |
+			old := owner.
+			owner := aHero.
+			old isNotNil ifTrue: [ old talisman: nil ].
+			aHero isNotNil ifTrue: [ aHero talisman: self ] ]
 ]

--- a/src/Fame-GT/FM3Class.extension.st
+++ b/src/Fame-GT/FM3Class.extension.st
@@ -9,10 +9,13 @@ FM3Class >> gtInspectorPropertiesIn: composite [
 		sorted: [ :attribute1 :attribute2 | attribute1 name < attribute2 name ];
 		column: 'name'
 			evaluated: [ :each | each name ]
-			tags: [ :each :aFM3Class | each mmClass ~= aFM3Class ifTrue: [ each mmClass name ] ifFalse: [ OrderedCollection new ] ];
+			tags: [ :each :aFM3Class | 
+			each mmClass ~= aFM3Class
+				ifTrue: [ each mmClass name ]
+				ifFalse: [ OrderedCollection new ] ];
 		column: 'type' evaluated: [ :each | each gtTypeString ];
 		column: 'derived?' evaluated: [ :each | each isDerived ] width: 50;
-		when: [ self allComplexProperties notEmpty ];
+		when: [ self allComplexProperties isNotEmpty ];
 		morphicSelectionAct: [ :list | Smalltalk tools browser openOnClass: list selection implementingClass selector: list selection implementingSelector ]
 			icon: GLMUIThemeExtraIcons glamorousBrowse
 			on: $b
@@ -23,33 +26,36 @@ FM3Class >> gtInspectorPropertiesIn: composite [
 { #category : #'*Fame-GT' }
 FM3Class >> gtInspectorRelationsIn: composite [
 	<gtInspectorPresentationOrder: 0>
-	^ composite table 
-			title: [ self allComplexProperties size asString , ' Relations' translated ]; 
-			display: [ self allComplexProperties ]; sorted: [ :attribute1 :attribute2 | attribute1 name < attribute2 name ]; 
-			column: 'name'
+	^ composite table
+		title: [ self allComplexProperties size asString , ' Relations' translated ];
+		display: [ self allComplexProperties ];
+		sorted: [ :attribute1 :attribute2 | attribute1 name < attribute2 name ];
+		column: 'name'
 			evaluated: [ :each | each name ]
 			tags: [ :each :aFM3Class | 
 			each mmClass ~= aFM3Class
 				ifTrue: [ each mmClass name ]
-				ifFalse: [ OrderedCollection new ] ]; column: 'type'
-			evaluated: [ :each | each gtTypeString ]; column: 'opposite'
-			evaluated: [ :each | each opposite ifNil: [ '' ] ifNotNil: [ :opposite | opposite name ] ]; 
-			column: 'derived?'
-			evaluated: [ :each | each isDerived ]
-			width: 50; column: 'container?' evaluated: [ :each | each isContainer ] width: 50; 
-			column: 'isTarget?'
-			evaluated: [ :each | each isTarget ]
-			width: 50; column: 'isSource?' evaluated: [ :each | each isSource ] width: 50; when: [ self allComplexProperties notEmpty ]; 
-			selectionPopulate: #selection
+				ifFalse: [ OrderedCollection new ] ];
+		column: 'type' evaluated: [ :each | each gtTypeString ];
+		column: 'opposite'
+			evaluated: [ :each | 
+			each opposite
+				ifNil: [ '' ]
+				ifNotNil: [ :opposite | opposite name ] ];
+		column: 'derived?' evaluated: [ :each | each isDerived ] width: 50;
+		column: 'container?' evaluated: [ :each | each isContainer ] width: 50;
+		column: 'isTarget?' evaluated: [ :each | each isTarget ] width: 50;
+		column: 'isSource?' evaluated: [ :each | each isSource ] width: 50;
+		when: [ self allComplexProperties isNotEmpty ];
+		selectionPopulate: #selection
 			on: $o
 			entitled: 'Open opposite'
-			with: [ :list | list selection opposite ]; morphicSelectionAct: [ :list | 
-				Smalltalk tools browser
-					openOnClass: list selection implementingClass
-					selector: list selection implementingSelector ]
+			with: [ :list | list selection opposite ];
+		morphicSelectionAct: [ :list | Smalltalk tools browser openOnClass: list selection implementingClass selector: list selection implementingSelector ]
 			icon: GLMUIThemeExtraIcons glamorousBrowse
 			on: $b
-			entitled: 'Browse implementation'; morphicSelectionAct: [ :list | list selection inspect ]
+			entitled: 'Browse implementation';
+		morphicSelectionAct: [ :list | list selection inspect ]
 			icon: GLMUIThemeExtraIcons glamorousInspect
 			on: $i
 			entitled: 'Inspect'

--- a/src/Fame-Tests/FMEquationSystemExample.class.st
+++ b/src/Fame-Tests/FMEquationSystemExample.class.st
@@ -68,7 +68,7 @@ FMEquationSystemExample >> setUp [
 
 { #category : #tests }
 FMEquationSystemExample >> testAllSubclasses [
-	self assert: (metaModel elementNamed: 'EQ.Expression') notNil.
+	self assert: (metaModel elementNamed: 'EQ.Expression') isNotNil.
 	self assert: (metaModel elementNamed: 'EQ.Expression') allSubclasses size equals: 4
 ]
 
@@ -82,7 +82,7 @@ FMEquationSystemExample >> testMetamodel [
 
 { #category : #tests }
 FMEquationSystemExample >> testMetamodelContainsCompound [
-	self assert: (metaModel elementNamed: 'EQ.Compound') notNil
+	self assert: (metaModel elementNamed: 'EQ.Compound') isNotNil
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMImporterTest.class.st
+++ b/src/Fame-Tests/FMImporterTest.class.st
@@ -169,10 +169,10 @@ FMImporterTest >> testResolvingMultiArgs [
 	ref2 := pack classNamed: 'MyName2'.
 	ref4 := pack classNamed: 'MyName4'.
 	ref5 := pack classNamed: 'MyName5'.
-	self assert: pack notNil.
-	self assert: ref2 notNil.
-	self assert: ref4 notNil.
-	self assert: ref5 notNil.
+	self assert: pack isNotNil.
+	self assert: ref2 isNotNil.
+	self assert: ref4 isNotNil.
+	self assert: ref5 isNotNil.
 	self assert: (pack classes includes: ref2).
 	self assert: (pack classes includes: ref4).
 	self assert: (pack classes includes: ref5)

--- a/src/Fame-Tests/FMJSONParserTest.class.st
+++ b/src/Fame-Tests/FMJSONParserTest.class.st
@@ -728,7 +728,7 @@ FMJSONParserTest >> testFamixModel [
 	accessorProperty := accessClass propertyNamed: 'accessor'.
 	self assert: accessorProperty isFM3Property.
 	self assert: accessorProperty name equals: #accessor.
-	self assert: accessorProperty opposite notNil.
+	self assert: accessorProperty opposite isNotNil.
 	behaviouralEntity := famixPackage classNamed: 'BehaviouralEntity'.
 	self assert: behaviouralEntity isFM3Class.
 	outgoingAccesses := behaviouralEntity propertyNamed: 'outgoingAccesses'.

--- a/src/Fame-Tests/FMLibraryExample.class.st
+++ b/src/Fame-Tests/FMLibraryExample.class.st
@@ -43,7 +43,7 @@ FMLibraryExample >> testBookstore2 [
 	class := package classNamed: 'Book'.
 	self assert: class isFM3Class.	"The superclass of Book should be Object"
 	objectMetaDescription := class superclass.
-	self assert: objectMetaDescription notNil.
+	self assert: objectMetaDescription isNotNil.
 	self assert: objectMetaDescription name equals: #Object.
 	attribute := class propertyNamed: 'authors'.
 	self assert: attribute isFM3Property.
@@ -54,7 +54,7 @@ FMLibraryExample >> testBookstore2 [
 	self flag: 'Maybe we should rename package to extensionPackage, and make package be derived from [ package or class package ].'.
 	self assert: attribute mmClass equals: class.
 	self assert: attribute type equals: (package classNamed: 'Person').
-	self assert: attribute opposite notNil
+	self assert: attribute opposite isNotNil
 ]
 
 { #category : #tests }
@@ -84,21 +84,21 @@ FMLibraryExample >> testMetamodelSmalltalkBinding [
 	self assert: metamodel classes anyOne isFM3Class.
 	self assert: metamodel properties anyOne isFM3Property.
 	b := metamodel elementNamed: 'LIB.Book'.
-	self assert: b notNil.
+	self assert: b isNotNil.
 	self assert: b isFM3Class.
 	self assert: b name equals: #Book.
 	self assert: b package name equals: #LIB.
 	self assert: b properties size equals: 2.
 	self assert: b implementingClass equals: LIBBook.
 	p := metamodel elementNamed: 'LIB.Person'.
-	self assert: p notNil.
+	self assert: p isNotNil.
 	self assert: p isFM3Class.
 	self assert: p name equals: #Person.
 	self assert: p package name equals: #LIB.
 	self assert: p properties size equals: 2.
 	self assert: p implementingClass equals: LIBPerson.
 	lib := metamodel elementNamed: 'LIB.Library'.
-	self assert: lib notNil.
+	self assert: lib isNotNil.
 	self assert: lib isFM3Class.
 	self assert: lib name equals: #Library.
 	self assert: lib package name equals: #LIB.

--- a/src/Fame-Tests/FMMSEParserTest.class.st
+++ b/src/Fame-Tests/FMMSEParserTest.class.st
@@ -633,7 +633,7 @@ FMMSEParserTest >> testFamixModel [
 	accessorProperty := accessClass propertyNamed: 'accessor'.
 	self assert: accessorProperty isFM3Property.
 	self assert: accessorProperty name equals: #accessor.
-	self assert: accessorProperty opposite notNil.
+	self assert: accessorProperty opposite isNotNil.
 	behaviouralEntity := famixPackage classNamed: 'BehaviouralEntity'.
 	self assert: behaviouralEntity isFM3Class.
 	outgoingAccesses := behaviouralEntity propertyNamed: 'outgoingAccesses'.

--- a/src/Fame-Tests/FMMetaModelTest.class.st
+++ b/src/Fame-Tests/FMMetaModelTest.class.st
@@ -48,8 +48,8 @@ FMMetaModelTest >> testDescriptionOfIfPresentIfAbsent [
 FMMetaModelTest >> testElementNamed [
 	| metamodel |
 	metamodel := FMMetaModel fromString: '((FM3.Package (name ''EG'') (classes (FM3.Class (name ''Boe'')))))'.
-	self assert: (metamodel elementNamed: 'EG') notNil.
-	self assert: (metamodel elementNamed: 'EG.Boe') notNil
+	self assert: (metamodel elementNamed: 'EG') isNotNil.
+	self assert: (metamodel elementNamed: 'EG.Boe') isNotNil
 ]
 
 { #category : #tests }

--- a/src/Fame-Tests/FMMetamodelBuilderTest.class.st
+++ b/src/Fame-Tests/FMMetamodelBuilderTest.class.st
@@ -84,7 +84,7 @@ FMMetaModelBuilderTest >> testSimple [
 	self assert: elements size equals: originalSize + 1.
 	props := rep properties.
 	self assert: props size equals: 1.
-	self assert: props anyOne mmClass notNil.
+	self assert: props anyOne mmClass isNotNil.
 	self assert: (elements includes: props anyOne mmClass).
 	mmClass := props anyOne mmClass.
 	self assert: mmClass name equals: #FMAnnotationTest.

--- a/src/Fame-Tests/FMMetamodelScripterTest.class.st
+++ b/src/Fame-Tests/FMMetamodelScripterTest.class.st
@@ -17,11 +17,11 @@ FMMetamodelScripterTest >> setUp [
 { #category : #tests }
 FMMetamodelScripterTest >> testClasses [
 	self assert: metamodel classes size equals: 3.
-	self assert: (metamodel elementNamed: 'RPG.Dragon') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Dragon') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Dragon') isFM3Class.
-	self assert: (metamodel elementNamed: 'RPG.Treasure') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Treasure') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Treasure') isFM3Class.
-	self assert: (metamodel elementNamed: 'RPG.Hero') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Hero') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Hero') isFM3Class
 ]
 
@@ -83,18 +83,18 @@ FMMetamodelScripterTest >> testPackages [
 { #category : #tests }
 FMMetamodelScripterTest >> testProperties [
 	self assert: metamodel properties size equals: 7.
-	self assert: (metamodel elementNamed: 'RPG.Dragon.hoard') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Dragon.hoard') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Dragon.hoard') isFM3Property.
-	self assert: (metamodel elementNamed: 'RPG.Dragon.killedBy') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Dragon.killedBy') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Dragon.killedBy') isFM3Property.
-	self assert: (metamodel elementNamed: 'RPG.Treasure.keeper') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Treasure.keeper') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Treasure.keeper') isFM3Property.
-	self assert: (metamodel elementNamed: 'RPG.Treasure.owner') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Treasure.owner') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Treasure.owner') isFM3Property.
-	self assert: (metamodel elementNamed: 'RPG.Hero.twin') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Hero.twin') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Hero.twin') isFM3Property.
-	self assert: (metamodel elementNamed: 'RPG.Hero.kills') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Hero.kills') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Hero.kills') isFM3Property.
-	self assert: (metamodel elementNamed: 'RPG.Hero.talisman') notNil.
+	self assert: (metamodel elementNamed: 'RPG.Hero.talisman') isNotNil.
 	self assert: (metamodel elementNamed: 'RPG.Hero.talisman') isFM3Property
 ]

--- a/src/Fame-Tests/FMMultivalueLinkTest.class.st
+++ b/src/Fame-Tests/FMMultivalueLinkTest.class.st
@@ -9,9 +9,9 @@ FMMultivalueLinkTest >> testBookPerson [
 	| book person |
 	book := LIBBook new.
 	person := LIBPerson new.
-	self assert: book authors notNil.
+	self assert: book authors isNotNil.
 	self assert: book authors isCollection.
-	self assert: person books notNil.
+	self assert: person books isNotNil.
 	self assert: person books isCollection.
 	book authors add: person.
 	self assert: book authors size equals: 1.
@@ -25,7 +25,7 @@ FMMultivalueLinkTest >> testClassPackage [
 	| package meta |
 	package := FM3Package new.
 	meta := FM3Class new.
-	self assert: package classes notNil.
+	self assert: package classes isNotNil.
 	self assert: package classes isCollection.
 	self assert: meta package isNil.
 	meta package: package.
@@ -39,7 +39,7 @@ FMMultivalueLinkTest >> testClassProperty [
 	| meta prop |
 	meta := FM3Class new.
 	prop := FM3Property new.
-	self assert: meta properties notNil.
+	self assert: meta properties isNotNil.
 	self assert: meta properties isCollection.
 	self assert: prop mmClass isNil.
 	meta properties add: prop.
@@ -89,7 +89,7 @@ FMMultivalueLinkTest >> testPackageClass [
 	| package meta |
 	package := FM3Package new.
 	meta := FM3Class new.
-	self assert: package classes notNil.
+	self assert: package classes isNotNil.
 	self assert: package classes isCollection.
 	self assert: meta package isNil.
 	package classes add: meta.
@@ -103,7 +103,7 @@ FMMultivalueLinkTest >> testPackageProperty [
 	| package prop |
 	package := FM3Package new.
 	prop := FM3Property new.
-	self assert: package extensions notNil.
+	self assert: package extensions isNotNil.
 	self assert: package extensions isCollection.
 	self assert: prop package isNil.
 	package extensions add: prop.
@@ -117,9 +117,9 @@ FMMultivalueLinkTest >> testPersonBook [
 	| book person |
 	book := LIBBook new.
 	person := LIBPerson new.
-	self assert: book authors notNil.
+	self assert: book authors isNotNil.
 	self assert: book authors isCollection.
-	self assert: person books notNil.
+	self assert: person books isNotNil.
 	self assert: person books isCollection.
 	person books add: book.
 	self assert: book authors size equals: 1.
@@ -133,7 +133,7 @@ FMMultivalueLinkTest >> testPropertyClass [
 	| meta prop |
 	meta := FM3Class new.
 	prop := FM3Property new.
-	self assert: meta properties notNil.
+	self assert: meta properties isNotNil.
 	self assert: meta properties isCollection.
 	self assert: prop mmClass isNil.
 	prop mmClass: meta.
@@ -147,7 +147,7 @@ FMMultivalueLinkTest >> testPropertyPackage [
 	| package prop |
 	package := FM3Package new.
 	prop := FM3Property new.
-	self assert: package extensions notNil.
+	self assert: package extensions isNotNil.
 	self assert: package extensions isCollection.
 	self assert: prop package isNil.
 	prop package: package.

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstance.class.st
@@ -17,16 +17,12 @@ FAMIXAnnotationInstance class >> annotation [
 
 { #category : #accessing }
 FAMIXAnnotationInstance >> mooseNameOn: aStream [
-	self annotationType notNil ifTrue: [
-		self annotationType mooseNameOn: aStream ].
+	self annotationType isNotNil ifTrue: [ self annotationType mooseNameOn: aStream ].
 	aStream nextPut: $(.
-	self attributes 
-			do: [:each | aStream nextPutAll: each value asString ]
-			separatedBy: [aStream nextPut: $,].  
+	self attributes do: [ :each | aStream nextPutAll: each value asString ] separatedBy: [ aStream nextPut: $, ].
 	aStream nextPut: $).
 	aStream nextPut: $-.
-	self annotatedEntity notNil ifTrue: [
-		self annotatedEntity mooseNameOn: aStream ]
+	self annotatedEntity isNotNil ifTrue: [ self annotatedEntity mooseNameOn: aStream ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAnnotationInstanceAttribute.class.st
@@ -16,8 +16,8 @@ FAMIXAnnotationInstanceAttribute class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FAMIXAnnotationInstanceAttribute >> name [ 
-	^ self annotationTypeAttribute notNil 
+FAMIXAnnotationInstanceAttribute >> name [
+	^ self annotationTypeAttribute isNotNil
 		ifTrue: [ self annotationTypeAttribute name ]
 		ifFalse: [ nil ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXComment.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXComment.class.st
@@ -30,15 +30,14 @@ FAMIXComment >> belongsTo [
 FAMIXComment >> gtDisplayOn: aStream [
 	| preview |
 	preview := self sourceText truncateWithElipsisTo: 10.
-	preview := preview copyReplaceAll: (String with: Character cr with: Character lf) with: ' '.	
-	preview := preview copyReplaceAll: (String with: Character cr) with: ' '.	
+	preview := preview copyReplaceAll: (String with: Character cr with: Character lf) with: ' '.
+	preview := preview copyReplaceAll: (String with: Character cr) with: ' '.
 	preview := preview copyReplaceAll: (String with: Character lf) with: ' '.
-	aStream 
+	aStream
 		nextPut: $";
 		nextPutAll: preview;
 		nextPutAll: '" in '.
-	self belongsTo notNil ifTrue: [
-		self belongsTo gtDisplayOn: aStream ]
+	self belongsTo isNotNil ifTrue: [ self belongsTo gtDisplayOn: aStream ]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXException.class.st
@@ -42,8 +42,8 @@ FAMIXException >> definingMethod: aMethod [
 ]
 
 { #category : #accessing }
-FAMIXException >> mooseNameOn: aStream [ 
+FAMIXException >> mooseNameOn: aStream [
 	aStream nextPutAll: (self class name withoutPrefix: 'FAMIX').
 	aStream nextPut: $-.
-	self exceptionClass notNil ifTrue: [self exceptionClass mooseNameOn: aStream]
+	self exceptionClass isNotNil ifTrue: [ self exceptionClass mooseNameOn: aStream ]
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -78,10 +78,10 @@ FAMIXInvocation >> isAPotentialInvocation [
 { #category : #'Famix-Extensions-testing' }
 FAMIXInvocation >> isASureInvocation [
 	"Test if the receiver (an invocation) is sure (i.e. we know for sure the class of the invocation's receiver)"
+
 	| invoRVar |
 	invoRVar := self receiver.
-	^(invoRVar notNil) and: 
-			[invoRVar class = FAMIXClass or: [invoRVar isImplicitVariable and: [invoRVar isSelf or: [invoRVar isSuper]]]]
+	^ invoRVar isNotNil and: [ invoRVar class = FAMIXClass or: [ invoRVar isImplicitVariable and: [ invoRVar isSelf or: [ invoRVar isSuper ] ] ] ]
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -215,25 +215,16 @@ FAMIXMethod >> isOverriding [
 ]
 
 { #category : #'Famix-Extensions-InvocationTesting' }
-FAMIXMethod >> isSurelyInvokedBy: aFAMIXMethod [ 
-	 
+FAMIXMethod >> isSurelyInvokedBy: aFAMIXMethod [
 	| outgoingInvo |
-
-	((self isAbstract or: [aFAMIXMethod isAbstract]) 
-		or: [(outgoingInvo := aFAMIXMethod queryAllOutgoingInvocations) isEmpty])
-		ifFalse: 
-			[
-			(outgoingInvo do:[:invo |
-				(invo signature = self signature and: [invo isASureInvocation]) ifTrue:[
-					| invocationRVar | 
-					invocationRVar := invo getReceivingFAMIXClass. 
-					(invocationRVar notNil 
-						and: [(invocationRVar lookUp: self signature) = self]) 
-							ifTrue:[^true]
-				]
-			]).
-		].
-	^false
+	((self isAbstract or: [ aFAMIXMethod isAbstract ]) or: [ (outgoingInvo := aFAMIXMethod queryAllOutgoingInvocations) isEmpty ])
+		ifFalse: [ outgoingInvo
+				do: [ :invo | 
+					(invo signature = self signature and: [ invo isASureInvocation ])
+						ifTrue: [ | invocationRVar |
+							invocationRVar := invo getReceivingFAMIXClass.
+							(invocationRVar isNotNil and: [ (invocationRVar lookUp: self signature) = self ]) ifTrue: [ ^ true ] ] ] ].
+	^ false
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXParameterizedType.class.st
@@ -37,13 +37,9 @@ FAMIXParameterizedType >> isParameterizedType [
 ]
 
 { #category : #printing }
-FAMIXParameterizedType >> mooseNameOn: aStream [ 
-	self parameterizableClass notNil 
-		ifTrue: [self parameterizableClass mooseNameOn: aStream].
+FAMIXParameterizedType >> mooseNameOn: aStream [
+	self parameterizableClass isNotNil ifTrue: [ self parameterizableClass mooseNameOn: aStream ].
 	aStream nextPut: $<.
-	self arguments 
-		do: [:each | each mooseNameOn: aStream]
-		separatedBy: [aStream nextPut: $,].  
-	aStream nextPut: $>.  
-
+	self arguments do: [ :each | each mooseNameOn: aStream ] separatedBy: [ aStream nextPut: $, ].
+	aStream nextPut: $>
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXType.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXType.class.st
@@ -33,7 +33,7 @@ FAMIXType >> allAnnotationTypes [
 { #category : #'Famix-Implementation' }
 FAMIXType >> allSuperclassesDo: aBlock [
 	self allSuperclassesWithoutAliasesDo: aBlock.
-	(self mooseModel sourceLanguage notNil and: [self mooseModel sourceLanguage isC])
+	(self mooseModel sourceLanguage isNotNil and: [ self mooseModel sourceLanguage isC ])
 		ifTrue: [ self typeAliases do: [ :each | each allSuperclassesWithoutAliasesDo: aBlock ] ]
 ]
 
@@ -157,10 +157,7 @@ FAMIXType >> isAbstract [
 
 { #category : #'Famix-Java' }
 FAMIXType >> isAnonymousClass [
-	^  self container notNil and: [
-			self container isMethod or: [
-				self name isAllDigits or: [
-					'*_anonymous_*' match: self name ]] ]
+	^ self container isNotNil and: [ self container isMethod or: [ self name isAllDigits or: [ '*_anonymous_*' match: self name ] ] ]
 ]
 
 { #category : #'Famix-Extensions' }
@@ -263,7 +260,7 @@ FAMIXType >> localMethods [
 ]
 
 { #category : #'Famix-Extensions-operations' }
-FAMIXType >> lookUp: aMethodSignature [ 
+FAMIXType >> lookUp: aMethodSignature [
 	"Returns the first method that has as signature #aMethodSignature. 
 	The search starts from the receiver's methods and traveses the inherited methods from the receiver's superclasses heirarchy.
 	If such a method has not been found, it returns nil"
@@ -272,15 +269,14 @@ FAMIXType >> lookUp: aMethodSignature [
 	c := self.
 	searchedM := nil.
 	toSearchIt := true.
-	[c notNil and: [toSearchIt]] whileTrue: 
-			[searchedM := c methods 
-						detect: [:m | m signature = aMethodSignature]
-						ifNone: [nil].
+	[ c isNotNil and: [ toSearchIt ] ]
+		whileTrue: [ searchedM := c methods
+				detect: [ :m | m signature = aMethodSignature ]
+				ifNone: [ nil ].
 			searchedM
-				ifNil: [c := c superclass]
-				ifNotNil: [toSearchIt := false]
-			].
-	^searchedM
+				ifNil: [ c := c superclass ]
+				ifNotNil: [ toSearchIt := false ] ].
+	^ searchedM
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Compatibility-Entities/MooseModel.extension.st
+++ b/src/Famix-Compatibility-Entities/MooseModel.extension.st
@@ -39,5 +39,5 @@ MooseModel >> inferNamespaceParentsBasedOnNames [
 
 { #category : #'*Famix-Compatibility-Entities' }
 MooseModel >> isSmalltalk [
-	^ self sourceLanguage notNil and: [self sourceLanguage isSmalltalk]
+	^ self sourceLanguage isNotNil and: [ self sourceLanguage isSmalltalk ]
 ]

--- a/src/Famix-Compatibility-Tests-C/FAMIXCImporting2Test.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCImporting2Test.class.st
@@ -70,12 +70,12 @@ FAMIXCImporting2Test >> testCompilationUnitIncludes [
 	self skip: 'Test skipped until C metamodel definition'.
 	cu := model entities detect: [ :e | e class == FAMIXCompilationUnit ].
 	header := model entities detect: [ :e | e class == FAMIXHeader ].
-	self assert: cu notNil.
+	self assert: cu isNotNil.
 	self assert: cu name equals: 'example.cpp'.
 	self assert: cu numberOfIncludes equals: 1.
 	self assert: cu outgoingIncludeRelations size equals: 1.
-	self assert: cu outgoingIncludeRelations anyOne notNil.
+	self assert: cu outgoingIncludeRelations anyOne isNotNil.
 	self assert: cu outgoingIncludeRelations anyOne class equals: FAMIXInclude.
 	self assert: cu outgoingIncludeRelations anyOne from equals: cu.
-	self assert: cu outgoingIncludeRelations anyOne to equals: header.
+	self assert: cu outgoingIncludeRelations anyOne to equals: header
 ]

--- a/src/Famix-Compatibility-Tests-C/FAMIXCImportingTest.class.st
+++ b/src/Famix-Compatibility-Tests-C/FAMIXCImportingTest.class.st
@@ -68,7 +68,7 @@ FAMIXCImportingTest >> testCompilationUnitIncludes [
 	| cu |
 	self skip: 'Test skipped until C metamodel definition'.
 	cu := model entities detect: [ :e | e class == FAMIXCompilationUnit ].
-	self assert: cu notNil.
+	self assert: cu isNotNil.
 	self assert: cu name equals: 'foobar.cpp'.
 	self assert: cu numberOfIncludes equals: 2
 ]
@@ -100,6 +100,6 @@ FAMIXCImportingTest >> testModuleHasCompilationUnit [
 	self skip: 'Test skipped until C metamodel definition'.
 	module := model entities detect: [ :e | e class == FAMIXModule ].
 	cu := module compilationUnit.
-	self assert: cu notNil.
+	self assert: cu isNotNil.
 	self assert: cu name equals: 'foobar.cpp'
 ]

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -17,16 +17,12 @@ FamixJavaAnnotationInstance class >> annotation [
 
 { #category : #'as yet unclassified' }
 FamixJavaAnnotationInstance >> mooseNameOn: aStream [
-	self annotationType notNil ifTrue: [
-		self annotationType mooseNameOn: aStream ].
+	self annotationType isNotNil ifTrue: [ self annotationType mooseNameOn: aStream ].
 	aStream nextPut: $(.
-	self attributes 
-			do: [:each | aStream nextPutAll: each value asString ]
-			separatedBy: [aStream nextPut: $,].  
+	self attributes do: [ :each | aStream nextPutAll: each value asString ] separatedBy: [ aStream nextPut: $, ].
 	aStream nextPut: $).
 	aStream nextPut: $-.
-	self annotatedEntity notNil ifTrue: [
-		self annotatedEntity mooseNameOn: aStream ]
+	self annotatedEntity isNotNil ifTrue: [ self annotatedEntity mooseNameOn: aStream ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -16,8 +16,8 @@ FamixJavaAnnotationInstanceAttribute class >> annotation [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaAnnotationInstanceAttribute >> name [ 
-	^ self annotationTypeAttribute notNil 
+FamixJavaAnnotationInstanceAttribute >> name [
+	^ self annotationTypeAttribute isNotNil
 		ifTrue: [ self annotationTypeAttribute name ]
 		ifFalse: [ nil ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -30,15 +30,14 @@ FamixJavaComment >> belongsTo [
 FamixJavaComment >> gtDisplayOn: aStream [
 	| preview |
 	preview := self sourceText truncateWithElipsisTo: 10.
-	preview := preview copyReplaceAll: (String with: Character cr with: Character lf) with: ' '.	
-	preview := preview copyReplaceAll: (String with: Character cr) with: ' '.	
+	preview := preview copyReplaceAll: (String with: Character cr with: Character lf) with: ' '.
+	preview := preview copyReplaceAll: (String with: Character cr) with: ' '.
 	preview := preview copyReplaceAll: (String with: Character lf) with: ' '.
-	aStream 
+	aStream
 		nextPut: $";
 		nextPutAll: preview;
 		nextPutAll: '" in '.
-	self belongsTo notNil ifTrue: [
-		self belongsTo gtDisplayOn: aStream ]
+	self belongsTo isNotNil ifTrue: [ self belongsTo gtDisplayOn: aStream ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -16,8 +16,8 @@ FamixJavaException class >> annotation [
 ]
 
 { #category : #accessing }
-FamixJavaException >> mooseNameOn: aStream [ 
+FamixJavaException >> mooseNameOn: aStream [
 	aStream nextPutAll: (self class name withoutPrefix: 'FamixJava').
 	aStream nextPut: $-.
-	self exceptionClass notNil ifTrue: [self exceptionClass mooseNameOn: aStream]
+	self exceptionClass isNotNil ifTrue: [ self exceptionClass mooseNameOn: aStream ]
 ]

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -78,10 +78,10 @@ FamixJavaInvocation >> isAPotentialInvocation [
 { #category : #'as yet unclassified' }
 FamixJavaInvocation >> isASureInvocation [
 	"Test if the receiver (an invocation) is sure (i.e. we know for sure the class of the invocation's receiver)"
+
 	| invoRVar |
 	invoRVar := self receiver.
-	^(invoRVar notNil) and: 
-			[invoRVar class = FamixJavaClass or: [invoRVar isImplicitVariable and: [invoRVar isSelf or: [invoRVar isSuper]]]]
+	^ invoRVar isNotNil and: [ invoRVar class = FamixJavaClass or: [ invoRVar isImplicitVariable and: [ invoRVar isSelf or: [ invoRVar isSuper ] ] ] ]
 ]
 
 { #category : #testing }

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -181,30 +181,20 @@ FamixJavaMethod >> isOverriding [
 
 { #category : #printing }
 FamixJavaMethod >> isStub [
-	^ super isStub
-		or: [ self parentType notNil and: [ self parentType isStub ] ]
+	^ super isStub or: [ self parentType isNotNil and: [ self parentType isStub ] ]
 ]
 
 { #category : #testing }
-FamixJavaMethod >> isSurelyInvokedBy: aFAMIXMethod [ 
-	 
+FamixJavaMethod >> isSurelyInvokedBy: aFAMIXMethod [
 	| outgoingInvo |
-
-	((self isAbstract or: [aFAMIXMethod isAbstract]) 
-		or: [(outgoingInvo := aFAMIXMethod queryAllOutgoingInvocations) isEmpty])
-		ifFalse: 
-			[
-			(outgoingInvo do:[:invo |
-				(invo signature = self signature and: [invo isASureInvocation]) ifTrue:[
-					| invocationRVar | 
-					invocationRVar := invo getReceivingFAMIXClass. 
-					(invocationRVar notNil 
-						and: [(invocationRVar lookUp: self signature) = self]) 
-							ifTrue:[^true]
-				]
-			]).
-		].
-	^false
+	((self isAbstract or: [ aFAMIXMethod isAbstract ]) or: [ (outgoingInvo := aFAMIXMethod queryAllOutgoingInvocations) isEmpty ])
+		ifFalse: [ outgoingInvo
+				do: [ :invo | 
+					(invo signature = self signature and: [ invo isASureInvocation ])
+						ifTrue: [ | invocationRVar |
+							invocationRVar := invo getReceivingFAMIXClass.
+							(invocationRVar isNotNil and: [ (invocationRVar lookUp: self signature) = self ]) ifTrue: [ ^ true ] ] ] ].
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
@@ -37,13 +37,9 @@ FamixJavaParameterizedType >> isParameterizedType [
 ]
 
 { #category : #'as yet unclassified' }
-FamixJavaParameterizedType >> mooseNameOn: aStream [ 
-	self parameterizableClass notNil 
-		ifTrue: [self parameterizableClass mooseNameOn: aStream].
+FamixJavaParameterizedType >> mooseNameOn: aStream [
+	self parameterizableClass isNotNil ifTrue: [ self parameterizableClass mooseNameOn: aStream ].
 	aStream nextPut: $<.
-	self arguments 
-		do: [:each | each mooseNameOn: aStream]
-		separatedBy: [aStream nextPut: $,].  
-	aStream nextPut: $>.  
-
+	self arguments do: [ :each | each mooseNameOn: aStream ] separatedBy: [ aStream nextPut: $, ].
+	aStream nextPut: $>
 ]

--- a/src/Famix-Java-Entities/FamixJavaTStructuralEntity.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTStructuralEntity.trait.st
@@ -1,7 +1,6 @@
 Trait {
 	#name : #FamixJavaTStructuralEntity,
 	#traits : 'FamixTStructuralEntity + FamixTWithDereferencedInvocations',
-	#classTraits : 'FamixTStructuralEntity classTrait + FamixTWithDereferencedInvocations classTrait',
 	#category : #'Famix-Java-Entities-Traits'
 }
 

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -85,10 +85,7 @@ FamixJavaType >> isAbstract [
 
 { #category : #testing }
 FamixJavaType >> isAnonymousClass [
-	^  self container notNil and: [
-			self container isMethod or: [
-				self name isAllDigits or: [
-					'*_anonymous_*' match: self name ]] ]
+	^ self container isNotNil and: [ self container isMethod or: [ self name isAllDigits or: [ '*_anonymous_*' match: self name ] ] ]
 ]
 
 { #category : #testing }
@@ -143,7 +140,7 @@ FamixJavaType >> isTestCase [
 ]
 
 { #category : #'Famix-Extensions-operations' }
-FamixJavaType >> lookUp: aMethodSignature [ 
+FamixJavaType >> lookUp: aMethodSignature [
 	"Returns the first method that has as signature #aMethodSignature. 
 	The search starts from the receiver's methods and traveses the inherited methods from the receiver's superclasses heirarchy.
 	If such a method has not been found, it returns nil"
@@ -152,15 +149,14 @@ FamixJavaType >> lookUp: aMethodSignature [
 	c := self.
 	searchedM := nil.
 	toSearchIt := true.
-	[c notNil and: [toSearchIt]] whileTrue: 
-			[searchedM := c methods 
-						detect: [:m | m signature = aMethodSignature]
-						ifNone: [nil].
+	[ c isNotNil and: [ toSearchIt ] ]
+		whileTrue: [ searchedM := c methods
+				detect: [ :m | m signature = aMethodSignature ]
+				ifNone: [ nil ].
 			searchedM
-				ifNil: [c := c superclass]
-				ifNotNil: [toSearchIt := false]
-			].
-	^searchedM
+				ifNil: [ c := c superclass ]
+				ifNotNil: [ toSearchIt := false ] ].
+	^ searchedM
 ]
 
 { #category : #accessing }

--- a/src/Famix-Java-Tests/FamixJavaParameterizedTypeTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaParameterizedTypeTest.class.st
@@ -108,7 +108,7 @@ FamixJavaParameterizedTypeTest >> testArgumentTypes [
 FamixJavaParameterizedTypeTest >> testArguments [
 	| parameterizableType |
 	parameterizableType := model allParameterizedTypes entityNamed: #'ParameterizableClassA<TypeB,TypeC>'.
-	self assert: parameterizableType arguments notEmpty.
+	self assert: parameterizableType arguments isNotEmpty.
 	self assert: parameterizableType arguments size equals: 2
 ]
 
@@ -135,10 +135,9 @@ FamixJavaParameterizedTypeTest >> testModelSize [
 
 { #category : #tests }
 FamixJavaParameterizedTypeTest >> testMooseName [
-
 	| parameterizableType |
 	parameterizableType := model allParameterizedTypes entityNamed: #'ParameterizableClassA<TypeB,TypeC>'.
-	self assert: parameterizableType notNil
+	self assert: parameterizableType isNotNil
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -16,15 +16,14 @@ FmxMBClass >> acceptVisitor: aVisitor [
 
 { #category : #accessing }
 FmxMBClass >> allClassGeneralizations [
-
-	| result c g|
+	| result c g |
 	result := OrderedCollection new.
 	c := self.
-	[ g := c classGeneralization. g notNil ] whileTrue: [ 
-		result add: g.
-		c := g ].
+	[ g := c classGeneralization.
+	g isNotNil ]
+		whileTrue: [ result add: g.
+			c := g ].
 	^ result
-
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
@@ -106,7 +106,7 @@ FmxMBRelationSide >> generationStrategy: anObject [
 
 { #category : #testing }
 FmxMBRelationSide >> hasRelation [
-	^ self relation notNil
+	^ self relation isNotNil
 ]
 
 { #category : #initialization }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRingEnvironment.class.st
@@ -54,35 +54,30 @@ FmxMBRingEnvironment >> compile: aSource in: aClass classified: aProtocol packag
 
 { #category : #initialization }
 FmxMBRingEnvironment >> createClassNamed: aClassName superclass: aSuperclass traitNames: traitNames slots: slots in: packageName overwrite: shouldOverwrite [
-
 	| aClass existingClass composition |
-	
 	existingClass := self ringEnvironment ask behaviorNamed: aClassName asSymbol.
-	
-	(existingClass notNil and: [ shouldOverwrite not]) 
-		ifTrue: [ ^ existingClass ].
-		
+
+	(existingClass isNotNil and: [ shouldOverwrite not ]) ifTrue: [ ^ existingClass ].
+
 	aClass := self ringEnvironment ensureClassNamed: aClassName.
 	aClass superclass: (self ringEnvironment ensureClassNamed: aSuperclass name).
 
 	composition := RGTraitComposition parent: aClass.
 	aClass traitComposition: composition.
-	traitNames do: [ :each |
-		composition addTransformation: (self ringEnvironment ensureTraitNamed: each) ].	
-	
+	traitNames do: [ :each | composition addTransformation: (self ringEnvironment ensureTraitNamed: each) ].
+
 	aClass package: (self ringEnvironment ensurePackageNamed: packageName).
 	aClass layout makeResolved.
-	slots do: [ :slotInBadEnvironment |
-		| slot |
-		slot := slotInBadEnvironment isSpecial
-			ifTrue: [ 			
-				(RGUnknownSlot named: slotInBadEnvironment name parent: aClass layout) 
-					expression: slotInBadEnvironment expression;
-					yourself ]
-			ifFalse: [ 
-				RGInstanceVariableSlot named: slotInBadEnvironment name parent: aClass layout ].
-		aClass layout addSlot: slot.
-		slot propertyNamed: #isGenerated put: true ].
+	slots
+		do: [ :slotInBadEnvironment | 
+			| slot |
+			slot := slotInBadEnvironment isSpecial
+				ifTrue: [ (RGUnknownSlot named: slotInBadEnvironment name parent: aClass layout)
+						expression: slotInBadEnvironment expression;
+						yourself ]
+				ifFalse: [ RGInstanceVariableSlot named: slotInBadEnvironment name parent: aClass layout ].
+			aClass layout addSlot: slot.
+			slot propertyNamed: #isGenerated put: true ].
 
 	^ aClass
 ]
@@ -106,37 +101,32 @@ FmxMBRingEnvironment >> createImportingcontextClassNamed: aClassName in: package
 
 { #category : #initialization }
 FmxMBRingEnvironment >> createTraitNamed: traitName uses: traitNames slots: slots in: packageName overwrite: shouldOverwrite [
-
 	| aPackage aTrait existingClass composition |
-
 	existingClass := self ringEnvironment ask behaviorNamed: traitName asSymbol.
-	
-	(existingClass notNil and: [ shouldOverwrite not]) 
-		ifTrue: [ ^ existingClass ].
+
+	(existingClass isNotNil and: [ shouldOverwrite not ]) ifTrue: [ ^ existingClass ].
 
 	aPackage := self ringEnvironment ensurePackageNamed: packageName.
-	aTrait := ringEnvironment ensureTraitNamed: traitName. 
+	aTrait := ringEnvironment ensureTraitNamed: traitName.
 	aTrait superclass: self basicTrait.
-	
+
 	composition := RGTraitComposition parent: aTrait.
 	aTrait traitComposition: composition.
-	traitNames do: [ :each |
-		composition addTransformation: (self ringEnvironment ensureTraitNamed: each) ].	
-	
+	traitNames do: [ :each | composition addTransformation: (self ringEnvironment ensureTraitNamed: each) ].
+
 	aTrait package: aPackage.
 	aTrait layout makeResolved.
-	slots do: [ :slotInBadEnvironment |
-		| slot |
-		slot := slotInBadEnvironment isSpecial
-			ifTrue: [ 			
-				(RGUnknownSlot named: slotInBadEnvironment name parent: aTrait layout) 
-					expression: slotInBadEnvironment expression;
-					yourself ]
-			ifFalse: [ 
-				RGInstanceVariableSlot named: slotInBadEnvironment name parent: aTrait layout ].
-		aTrait layout addSlot: slot.
-		slot propertyNamed: #isGenerated put: true ].
-	
+	slots
+		do: [ :slotInBadEnvironment | 
+			| slot |
+			slot := slotInBadEnvironment isSpecial
+				ifTrue: [ (RGUnknownSlot named: slotInBadEnvironment name parent: aTrait layout)
+						expression: slotInBadEnvironment expression;
+						yourself ]
+				ifFalse: [ RGInstanceVariableSlot named: slotInBadEnvironment name parent: aTrait layout ].
+			aTrait layout addSlot: slot.
+			slot propertyNamed: #isGenerated put: true ].
+
 	^ aTrait
 ]
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
@@ -17,28 +17,24 @@ Class {
 
 { #category : #tests }
 FmxMBBuilderTest >> testChildBuildersGeneration [
-
 	| parentBuilder childBuilder environment |
-	
 	parentBuilder := FamixMetamodelBuilder forTesting.
 	parentBuilder configuration packageName: 'ParentBuilderPackage'.
 	parentBuilder ensureClassNamed: 'ParentEntity'.
-	
+
 	childBuilder := FamixMetamodelBuilder new.
 	childBuilder parentBuilder: parentBuilder.
 	childBuilder configuration packageName: 'ChildBuilderPackage'.
 	childBuilder ensureClassNamed: 'ChildEntity'.
-	
+
 	parentBuilder generate.
 	parentBuilder generateRemotes.
-	
+
 	environment := parentBuilder environment ringEnvironment.
-	
-	self assert: (environment ask behaviorNamed: #TstParentEntity) notNil.
-	self assert: (environment ask behaviorNamed: #TstParentEntity) package name equals: 'ParentBuilderPackage'. 
-	self assert: (environment ask behaviorNamed: #TstChildEntity) isNil.
-	
-	
+
+	self assert: (environment ask behaviorNamed: #TstParentEntity) isNotNil.
+	self assert: (environment ask behaviorNamed: #TstParentEntity) package name equals: 'ParentBuilderPackage'.
+	self assert: (environment ask behaviorNamed: #TstChildEntity) isNil
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
@@ -63,46 +63,40 @@ FmxMBClassTest >> testBasicTrait [
 
 { #category : #tests }
 FmxMBClassTest >> testBuilderPackageChange [
-	
 	"if we set for a builder a packag name, all newely defined entities should use be assigned to this package. If no explicit package name is set, the default one is used."
 
 	| generated |
-	
-	builder newClassNamed: #Comment.	
+	builder newClassNamed: #Comment.
 	builder configuration packageName: 'Another'.
-	builder newClassNamed: #Method.	
+	builder newClassNamed: #Method.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
-	self assert: generated notNil.
+	self assert: generated isNotNil.
 	self assert: generated isClass.
 	self assert: generated package name equals: #Tst.
 	generated := builder testingEnvironment ask classNamed: 'TstMethod'.
-	self assert: generated notNil.
+	self assert: generated isNotNil.
 	self assert: generated isClass.
-	self assert: generated package name equals: #Another.
-
+	self assert: generated package name equals: #Another
 ]
 
 { #category : #tests }
 FmxMBClassTest >> testBuilderPrefixChange [
-
 	"if we set for a builder a prefix, all newely defined entities should use it. If no explicit prefix is set, the default one is used."
 
 	| generated |
-	
-	builder newClassNamed: #Comment.	
+	builder newClassNamed: #Comment.
 	builder configuration prefix: 'Another'.
-	builder newClassNamed: #Method.	
+	builder newClassNamed: #Method.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstComment'.
-	self assert: generated notNil.
+	self assert: generated isNotNil.
 	self assert: generated isClass.
 	self assert: generated package name equals: #Tst.
 	generated := builder testingEnvironment ask classNamed: 'AnotherMethod'.
-	self assert: generated notNil.
+	self assert: generated isNotNil.
 	self assert: generated isClass.
-	self assert: generated package name equals: #Tst.
-
+	self assert: generated package name equals: #Tst
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBConfigurationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBConfigurationTest.class.st
@@ -6,13 +6,11 @@ Class {
 
 { #category : #tests }
 FmxMBConfigurationTest >> testConfiguration [
-
-	| config | 
-	
+	| config |
 	config := builder configuration.
-	
-	self assert: config notNil.
-	
+
+	self assert: config isNotNil.
+
 	self assert: config basicSuperclassName equals: config defaultBasicSuperclassName.
 	config basicSuperclassName: #TestValue1.
 	self assert: config basicSuperclassName equals: #TestValue1.
@@ -35,6 +33,5 @@ FmxMBConfigurationTest >> testConfiguration [
 
 	self deny: config wantsToGenerateImportingContext.
 	config wantsToGenerateImportingContext: true.
-	self assert: config wantsToGenerateImportingContext.
-
+	self assert: config wantsToGenerateImportingContext
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -38,7 +38,7 @@ FmxMBGeneratorTest >> testMooseModelSubclassHasMetaModel [
 FmxMBGeneratorTest >> testResetMetamodel [
 	| metamodel |
 	metamodel := FamixTest1Model resetMetamodel.
-	self assert: (metamodel elementNamed: 'Famix-Test1-Entities.Entity' ifAbsent: [ nil ]) notNil
+	self assert: (metamodel elementNamed: 'Famix-Test1-Entities.Entity' ifAbsent: [ nil ]) isNotNil
 ]
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
@@ -47,7 +47,7 @@ FmxMBImportingContextTest >> testDefineImport [
 
 { #category : #tests }
 FmxMBImportingContextTest >> testGeneratedContextClass [
-	self assert: generatedContext notNil.
+	self assert: generatedContext isNotNil.
 	self assert: generatedContext superclass name equals: #FmxImportingContext
 ]
 

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBNavigationGroupTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBNavigationGroupTest.class.st
@@ -19,26 +19,23 @@ FmxMBNavigationGroupTest >> testEmptyRelationGroups [
 
 { #category : #tests }
 FmxMBNavigationGroupTest >> testRelationGroupsForTraits [
-
 	| tClass tMethod class method relation |
-	
 	builder configuration navigationForContainers.
-	
+
 	tClass := builder newTraitNamed: #TClass.
 	tMethod := builder newTraitNamed: #TMethod.
 	class := builder newClassNamed: #Class.
 	method := builder newClassNamed: #Method.
-	
-	relation := (tClass <>-* tMethod).
-	
+
+	relation := tClass <>-* tMethod.
+
 	class --|> tClass.
 	method --|> tMethod.
-	
-	self assert: (tClass allNavigationGroups notEmpty).	
-	self assert: (tMethod allNavigationGroups notEmpty).
-	self assert: (class allNavigationGroups isEmpty).	
-	self assert: (method allNavigationGroups isEmpty).	
 
-	self assert: tClass allNavigationGroups anyOne relation equals: relation.	
+	self assert: tClass allNavigationGroups isNotEmpty.
+	self assert: tMethod allNavigationGroups isNotEmpty.
+	self assert: class allNavigationGroups isEmpty.
+	self assert: method allNavigationGroups isEmpty.
 
+	self assert: tClass allNavigationGroups anyOne relation equals: relation
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
@@ -275,18 +275,16 @@ FmxMBTraitTest >> testSimpleClassAnnotation [
 
 { #category : #tests }
 FmxMBTraitTest >> testSimpleTrait [
-
 	| generated |
-	
-	builder newTraitNamed: #TComment.	
+	builder newTraitNamed: #TComment.
 	builder generate.
 	generated := builder testingEnvironment ask classNamed: 'TstTComment'.
-	self assert: generated notNil.
+	self assert: generated isNotNil.
 	self assert: generated isClass.
 	self assert: generated superclass name equals: 'Trait'.
 	self assert: generated slots isEmpty.
-	self assert: generated instanceSide localSelectors isEmpty.	
-	self assertCollection: generated classSide localSelectors sorted equals: #(annotation).
+	self assert: generated instanceSide localSelectors isEmpty.
+	self assertCollection: generated classSide localSelectors sorted equals: #(annotation)
 ]
 
 { #category : #tests }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -16,8 +16,8 @@ FamixStAnnotationInstanceAttribute class >> annotation [
 ]
 
 { #category : #accessing }
-FamixStAnnotationInstanceAttribute >> name [ 
-	^ self annotationTypeAttribute notNil 
+FamixStAnnotationInstanceAttribute >> name [
+	^ self annotationTypeAttribute isNotNil
 		ifTrue: [ self annotationTypeAttribute name ]
 		ifFalse: [ nil ]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -62,7 +62,7 @@ FamixStClass >> instanceSide [
 { #category : #testing }
 FamixStClass >> isAnonymousClass [
 	self flag: #todo.	"We need to check how to do that in Pharo smalltalk because I think some of the conditions are for Java"
-	^ self typeContainer notNil and: [ self typeContainer isMethod or: [ self name isAllDigits or: [ '*_anonymous_*' match: self name ] ] ]
+	^ self typeContainer isNotNil and: [ self typeContainer isMethod or: [ self name isAllDigits or: [ '*_anonymous_*' match: self name ] ] ]
 ]
 
 { #category : #testing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -25,15 +25,14 @@ FamixStComment >> belongsTo [
 FamixStComment >> gtDisplayOn: aStream [
 	| preview |
 	preview := self sourceText truncateWithElipsisTo: 10.
-	preview := preview copyReplaceAll: (String with: Character cr with: Character lf) with: ' '.	
-	preview := preview copyReplaceAll: (String with: Character cr) with: ' '.	
+	preview := preview copyReplaceAll: (String with: Character cr with: Character lf) with: ' '.
+	preview := preview copyReplaceAll: (String with: Character cr) with: ' '.
 	preview := preview copyReplaceAll: (String with: Character lf) with: ' '.
-	aStream 
+	aStream
 		nextPut: $";
 		nextPutAll: preview;
 		nextPutAll: '" in '.
-	self belongsTo notNil ifTrue: [
-		self belongsTo gtDisplayOn: aStream ]
+	self belongsTo isNotNil ifTrue: [ self belongsTo gtDisplayOn: aStream ]
 ]
 
 { #category : #printing }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -44,8 +44,8 @@ FamixStInvocation >> initialize [
 { #category : #'instance creation' }
 FamixStInvocation >> isASureInvocation [
 	"Test if the receiver (an invocation) is sure (i.e. we know for sure the class of the invocation's receiver)"
+
 	| invoRVar |
 	invoRVar := self receiver.
-	^(invoRVar notNil) and: 
-			[invoRVar class = FamixStClass or: [invoRVar isImplicitVariable and: [invoRVar isSelf or: [invoRVar isSuper]]]]
+	^ invoRVar isNotNil and: [ invoRVar class = FamixStClass or: [ invoRVar isImplicitVariable and: [ invoRVar isSelf or: [ invoRVar isSuper ] ] ] ]
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -158,25 +158,16 @@ FamixStMethod >> isOverriding [
 ]
 
 { #category : #'Famix-Extensions-metrics-support' }
-FamixStMethod >> isSurelyInvokedBy: aFAMIXMethod [ 
-	 
+FamixStMethod >> isSurelyInvokedBy: aFAMIXMethod [
 	| outgoingInvo |
-
-	((self isAbstract or: [aFAMIXMethod isAbstract]) 
-		or: [(outgoingInvo := aFAMIXMethod queryAllOutgoingInvocations) isEmpty])
-		ifFalse: 
-			[
-			(outgoingInvo do:[:invo |
-				(invo signature = self signature and: [invo isASureInvocation]) ifTrue:[
-					| invocationRVar | 
-					invocationRVar := invo getReceivingFAMIXClass. 
-					(invocationRVar notNil 
-						and: [(invocationRVar lookUp: self signature) = self]) 
-							ifTrue:[^true]
-				]
-			]).
-		].
-	^false
+	((self isAbstract or: [ aFAMIXMethod isAbstract ]) or: [ (outgoingInvo := aFAMIXMethod queryAllOutgoingInvocations) isEmpty ])
+		ifFalse: [ outgoingInvo
+				do: [ :invo | 
+					(invo signature = self signature and: [ invo isASureInvocation ])
+						ifTrue: [ | invocationRVar |
+							invocationRVar := invo getReceivingFAMIXClass.
+							(invocationRVar isNotNil and: [ (invocationRVar lookUp: self signature) = self ]) ifTrue: [ ^ true ] ] ] ].
+	^ false
 ]
 
 { #category : #'Famix-Extensions-private' }

--- a/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
@@ -48,13 +48,13 @@ FamixSourceAnchorTest >> testImportFileAnchors [
 		(Famix-Test1-Entities.FileAnchor (id: 4) (element (ref: 2)) (fileName ''afile'') (startLine 3) (endLine 30))
 	)' readStream.
 	self assert: model entities size equals: 4.
-	self assert: model allClasses first sourceAnchor notNil.
+	self assert: model allClasses first sourceAnchor isNotNil.
 	self assert: model allClasses first sourceAnchor mooseModel identicalTo: model.
 	self assert: (model allClasses first sourceAnchor isKindOf: FamixTest1SourceAnchor).
 	self assert: model allClasses first sourceAnchor fileName equals: 'afile'.
 	aMethod := model allMethods first.
 	self assert: aMethod hasSourceAnchor.
-	self assert: aMethod sourceAnchor notNil.
+	self assert: aMethod sourceAnchor isNotNil.
 	self assert: aMethod sourceAnchor fileName equals: 'afile'.
 	self assert: aMethod sourceAnchor startLine equals: 3.
 	self assert: aMethod sourceAnchor endLine equals: 30.

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#entities => FMMany type: #FamixTWithFiles opposite: #containerFiles'
 	],
 	#traits : 'FamixTFileSystemEntity',
-	#classTraits : 'FamixTFileSystemEntity classTrait',
 	#category : #'Famix-Traits-File'
 }
 

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#startLine => FMProperty'
 	],
 	#traits : 'FamixTFileAnchor',
+	#classTraits : 'FamixTFileAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 
@@ -88,7 +89,7 @@ FamixTFileNavigation >> interval [
 
 { #category : #accessing }
 FamixTFileNavigation >> lineCount [
-	(endLine notNil and: [ startLine notNil ]) ifTrue: [ ^ endLine - startLine + 1 ].
+	(endLine isNotNil and: [ startLine isNotNil ]) ifTrue: [ ^ endLine - startLine + 1 ].
 
 	"if no start/end position, use the comple text ..."
 	^ self hasSourceText

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTSourceEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTTypedEntity)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTSourceEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTTypedEntity classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -10,6 +10,7 @@ Trait {
 		'#parentScope => FMOne type: #FamixTScopingEntity opposite: #childScopes'
 	],
 	#traits : 'TOODependencyQueries',
+	#classTraits : 'TOODependencyQueries classTrait',
 	#category : #'Famix-Traits-ScopingEntity'
 }
 
@@ -49,8 +50,7 @@ FamixTScopingEntity >> allChildScopesGroup [
 
 { #category : #accessing }
 FamixTScopingEntity >> allParentScopesDo: aBlock [
-	self parentScope notNil ifTrue: [
-		self parentScope withAllParentScopesDo: aBlock ]
+	self parentScope isNotNil ifTrue: [ self parentScope withAllParentScopesDo: aBlock ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -30,7 +30,7 @@ FamixTSourceLanguage >> addSourcedEntity: aSourcedEntity [
 FamixTSourceLanguage >> isAttached [
 	"Returns whether the receiver (a language) has some entities associated with it. By default, if there are no entities attached, it means that all of them are of this language."
 
-	^ self sourcedEntities notEmpty  
+	^ self sourcedEntities isNotEmpty
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -68,7 +68,7 @@ FamixTWithAnnotationInstances >> annotationTypes [
 
 { #category : #'Famix-Java' }
 FamixTWithAnnotationInstances >> isAnnotated [
-	^ self annotationInstances notEmpty
+	^ self annotationInstances isNotEmpty
 ]
 
 { #category : #'Famix-Java' }

--- a/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
@@ -26,7 +26,7 @@ FamixTWithSourceAnchor >> computeNumberOfLinesOfCode [
 
 { #category : #testing }
 FamixTWithSourceAnchor >> hasSourceAnchor [
-	^ self sourceAnchor notNil
+	^ self sourceAnchor isNotNil
 ]
 
 { #category : #properties }

--- a/src/Merlin/MerlinMorphicPaneRenderer.class.st
+++ b/src/Merlin/MerlinMorphicPaneRenderer.class.st
@@ -20,11 +20,13 @@ MerlinMorphicPaneRenderer >> adaptSize [
 { #category : #updating }
 MerlinMorphicPaneRenderer >> applyChanges [
 	"make sure that all changes become visible in the frame"
-	
+
 	| contentMorph |
 	contentMorph := self dialogWindow contentMorph.
-	contentMorph notNil
-		ifTrue: [self dialogWindow contentMorph: contentMorph; model: nil].
+	contentMorph isNotNil
+		ifTrue: [ self dialogWindow
+				contentMorph: contentMorph;
+				model: nil ]
 ]
 
 { #category : #'accessing - buttons' }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -533,7 +533,7 @@ MooseAbstractGroup >> mooseModel [
 
 { #category : #testing }
 MooseAbstractGroup >> notEmpty [
-	^ self entities notEmpty
+	^ self entities isNotEmpty
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -545,7 +545,7 @@ MooseModel >> name: aStringOrSymbol [
 	| oldName |
 	oldName := name.
 	name := aStringOrSymbol.
-	(oldName notNil and: [ oldName ~= name ])
+	(oldName isNotNil and: [ oldName ~= name ])
 		ifTrue: [ self resetMooseName.
 			self announcer announce: (MooseEntityRenamed new oldName: oldName) ]
 ]

--- a/src/Moose-Finder/FAMIXAbstractFileAnchor.extension.st
+++ b/src/Moose-Finder/FAMIXAbstractFileAnchor.extension.st
@@ -3,11 +3,12 @@ Extension { #name : #FAMIXAbstractFileAnchor }
 { #category : #'*Moose-Finder' }
 FAMIXAbstractFileAnchor >> mooseFinderCompleteSourceTextIn: composite [
 	<moosePresentationOrder: 11>
-	composite custom: 
-		((MooseFileSourceAnchorViewer startOn: self)
-						title: 'Complete source';
-						titleIcon: MooseIcons mooseSourceText;
-						when: [ :input | input mooseInterestingEntity completeText notEmpty ])
+	composite
+		custom:
+			((MooseFileSourceAnchorViewer startOn: self)
+				title: 'Complete source';
+				titleIcon: MooseIcons mooseSourceText;
+				when: [ :input | input mooseInterestingEntity completeText isNotEmpty ])
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-Finder/FAMIXContainerEntity.extension.st
+++ b/src/Moose-Finder/FAMIXContainerEntity.extension.st
@@ -3,21 +3,21 @@ Extension { #name : #FAMIXContainerEntity }
 { #category : #'*Moose-Finder' }
 FAMIXContainerEntity >> mooseFinderFunctionsIn: composite [
 	<moosePresentationOrder: 40>
-	composite list 
+	composite list
 		title: 'Functions';
 		titleIcon: MooseIcons famixFunctionGroup;
 		display: [ self functions ];
 		format: [ :each | each mooseName ];
-		when: [ self functions notEmpty ]
+		when: [ self functions isNotEmpty ]
 ]
 
 { #category : #'*Moose-Finder' }
 FAMIXContainerEntity >> mooseFinderTypesIn: composite [
 	<moosePresentationOrder: 40>
-	composite list 
+	composite list
 		title: 'Types';
 		titleIcon: MooseIcons famixClassGroup;
 		display: [ self types ];
 		format: [ :each | each mooseName ];
-		when: [ self types notEmpty ]
+		when: [ self types isNotEmpty ]
 ]

--- a/src/Moose-Finder/FAMIXNamedEntity.extension.st
+++ b/src/Moose-Finder/FAMIXNamedEntity.extension.st
@@ -4,9 +4,9 @@ Extension { #name : #FAMIXNamedEntity }
 FAMIXNamedEntity >> mooseFinderAnnotationInstancesIn: composite [
 	<moosePresentationOrder: 20>
 	composite list
-			title: 'Annotation instances';
-			titleIcon: MooseIcons famixAnnotationInstanceGroup;
-			display: [ self annotationInstances ];
-			format: #mooseName;
-			when: [ self annotationInstances notEmpty ]
+		title: 'Annotation instances';
+		titleIcon: MooseIcons famixAnnotationInstanceGroup;
+		display: [ self annotationInstances ];
+		format: #mooseName;
+		when: [ self annotationInstances isNotEmpty ]
 ]

--- a/src/Moose-Finder/FAMIXSourceAnchor.extension.st
+++ b/src/Moose-Finder/FAMIXSourceAnchor.extension.st
@@ -4,8 +4,8 @@ Extension { #name : #FAMIXSourceAnchor }
 FAMIXSourceAnchor >> mooseFinderSourceTextIn: composite [
 	<moosePresentationOrder: 10>
 	composite text
-			title: 'Source';
-			titleIcon: MooseIcons mooseSourceTextPartial;
-			display: [ :each | each mooseInterestingEntity sourceText ];
-			when: [ :input | input mooseInterestingEntity sourceText notEmpty ]
+		title: 'Source';
+		titleIcon: MooseIcons mooseSourceTextPartial;
+		display: [ :each | each mooseInterestingEntity sourceText ];
+		when: [ :input | input mooseInterestingEntity sourceText isNotEmpty ]
 ]

--- a/src/Moose-Finder/FAMIXType.extension.st
+++ b/src/Moose-Finder/FAMIXType.extension.st
@@ -4,16 +4,14 @@ Extension { #name : #FAMIXType }
 FAMIXType >> mooseFinderAttributesIn: composite [
 	<moosePresentationOrder: 20>
 	composite table
-			title: 'Attributes';
-			titleIcon: MooseIcons famixAttributeGroup;
-			display: [ self attributes ];
-			column: 'Name' evaluated: #name;
-			column: 'Declared type' evaluated: [ :each | each declaredType gtDisplayString ];
-			column: 'Modifiers' evaluated: [ '' ] tags: #modifiers;
-			when: [ self attributes notEmpty ];
-			selectionPopulate: #selection  
-				entitled: 'Open declared type' 
-				with:  [ :table | table selection declaredType ]
+		title: 'Attributes';
+		titleIcon: MooseIcons famixAttributeGroup;
+		display: [ self attributes ];
+		column: 'Name' evaluated: #name;
+		column: 'Declared type' evaluated: [ :each | each declaredType gtDisplayString ];
+		column: 'Modifiers' evaluated: [ '' ] tags: #modifiers;
+		when: [ self attributes isNotEmpty ];
+		selectionPopulate: #selection entitled: 'Open declared type' with: [ :table | table selection declaredType ]
 ]
 
 { #category : #'*Moose-Finder' }
@@ -30,13 +28,11 @@ FAMIXType >> mooseFinderHierarchyIn: composite [
 FAMIXType >> mooseFinderMethodsIn: composite [
 	<moosePresentationOrder: 20>
 	composite table
-			title: 'Methods';
-			titleIcon: MooseIcons famixMethodGroup;
-			display: [ self methods ];
-			column: 'Name' evaluated: #signature;
-			column: 'Declared type' evaluated: [ :each | each declaredType gtDisplayString ];
-			when: [ self methods notEmpty ];
-			selectionPopulate: #selection  
-				entitled: 'Open declared type' 
-				with:  [ :table | table selection declaredType ]
+		title: 'Methods';
+		titleIcon: MooseIcons famixMethodGroup;
+		display: [ self methods ];
+		column: 'Name' evaluated: #signature;
+		column: 'Declared type' evaluated: [ :each | each declaredType gtDisplayString ];
+		when: [ self methods isNotEmpty ];
+		selectionPopulate: #selection entitled: 'Open declared type' with: [ :table | table selection declaredType ]
 ]

--- a/src/Moose-Finder/FM3Class.extension.st
+++ b/src/Moose-Finder/FM3Class.extension.st
@@ -5,7 +5,7 @@ FM3Class >> gtInspectorConnectionsIn: composite [
 	<gtInspectorPresentationOrder: 3>
 	composite roassal2
 		title: 'Connections';
-		initializeView: [RTMondrian new];
+		initializeView: [ RTMondrian new ];
 		painting: [ :view | self viewConnectionsOn: view ];
-		when: [ self allComplexProperties notEmpty ]
+		when: [ self allComplexProperties isNotEmpty ]
 ]

--- a/src/Moose-Finder/FamixTWithSourceAnchor.extension.st
+++ b/src/Moose-Finder/FamixTWithSourceAnchor.extension.st
@@ -13,10 +13,10 @@ FamixTWithSourceAnchor >> mooseFinderParentFolderIn: composite [
 FamixTWithSourceAnchor >> mooseFinderSourceTextIn: composite [
 	<moosePresentationOrder: 10>
 	composite text
-			title: 'Source';
-			titleIcon: MooseIcons mooseSourceText;
-			format: [ self mooseInterestingEntity formattedSourceText ];
-			when: [ self mooseInterestingEntity sourceText notEmpty ]
+		title: 'Source';
+		titleIcon: MooseIcons mooseSourceText;
+		format: [ self mooseInterestingEntity formattedSourceText ];
+		when: [ self mooseInterestingEntity sourceText isNotEmpty ]
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-Finder/MPImportFileStructureCommand.class.st
+++ b/src/Moose-Finder/MPImportFileStructureCommand.class.st
@@ -9,9 +9,8 @@ MPImportFileStructureCommand >> execute [
 	| model |
 	model := MooseModel new.
 	model importFileStructure.
-	model notEmpty
-		ifTrue: [ 
-			model install.
+	model isNotEmpty
+		ifTrue: [ model install.
 			self addModel: model ]
 ]
 

--- a/src/Moose-Finder/MPImportMSECommand.class.st
+++ b/src/Moose-Finder/MPImportMSECommand.class.st
@@ -6,13 +6,11 @@ Class {
 
 { #category : #hooks }
 MPImportMSECommand >> execute [
-	[ 
-	| model |
+	[ | model |
 	model := MooseModel new.
 	model importFromMSE.
-	model notEmpty
-		ifTrue: [ 
-			model install.
+	model isNotEmpty
+		ifTrue: [ model install.
 			self addModel: model ] ] fork
 ]
 

--- a/src/Moose-Finder/MooseBrowsers.class.st
+++ b/src/Moose-Finder/MooseBrowsers.class.st
@@ -12,24 +12,43 @@ MooseBrowsers >> codeBrowser [
 	| browser |
 	browser := GLMTabulator new.
 	browser title: 'Moose Code Browser'.
-	browser row: #navigation; row: #details.
-	browser transmit to: #navigation; andShow: [ :a |
-		a custom: MooseCodeNavigator new browser ].
-	browser transmit to: #details; from: #navigation port: #class; from: #navigation port: #method; andShow: [ :a |
-		a text
-			title: 'Source';
-			display: [:cls | cls formattedSourceText];
-			useExplicitNotNil;
-			when: [:cls :method | cls notNil and: [method isNil] ].
-		a text
-			title: 'Source';
-			display: [:cls :method | method formattedSourceText]	  ].
-	browser transmit toOutsidePort: #namespace; from: #navigation port: #namespace.
-	browser transmit toOutsidePort: #class; from: #navigation port: #class.
-	browser transmit toOutsidePort: #method; from: #navigation port: #method.
-	browser transmit to: #navigation port: #namespaceToSelect; fromOutsidePort: #namespaceToSelect.
-	browser transmit to: #navigation port: #classToSelect; fromOutsidePort: #classToSelect.
-	browser transmit to: #navigation port: #methodToSelect; fromOutsidePort: #methodToSelect.
+	browser
+		row: #navigation;
+		row: #details.
+	browser transmit
+		to: #navigation;
+		andShow: [ :a | a custom: MooseCodeNavigator new browser ].
+	browser transmit
+		to: #details;
+		from: #navigation port: #class;
+		from: #navigation port: #method;
+		andShow: [ :a | 
+			a text
+				title: 'Source';
+				display: [ :cls | cls formattedSourceText ];
+				useExplicitNotNil;
+				when: [ :cls :method | cls isNotNil and: [ method isNil ] ].
+			a text
+				title: 'Source';
+				display: [ :cls :method | method formattedSourceText ] ].
+	browser transmit
+		toOutsidePort: #namespace;
+		from: #navigation port: #namespace.
+	browser transmit
+		toOutsidePort: #class;
+		from: #navigation port: #class.
+	browser transmit
+		toOutsidePort: #method;
+		from: #navigation port: #method.
+	browser transmit
+		to: #navigation port: #namespaceToSelect;
+		fromOutsidePort: #namespaceToSelect.
+	browser transmit
+		to: #navigation port: #classToSelect;
+		fromOutsidePort: #classToSelect.
+	browser transmit
+		to: #navigation port: #methodToSelect;
+		fromOutsidePort: #methodToSelect.
 	^ browser
 ]
 
@@ -37,39 +56,57 @@ MooseBrowsers >> codeBrowser [
 MooseBrowsers >> codeNavigator [
 	| browser col |
 	browser := GLMTabulator new.
-	browser column: #namespaces; column: #classes; column: #methods.
-	browser transmit to: #namespaces; andShow: [:a |
+	browser
+		column: #namespaces;
+		column: #classes;
+		column: #methods.
+	browser transmit
+		to: #namespaces;
+		andShow: [ :a | 
 			a tree
-				display: [:model | (model allNamespaces select: #isRoot) sorted: [:x :y | x name < y name]];				
-				children: [:namespace | namespace childScopes asSortedCollection: [:x :y | x name < y name]];
-				format: [:namespace | namespace stubFormattedName];
-				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ]
-		].
-	browser transmit to: #classes;
+				display: [ :model | (model allNamespaces select: #isRoot) sorted: [ :x :y | x name < y name ] ];
+				children: [ :namespace | namespace childScopes asSortedCollection: [ :x :y | x name < y name ] ];
+				format: [ :namespace | namespace stubFormattedName ];
+				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ] ].
+	browser transmit
+		to: #classes;
 		from: #namespaces;
 		andShow: [ :a | 
 			a tree
-				display: [:namespace | namespace classes asSortedCollection: [:x :y | x name < y name]];		
-				format: [:class | class stubFormattedName];
-				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ]].
-	browser transmit to: #methods;
+				display: [ :namespace | namespace classes asSortedCollection: [ :x :y | x name < y name ] ];
+				format: [ :class | class stubFormattedName ];
+				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ] ].
+	browser transmit
+		to: #methods;
 		from: #classes;
-		andShow: [ :a |
+		andShow: [ :a | 
 			a tree
-				display: [:class | class methods asSortedCollection: [:x :y | x name < y name]];
+				display: [ :class | class methods asSortedCollection: [ :x :y | x name < y name ] ];
 				format: #stubFormattedName;
-				tags: [:method |
-					col := method modifiers copy. 
-					method hasClassScope ifTrue: [col add: 'isStatic'].
-					method kind notNil ifTrue: [col add: method kind].
+				tags: [ :method | 
+					col := method modifiers copy.
+					method hasClassScope ifTrue: [ col add: 'isStatic' ].
+					method kind isNotNil ifTrue: [ col add: method kind ].
 					col ];
-				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ]].
-	browser transmit toOutsidePort: #namespace; from: #namespaces.
-	browser transmit toOutsidePort: #class; from: #classes.
-	browser transmit toOutsidePort: #method; from: #methods.
-	browser transmit to: #namespaces port: #selection; fromOutsidePort: #namespaceToSelect.
-	browser transmit to: #classes port: #selection; fromOutsidePort: #classToSelect.
-	browser transmit to: #methods port: #selection; fromOutsidePort: #methodToSelect.
+				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ] ].
+	browser transmit
+		toOutsidePort: #namespace;
+		from: #namespaces.
+	browser transmit
+		toOutsidePort: #class;
+		from: #classes.
+	browser transmit
+		toOutsidePort: #method;
+		from: #methods.
+	browser transmit
+		to: #namespaces port: #selection;
+		fromOutsidePort: #namespaceToSelect.
+	browser transmit
+		to: #classes port: #selection;
+		fromOutsidePort: #classToSelect.
+	browser transmit
+		to: #methods port: #selection;
+		fromOutsidePort: #methodToSelect.
 	^ browser
 ]
 

--- a/src/Moose-Finder/MooseClassHierarchyBrowser.class.st
+++ b/src/Moose-Finder/MooseClassHierarchyBrowser.class.st
@@ -44,16 +44,18 @@ MooseClassHierarchyBrowser >> detailsIn: a [
 		title: 'Type source';
 		allowNil;
 		display: [ :type | type formattedSourceText ].
-	a custom: 
-		((MooseFileSourceAnchorViewer new browser )
-						title: 'Method file source';
-						display: [:type :method | method ifNotNil: [ method sourceAnchor] ];
-						when: [:type :method | method notNil ]).		
-	a custom: 
-		((MooseFileSourceAnchorViewer new browser )
-						title: 'Type file source';
-						allowNil;
-						display: [:type | type sourceAnchor ])
+	a
+		custom:
+			(MooseFileSourceAnchorViewer new browser
+				title: 'Method file source';
+				display: [ :type :method | method ifNotNil: [ method sourceAnchor ] ];
+				when: [ :type :method | method isNotNil ]).
+	a
+		custom:
+			(MooseFileSourceAnchorViewer new browser
+				title: 'Type file source';
+				allowNil;
+				display: [ :type | type sourceAnchor ])
 ]
 
 { #category : #building }

--- a/src/Moose-Finder/MooseCodeBrowser.class.st
+++ b/src/Moose-Finder/MooseCodeBrowser.class.st
@@ -67,39 +67,48 @@ MooseCodeBrowser >> onClassesFromPackages [
 
 { #category : #building }
 MooseCodeBrowser >> onDetailsFromPackagesFromClassesFromMethods [
-	browser
-		transmit to: #details; from: #classes; from: #methods; from: #packages; 
-		andShow: [ :a :class :method |
+	browser transmit
+		to: #details;
+		from: #classes;
+		from: #methods;
+		from: #packages;
+		andShow: [ :a :class :method | 
 			a text
-					title: 'Method';
-					format: [ method formattedSourceText ].
+				title: 'Method';
+				format: [ method formattedSourceText ].
 			a text
-					title: 'Class';
-					useExplicitNotNil;
-					when: [ class notNil and: [method isNil]];
-					format: [ class formattedSourceText ].
-"			browser list
+				title: 'Class';
+				useExplicitNotNil;
+				when: [ class isNotNil and: [ method isNil ] ];
+				format: [ class formattedSourceText ].
+			"			browser list
 					title: 'References';
 					useExplicitNotNil;
 					when: [:class | class notNil ];
 					display: [:class | class references];
 					format: [:each | each glmBehavior name, '>>', each name];
 					populate: #focusOnMethod on: $f entitled: 'Jump there' with: [:list | list selection ].
-"			a list
-					title: 'Senders';
-					display: [ method invokingMethods ];
-					format: [:each | each mooseName ];
-					dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
-					selectionPopulate: #focusOnMethod on: $f entitled: 'Jump there' with: [:list | list selection ];
-					when: [ method invokingMethods notEmpty ].
+"
 			a list
-					title: 'Messages';
-					display: [ method invokedMethods];
-					format: [:each | each mooseName ];
-					dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
-					selectionPopulate: #focusOnMethod on: $f entitled: 'Jump there' with: [:list | list selection ];
-					when: [ method invokedMethods notEmpty ].
-		]
+				title: 'Senders';
+				display: [ method invokingMethods ];
+				format: [ :each | each mooseName ];
+				dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
+				selectionPopulate: #focusOnMethod
+					on: $f
+					entitled: 'Jump there'
+					with: [ :list | list selection ];
+				when: [ method invokingMethods isNotEmpty ].
+			a list
+				title: 'Messages';
+				display: [ method invokedMethods ];
+				format: [ :each | each mooseName ];
+				dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
+				selectionPopulate: #focusOnMethod
+					on: $f
+					entitled: 'Jump there'
+					with: [ :list | list selection ];
+				when: [ method invokedMethods isNotEmpty ] ]
 ]
 
 { #category : #building }

--- a/src/Moose-Finder/MooseCodeNavigator.class.st
+++ b/src/Moose-Finder/MooseCodeNavigator.class.st
@@ -60,12 +60,10 @@ MooseCodeNavigator >> methodsIn: a [
 		display: [ :class | class methods asSortedCollection: [ :x :y | x name < y name ] ];
 		format: #stubFormattedName;
 		tags: [ :method | 
-					col := method modifiers copy.
-					method hasClassScope
-						ifTrue: [ col add: 'isStatic' ].
-					method kind notNil
-						ifTrue: [ col add: method kind ].
-					col ];
+			col := method modifiers copy.
+			method hasClassScope ifTrue: [ col add: 'isStatic' ].
+			method kind isNotNil ifTrue: [ col add: method kind ].
+			col ];
 		dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ]
 ]
 

--- a/src/Moose-Finder/MooseDependencyBrowser.class.st
+++ b/src/Moose-Finder/MooseDependencyBrowser.class.st
@@ -43,7 +43,7 @@ MooseDependencyBrowser >> detailsIn: a [
 				method: method
 				on: view ];
 		allowNil;
-		when: [ :model | model notNil ].
+		when: [ :model | model isNotNil ].
 	a roassal2
 		initializeView: [ RTMondrian new ];
 		title: 'Map of clients';
@@ -56,37 +56,47 @@ MooseDependencyBrowser >> detailsIn: a [
 				method: method
 				on: view ];
 		allowNil;
-		when: [ :model | model notNil ].
+		when: [ :model | model isNotNil ].
 	a text
 		title: 'Source code';
 		display: [ :model :namespace :class | class formattedSourceText ];
 		allowNil;
-		when: [ :model :namespace :class :method | class notNil and: [ method isNil ] ].
+		when: [ :model :namespace :class :method | class isNotNil and: [ method isNil ] ].
 	^ a text
 		title: 'Source code';
 		display: [ :model :namespace :class :method | method formattedSourceText ]
 ]
 
 { #category : #reusable }
-MooseDependencyBrowser >> viewNamespaceMapOf: aBlock fromModel: model namespace: namespace class:class method:method on: view [
+MooseDependencyBrowser >> viewNamespaceMapOf: aBlock fromModel: model namespace: namespace class: class method: method on: view [
 	| source invokedNamespaces allInvokedNamespaces layoutEdges |
-	source := method ifNil: [ class  ].
-	invokedNamespaces := source notNil ifTrue: [ aBlock value: source ] ifFalse: [ #() ].
-	allInvokedNamespaces := namespace notNil ifTrue: [ aBlock value: namespace  ] ifFalse: [ #() ].
+	source := method ifNil: [ class ].
+	invokedNamespaces := source isNotNil
+		ifTrue: [ aBlock value: source ]
+		ifFalse: [ #() ].
+	allInvokedNamespaces := namespace isNotNil
+		ifTrue: [ aBlock value: namespace ]
+		ifFalse: [ #() ].
 	view shape rectangle
-		height: #numberOfClasses; width: 7; 
-		borderColor: Color lightGray; fillColor: [:each | 
-		each = namespace 
-			ifTrue: [Color blue]
-			ifFalse: [(invokedNamespaces includes: each ) 
-				ifTrue: [Color red] ifFalse: [(allInvokedNamespaces includes: each ) 
-					ifTrue: [Color lightRed] ifFalse: [Color white] ]] ].
+		height: #numberOfClasses;
+		width: 7;
+		borderColor: Color lightGray;
+		fillColor: [ :each | 
+			each = namespace
+				ifTrue: [ Color blue ]
+				ifFalse: [ (invokedNamespaces includes: each)
+						ifTrue: [ Color red ]
+						ifFalse: [ (allInvokedNamespaces includes: each)
+								ifTrue: [ Color lightRed ]
+								ifFalse: [ Color white ] ] ] ].
 	view nodes: model allNamespaces.
 	view shape orthoVerticalLine color: Color veryLightGray.
 	layoutEdges := view edgesFrom: #belongsTo.
-	view layout tree horizontalGap: 1; userDefinedEdges: layoutEdges.
-"				source ~= namespace ifTrue: [
+	view layout tree
+		horizontalGap: 1;
+		userDefinedEdges: layoutEdges
+	"				source ~= namespace ifTrue: [
 					view shape splineLine color: Color red.
 					view edges: {namespace} from: #yourself toAll: invokedNamespaces ]
-"				
+"
 ]

--- a/src/Moose-Finder/MooseFileSourceAnchorViewer.class.st
+++ b/src/Moose-Finder/MooseFileSourceAnchorViewer.class.st
@@ -11,13 +11,13 @@ Class {
 MooseFileSourceAnchorViewer >> buildBrowser [
 	browser := GLMTabulator new.
 	browser column: #one.
-	browser transmit 
-		to: #one; 
-		andShow: [:a | a text display: [:sourceAnchor | sourceAnchor completeText ]].
-	browser transmit 
-		fromOutsidePort: #entity; 
-		to: #one port: #selectionInterval; 
-		transformed: [:sourceAnchor | sourceAnchor intervalAsCharPos ];
-		when: [:sourceAnchor | sourceAnchor notNil ].
+	browser transmit
+		to: #one;
+		andShow: [ :a | a text display: [ :sourceAnchor | sourceAnchor completeText ] ].
+	browser transmit
+		fromOutsidePort: #entity;
+		to: #one port: #selectionInterval;
+		transformed: [ :sourceAnchor | sourceAnchor intervalAsCharPos ];
+		when: [ :sourceAnchor | sourceAnchor isNotNil ].
 	^ browser
 ]

--- a/src/Moose-Finder/MooseMetaBrowser.class.st
+++ b/src/Moose-Finder/MooseMetaBrowser.class.st
@@ -174,9 +174,12 @@ MooseMetaBrowser >> commentOfProperty: fm3Prop [
 MooseMetaBrowser >> commentsIn: a [
 	a text
 		title: 'Comment' translated;
-		display: [ :fm3Class | fm3Class implementingClass ifNil: [ '' ] ifNotNil: [ :class | class comment ] ];
+		display: [ :fm3Class | 
+			fm3Class implementingClass
+				ifNil: [ '' ]
+				ifNotNil: [ :class | class comment ] ];
 		useExplicitNotNil;
-		when: [ :fm3Class :fm3Prop | fm3Class notNil and: [ fm3Prop isNil ] ];
+		when: [ :fm3Class :fm3Prop | fm3Class isNotNil and: [ fm3Prop isNil ] ];
 		act: [ :text :fm3Class | fm3Class implementingClass ifNotNil: [ :class | class comment: text text ] ]
 			icon: MooseIcons mooseAccept
 			on: $s
@@ -188,7 +191,7 @@ MooseMetaBrowser >> commentsIn: a [
 			icon: MooseIcons mooseAccept
 			on: $s
 			entitled: 'Accept';
-		when: [ :fm3Class :fm3Prop | fm3Prop notNil ]
+		when: [ :fm3Class :fm3Prop | fm3Prop isNotNil ]
 ]
 
 { #category : #private }
@@ -223,21 +226,28 @@ MooseMetaBrowser >> metamodelMapIn: a [
 		painting: [ :view :all :fm3Class :fm3Prop | 
 			b := RTMondrian new.
 			b view: view.
-			self viewClass: fm3Class property: fm3Prop in: all on: b.
+			self
+				viewClass: fm3Class
+				property: fm3Prop
+				in: all
+				on: b.
 			b build.
-			
+
 			self addClassLegendOn: view ];
 		useExplicitNotNil;
-		when: [ :fm3Class | fm3Class notNil ]
+		when: [ :fm3Class | fm3Class isNotNil ]
 ]
 
 { #category : #building }
 MooseMetaBrowser >> methodCommentsIn: a [
 	a text
 		title: 'Comment' translated;
-		display: [ :fm3Class | fm3Class implementingClass ifNil: [ '' ] ifNotNil: [ :class | class comment ] ];
+		display: [ :fm3Class | 
+			fm3Class implementingClass
+				ifNil: [ '' ]
+				ifNotNil: [ :class | class comment ] ];
 		useExplicitNotNil;
-		when: [ :fm3Class :compiledMethod | fm3Class notNil and: [ compiledMethod isNil ] ];
+		when: [ :fm3Class :compiledMethod | fm3Class isNotNil and: [ compiledMethod isNil ] ];
 		act: [ :text :fm3Class | fm3Class implementingClass ifNotNil: [ fm3Class implementingClass comment: text text ] ]
 			icon: MooseIcons mooseAccept
 			on: $s
@@ -249,7 +259,7 @@ MooseMetaBrowser >> methodCommentsIn: a [
 			icon: MooseIcons mooseAccept
 			on: $s
 			entitled: 'Accept';
-		when: [ :fm3Class :compiledMethod | compiledMethod notNil ]
+		when: [ :fm3Class :compiledMethod | compiledMethod isNotNil ]
 ]
 
 { #category : #private }
@@ -267,23 +277,30 @@ MooseMetaBrowser >> viewClass: fm3Class property: fm3Prop in: all on: view [
 	| edges |
 	view interaction popupText: [ :each | each fullName asString ].
 	view shape rectangle
-		fillColor: [ :each | each = fm3Class ifTrue: [ Color blue muchLighter ] ifFalse: [
-				each implementingClass 
-					ifNil: [Color lightRed]
-					ifNotNil: [:aClass | aClass organization classComment isNotEmpty ifTrue: [ Color white ] ifFalse: [ Color lightRed ] ]
-				] ];
-		borderColor: [ :each | each = fm3Class ifTrue: [ Color blue lighter ] ifFalse: [ Color gray ] ];
+		fillColor: [ :each | 
+			each = fm3Class
+				ifTrue: [ Color blue muchLighter ]
+				ifFalse: [ each implementingClass
+						ifNil: [ Color lightRed ]
+						ifNotNil: [ :aClass | 
+							aClass organization classComment isNotEmpty
+								ifTrue: [ Color white ]
+								ifFalse: [ Color lightRed ] ] ] ];
+		borderColor: [ :each | 
+			each = fm3Class
+				ifTrue: [ Color blue lighter ]
+				ifFalse: [ Color gray ] ];
 		height: [ :each | each complexProperties size * 2 + 5 ];
 		width: [ :each | each primitiveProperties size ].
 	view nodes: all classes.
 	edges := view edgesFrom: #superclass.
-	fm3Class notNil ifTrue: [
-		view shape line 
-			color: Color blue muchLighter ;
-			width: [:each | each = fm3Prop ifTrue: [ 3 ] ifFalse: [ 1 ] ].
-		view 
-			edges source: fm3Class allComplexProperties 
-			connectFrom: fm3Class 
-			to: [ :attr | attr type ] ].
+	fm3Class isNotNil
+		ifTrue: [ view shape line
+				color: Color blue muchLighter;
+				width: [ :each | 
+					each = fm3Prop
+						ifTrue: [ 3 ]
+						ifFalse: [ 1 ] ].
+			view edges source: fm3Class allComplexProperties connectFrom: fm3Class to: [ :attr | attr type ] ].
 	view treeLayout userDefinedEdges: edges
 ]

--- a/src/Moose-Finder/MooseModel.extension.st
+++ b/src/Moose-Finder/MooseModel.extension.st
@@ -174,13 +174,9 @@ MooseModel >> mooseInterestingEntity [
 { #category : #'*Moose-Finder' }
 MooseModel >> rename [
 	<menuItem: 'Rename' category: 'Utilities'>
-
 	| newName |
-	newName := UITheme builder
-		textEntry: 'Set new name for MooseModel ', self name.
-	(newName notNil and: [newName notEmpty])
-		ifTrue: [ self name: newName ]
-
+	newName := UITheme builder textEntry: 'Set new name for MooseModel ' , self name.
+	(newName isNotNil and: [ newName isNotEmpty ]) ifTrue: [ self name: newName ]
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-Finder/MooseObject.extension.st
+++ b/src/Moose-Finder/MooseObject.extension.st
@@ -111,7 +111,7 @@ MooseObject >> mooseFinderPropertiesIn: composite [
 				do: [ 'error' ] ];
 		when: [ :anObject | 
 			(anObject mooseInterestingEntity isKindOf: MooseObject)
-				and: [ anObject mooseInterestingEntity mooseDescription notNil and: [ anObject mooseInterestingEntity mooseDescription allPrimitiveProperties notEmpty ] ] ]
+				and: [ anObject mooseInterestingEntity mooseDescription isNotNil and: [ anObject mooseInterestingEntity mooseDescription allPrimitiveProperties isNotEmpty ] ] ]
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-GenericImporters-Tests/MooseFileStructureImporterTest.class.st
+++ b/src/Moose-GenericImporters-Tests/MooseFileStructureImporterTest.class.st
@@ -225,7 +225,7 @@ MooseFileStructureImporterTest >> testNestedFiles [
 MooseFileStructureImporterTest >> testSourceText [
 	| files |
 	files := model allFiles.
-	self assert: (files entityNamed: #'folders/fileWith9Chars2Lines') sourceText notEmpty
+	self assert: (files entityNamed: #'folders/fileWith9Chars2Lines') sourceText isNotEmpty
 ]
 
 { #category : #accessing }

--- a/src/Moose-RoassalPaintings/FamixAnnotationTypeGroup.extension.st
+++ b/src/Moose-RoassalPaintings/FamixAnnotationTypeGroup.extension.st
@@ -20,14 +20,20 @@ FamixAnnotationTypeGroup >> viewAnnotationConstellationOf: aClassGroup on: view 
 	view shape label
 		fillColor: Color gray;
 		text: #name;
-		height: (RTNFontLinearNormalizer inContext: self withCommand: [ :each | (each instances collectAsSet: [ :inst | (inst annotatedEntity atScope: FamixTType) anyOne ]) size max: 20 ]).
+		height:
+			(RTNFontLinearNormalizer
+				inContext: self
+				withCommand: [ :each | (each instances collectAsSet: [ :inst | (inst annotatedEntity atScope: FamixTType) anyOne ]) size max: 20 ]).
 	view interaction menu action: #mooseMenuMorph.
-	view nodes: (self select: [ :each | each annotatedEntities notEmpty ]).
+	view nodes: (self select: [ :each | each annotatedEntities isNotEmpty ]).
 
 	view shape line
 		color: (Color veryVeryLightGray alpha: 0.5);
 		width: 1.
-	view edges source: self connectFromAll: [ :each | each annotatedEntities collectAsSet: [ :inst | (inst annotatedEntity atScope: FamixTType) anyOne ] ] to: #yourself.
+	view edges
+		source: self
+		connectFromAll: [ :each | each annotatedEntities collectAsSet: [ :inst | (inst annotatedEntity atScope: FamixTType) anyOne ] ]
+		to: #yourself.
 	view layout force.
 	view view pushBackEdges
 ]

--- a/src/Moose-SmalltalkImporter/AbstractSmalltalkMethodVisitor.class.st
+++ b/src/Moose-SmalltalkImporter/AbstractSmalltalkMethodVisitor.class.st
@@ -98,62 +98,37 @@ AbstractSmalltalkMethodVisitor >> matchConstant: aMethodNode [
 ]
 
 { #category : #'method-classifying' }
-AbstractSmalltalkMethodVisitor >> matchConstructor: aMethodNode [ 
-	 
-	famixMethod protocol notNil 
-		ifTrue: 
-			[('*instance*creation*' match: famixMethod protocol asLowercase) 
-				ifTrue: [famixMethod kind: #constructor]]
+AbstractSmalltalkMethodVisitor >> matchConstructor: aMethodNode [
+	famixMethod protocol isNotNil ifTrue: [ ('*instance*creation*' match: famixMethod protocol asLowercase) ifTrue: [ famixMethod kind: #constructor ] ]
 ]
 
 { #category : #'method-classifying' }
-AbstractSmalltalkMethodVisitor >> matchGetter: aMethodNode [ 
-	 
-	| return attribute | 
-	aMethodNode arguments isEmpty 
-		ifTrue: 
-			[aMethodNode body isSequence 
-				ifTrue: 
-					[aMethodNode body statements size = 1 
-						ifTrue: 
-							[return := aMethodNode body statements first. 
-							return isReturn 
-								ifTrue: 
-									[return value isVariable 
-										ifTrue: 
-											[attribute := methodScope 
-												resolve: return value name 
-												ifAbsent: nil. 
-											attribute notNil 
-												ifTrue: 
-													[attribute class = self importer factory attribute ifTrue: [famixMethod kind: #getter]]]]]]]
+AbstractSmalltalkMethodVisitor >> matchGetter: aMethodNode [
+	| return attribute |
+	aMethodNode arguments isEmpty
+		ifTrue: [ aMethodNode body isSequence
+				ifTrue: [ aMethodNode body statements size = 1
+						ifTrue: [ return := aMethodNode body statements first.
+							return isReturn
+								ifTrue: [ return value isVariable
+										ifTrue: [ attribute := methodScope resolve: return value name ifAbsent: nil.
+											attribute isNotNil ifTrue: [ attribute class = self importer factory attribute ifTrue: [ famixMethod kind: #getter ] ] ] ] ] ] ]
 ]
 
 { #category : #'method-classifying' }
-AbstractSmalltalkMethodVisitor >> matchSetter: aMethodNode [ 
-	 
-	| assignment attribute | 
-	aMethodNode arguments size = 1 
-		ifTrue: 
-			[aMethodNode body isSequence 
-				ifTrue: 
-					[aMethodNode body statements size = 1 
-						ifTrue: 
-							[assignment := aMethodNode body statements first. 
-							assignment isReturn ifTrue: [assignment := assignment value]. 
-							assignment isAssignment 
-								ifTrue: 
-									[attribute := methodScope 
-										resolve: assignment variable name 
-										ifAbsent: nil. 
-									attribute notNil 
-										ifTrue: 
-											[attribute class = self importer factory attribute 
-												ifTrue: 
-													[assignment value isVariable 
-														ifTrue: 
-															[assignment value name = aMethodNode arguments first name 
-																ifTrue: [famixMethod kind: #setter]]]]]]]]
+AbstractSmalltalkMethodVisitor >> matchSetter: aMethodNode [
+	| assignment attribute |
+	aMethodNode arguments size = 1
+		ifTrue: [ aMethodNode body isSequence
+				ifTrue: [ aMethodNode body statements size = 1
+						ifTrue: [ assignment := aMethodNode body statements first.
+							assignment isReturn ifTrue: [ assignment := assignment value ].
+							assignment isAssignment
+								ifTrue: [ attribute := methodScope resolve: assignment variable name ifAbsent: nil.
+									attribute isNotNil
+										ifTrue: [ attribute class = self importer factory attribute
+												ifTrue:
+													[ assignment value isVariable ifTrue: [ assignment value name = aMethodNode arguments first name ifTrue: [ famixMethod kind: #setter ] ] ] ] ] ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/Moose-TestResources-LAN/LANPacket.class.st
+++ b/src/Moose-TestResources-LAN/LANPacket.class.st
@@ -55,14 +55,8 @@ LANPacket >> originator: aNode [
 ]
 
 { #category : #printing }
-LANPacket >> printOn: aStream [ 
-	 
-	super printOn: aStream. 
-	self originator notNil 
-		ifTrue: 
-			[aStream nextPutAll: ' coming from ' , self originator name printString]. 
-	aStream 
-		nextPutAll: 
-			' addressed to ' , self addressee printString , ' with contents: ' 
-				, self contents
+LANPacket >> printOn: aStream [
+	super printOn: aStream.
+	self originator isNotNil ifTrue: [ aStream nextPutAll: ' coming from ' , self originator name printString ].
+	aStream nextPutAll: ' addressed to ' , self addressee printString , ' with contents: ' , self contents
 ]

--- a/src/Moose-Tests-Core/FamixTest.class.st
+++ b/src/Moose-Tests-Core/FamixTest.class.st
@@ -99,5 +99,5 @@ FamixTest >> testSourcesAnchorsAreNotDuplicatedAfterExport [
 	tempFile writeStreamDo: [ :s | model exportToMSEStream: s ].
 	importedModel := FamixTest3Model new importFromMSEStream: tempFile readStream.
 	self assert: importedModel size equals: model size.
-	self assert: importedModel allClasses anyOne sourceAnchor notNil
+	self assert: importedModel allClasses anyOne sourceAnchor isNotNil
 ]

--- a/src/Moose-Tests-Core/MooseMSEImporterTest.class.st
+++ b/src/Moose-Tests-Core/MooseMSEImporterTest.class.st
@@ -12,8 +12,9 @@ MooseMSEImporterTest >> readMSEStream: aStream [
 { #category : #tests }
 MooseMSEImporterTest >> testComplex [
 	| mooseModel |
-	mooseModel := self readMSEStream: (
-'(
+	mooseModel := self
+		readMSEStream:
+			'(
 	(FAMIX.Namespace (id: 1) (name ''aNamespace''))
 
 	(FAMIX.Class (id: 2) (name ''ClassA'') (container (ref: 1)) (parentPackage (ref: 201)))
@@ -26,18 +27,18 @@ MooseMSEImporterTest >> testComplex [
 
 	(FAMIX.Package (id: 201) (name ''aPackage''))
 	(FAMIX.Package (id: 202) (name ''aPackage'') (parentPackage (ref: 201)))
-)' readStream).
-	
-	self assert: (mooseModel entities notEmpty).
+)' readStream.
+
+	self assert: mooseModel entities isNotEmpty.
 	self assert: ((mooseModel allPackages collect: #name) includes: 'aPackage').
-	self assert: ((mooseModel allClasses collect: #name) includes: 'ClassA').
+	self assert: ((mooseModel allClasses collect: #name) includes: 'ClassA')
 ]
 
 { #category : #tests }
 MooseMSEImporterTest >> testOneClass [
 	| mooseModel |
 	mooseModel := self readMSEStream: '((FAMIX.Class (name ''ClassA'')))' readStream.
-	self assert: mooseModel entities notEmpty.
+	self assert: mooseModel entities isNotEmpty.
 	self assert: (mooseModel allClasses collect: #name) first equals: 'ClassA'
 ]
 
@@ -50,7 +51,7 @@ MooseMSEImporterTest >> testOneClassAndOnePackage [
 	(FAMIX.Class (id: 2) (name ''ClassA'') (parentPackage (ref: 201)))
 	(FAMIX.Package (id: 201) (name ''aPackage''))	
 )' readStream.
-	self assert: mooseModel entities notEmpty.
+	self assert: mooseModel entities isNotEmpty.
 	self assert: (mooseModel allPackages collect: #name) first equals: 'aPackage'.
 	self assert: (mooseModel allClasses collect: #name) first equals: 'ClassA'
 ]
@@ -58,17 +59,17 @@ MooseMSEImporterTest >> testOneClassAndOnePackage [
 { #category : #tests }
 MooseMSEImporterTest >> testOnePackage [
 	| mooseModel |
-	mooseModel := self readMSEStream: ('((FAMIX.Package (name ''PackageA'')))' readStream).
-	
-	self assert: (mooseModel entities notEmpty).
-	self assert: ((mooseModel allPackages collect: #name) includes: 'PackageA').
+	mooseModel := self readMSEStream: '((FAMIX.Package (name ''PackageA'')))' readStream.
+
+	self assert: mooseModel entities isNotEmpty.
+	self assert: ((mooseModel allPackages collect: #name) includes: 'PackageA')
 ]
 
 { #category : #tests }
 MooseMSEImporterTest >> testOnePrimitiveType [
 	| mooseModel |
 	mooseModel := self readMSEStream: '((FAMIX.PrimitiveType (name ''int'')))' readStream.
-	self assert: mooseModel entities notEmpty.
+	self assert: mooseModel entities isNotEmpty.
 	self assert: (mooseModel allPrimitiveTypes collect: #name) first equals: 'int'
 ]
 
@@ -99,11 +100,11 @@ MooseMSEImporterTest >> testSimple [
 	| mooseSample mooseModel classA |
 	mooseSample := MooseSampleData new.
 	mooseModel := self readMSEStream: mooseSample modelVersion1 readStream.
-	self assert: mooseModel entities notEmpty.
+	self assert: mooseModel entities isNotEmpty.
 	self assert: (mooseModel allClasses collect: #name) asSortedCollection asArray equals: {'ClassA' . 'ClassB'}.
 	self assert: (mooseModel allPackages collect: #name) asArray equals: {'aPackage' . 'aPackage'}.
 	classA := mooseModel entityNamed: #'aNamespace::ClassA'.
-	self assert: classA notNil.
+	self assert: classA isNotNil.
 	self assert: classA container identicalTo: (mooseModel entityNamed: #aNamespace).
 	self assert: classA methods size equals: 1.	"====="
 	self shouldnt: [ self readMSEStream: mooseSample modelVersion2 readStream ] raise: Error.
@@ -117,6 +118,6 @@ MooseMSEImporterTest >> testUndeclaredProperty [
 	| mooseModel |
 	mooseModel := self readMSEStream: '((FAMIX.Class (name ''ClassA'') (Undeclared 42) ))' readStream.
 	self assert: mooseModel allClasses first name equals: 'ClassA'.
-	self assert: (mooseModel allClasses first propertyNamed: #Undeclared) notNil.
+	self assert: (mooseModel allClasses first propertyNamed: #Undeclared) isNotNil.
 	self assert: (mooseModel allClasses first propertyNamed: #Undeclared) equals: 42
 ]

--- a/src/Moose-Tests-Core/MooseModelTest.class.st
+++ b/src/Moose-Tests-Core/MooseModelTest.class.st
@@ -134,8 +134,7 @@ MooseModelTest >> testMenuCommandOn [
 	self assert: builder itemList isNil.
 	MooseModel menuCommandOn: builder.
 	self assert: builder itemList isCollection.
-	self assert: builder itemList notEmpty.
-
+	self assert: builder itemList isNotEmpty
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-Core/MooseObjectTest.class.st
+++ b/src/Moose-Tests-Core/MooseObjectTest.class.st
@@ -105,7 +105,7 @@ MooseObjectTest >> testPrivateStateMutator [
 	| entity state mooseState |
 	entity := self actualClass new.
 	state := entity privateState.
-	self assert: state notNil.
+	self assert: state isNotNil.
 
 	mooseState := MooseMemoryEfficientState new.
 	entity privateState: mooseState.

--- a/src/Moose-Tests-Finder/MooseModelFinderExtensionsTest.class.st
+++ b/src/Moose-Tests-Finder/MooseModelFinderExtensionsTest.class.st
@@ -50,8 +50,7 @@ MooseModelFinderExtensionsTest >> testMenuBrowseMetaOn [
 	self assert: builder itemList isNil.
 	MooseModel menuBrowseMetaOn: builder.
 	self assert: builder itemList isCollection.
-	self assert: builder itemList notEmpty.
-
+	self assert: builder itemList isNotEmpty
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-RoassalPaintings/MooseGroupPaintingTest.class.st
+++ b/src/Moose-Tests-RoassalPaintings/MooseGroupPaintingTest.class.st
@@ -15,26 +15,22 @@ MooseGroupPaintingTest >> tearDown [
 
 { #category : #tests }
 MooseGroupPaintingTest >> testBasic [
-
 	| m |
 	m := MooseGroup new.
 	self assert: m symbolsUsedInName isEmpty.
 	window := m viewNameCloud.
-	self assert: window notNil.
-	
+	self assert: window isNotNil
 ]
 
 { #category : #tests }
 MooseGroupPaintingTest >> testBasic02 [
-
 	| m |
 	m := MooseGroup new.
 	m add: (FAMIXClass new name: 'Hello').
 	m add: (FAMIXClass new name: 'World').
-	
+
 	self assert: m symbolsUsedInName size equals: 1.
-	
+
 	window := m viewNameCloud.
-	self assert: window notNil.
-	
+	self assert: window isNotNil
 ]

--- a/src/Moose-Tests-RoassalPaintings/OverviewPyramidTest.class.st
+++ b/src/Moose-Tests-RoassalPaintings/OverviewPyramidTest.class.st
@@ -17,7 +17,7 @@ OverviewPyramidTest >> model [
 OverviewPyramidTest >> prepareAnyMooseModel [
 	| model importer models |
 	models := MooseModel root allModels.
-	models notEmpty ifTrue: [ ^ models anyOne ].
+	models isNotEmpty ifTrue: [ ^ models anyOne ].
 	model := FamixStModel new.
 	model name: 'AST'.
 	importer := MoosePharoImporterTask new.

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
@@ -371,8 +371,8 @@ FamixReferenceModelImporterTest >> testClassReferenceFromTheInstanceSide [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassReferencesByFullNameReified [
 	"self debug: #testClassReferencesByFullNameReified"
-	
-	self assert: (self model entityNamed: TestCase class mooseName) notNil
+
+	self assert: (self model entityNamed: TestCase class mooseName) isNotNil
 ]
 
 { #category : #tests }
@@ -553,10 +553,10 @@ FamixReferenceModelImporterTest >> testExternalExtension [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testFormalParameterReified [
 	"self debug: #testFormalParameterReified"
-	
+
 	| formalParameterName |
 	formalParameterName := #'Smalltalk::TheRoot.accessingArgument:(Object).anArgument'.
-	self assert: (self model entityNamed: formalParameterName) notNil
+	self assert: (self model entityNamed: formalParameterName) isNotNil
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-Core/MooseScripts.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/MooseScripts.class.st
@@ -266,12 +266,12 @@ MooseScripts class >> packagesForConfigurationVersion: aConfiguration [
 	version ignoreImage: true.
 	directive := version record loadDirective.
 	packages := OrderedCollection new.
-	directive versionDirectivesDo: [:vrsnDirective | | spec |
-	spec := vrsnDirective spec.
-	(spec notNil and: [spec project = aConfiguration spec project ])
-		ifTrue: [ 
-			vrsnDirective packagesDo: [:pkgDirective | 
-				packages add: (self extractPackageNameOutOfMetacelloFile: pkgDirective file) ]]].
+	directive
+		versionDirectivesDo: [ :vrsnDirective | 
+			| spec |
+			spec := vrsnDirective spec.
+			(spec isNotNil and: [ spec project = aConfiguration spec project ])
+				ifTrue: [ vrsnDirective packagesDo: [ :pkgDirective | packages add: (self extractPackageNameOutOfMetacelloFile: pkgDirective file) ] ] ].
 	^ packages asSet reject: [ :each | each beginsWith: 'ConfigurationOf' ]
 ]
 

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FAMIXStepwiseImporterTest.class.st
@@ -106,7 +106,7 @@ FAMIXStepwiseImporterTest >> testImportAttributeAccesses [
 	nodeClass := importer classes at: LANNode.
 	self assert: nodeClass attributes size equals: 2.
 	attr := nodeClass attributes at: 1.
-	self assert: attr readAccesses notEmpty
+	self assert: attr readAccesses isNotEmpty
 ]
 
 { #category : #tests }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FamixInvocationsTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FamixInvocationsTest.class.st
@@ -29,7 +29,7 @@ FamixInvocationsTest >> outputServerAcceptMethod [
 FamixInvocationsTest >> testCandidateAbstractMethodWithTwoSubclasses [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.accept:(Object)' to: #'output:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 2.
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANFileServer.output:(Object)')).
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANPrintServer.output:(Object)'))
@@ -39,7 +39,7 @@ FamixInvocationsTest >> testCandidateAbstractMethodWithTwoSubclasses [
 FamixInvocationsTest >> testCandidateInvocationsAbstractMethodWithTwoSubclasses [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.accept:(Object)' to: #'output:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 2.
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANFileServer.output:(Object)')).
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANPrintServer.output:(Object)'))	"	self assert: (invocation candidates includes: (self model entityNamed: #'Root::Smalltalk::LAN::OutputServer.output:(Object)'))."
@@ -60,7 +60,7 @@ FamixInvocationsTest >> testCandidateInvocationsClassMethodsDefinedInSuperclass 
 FamixInvocationsTest >> testCandidateInvocationsOnlyDefinedInSuperclass [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.accept:(Object)' to: #'send:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 1.
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANNode.send:(Object)'))
 ]
@@ -69,7 +69,7 @@ FamixInvocationsTest >> testCandidateInvocationsOnlyDefinedInSuperclass [
 FamixInvocationsTest >> testCandidateInvocationsThree [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANSingleDestinationAddress.equalsSingle:(Object)' to: #'id()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 1.
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANSingleDestinationAddress.id()'))
 ]
@@ -78,17 +78,16 @@ FamixInvocationsTest >> testCandidateInvocationsThree [
 FamixInvocationsTest >> testCandidateInvocationsTwo [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANInterface.originate()' to: #'originate:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 1.
-	self
-		assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANWorkStation.originate:(Object)'))
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANWorkStation.originate:(Object)'))
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsUnknownReceiver [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANNode.send:(Object)' to: #'accept:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 3.
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANNode.accept:(Object)')).
 	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANWorkStation.accept:(Object)')).
@@ -101,7 +100,7 @@ FamixInvocationsTest >> testReceivingFormalParameter [
 
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'addressee()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver name equals: #thePacket
 ]
 
@@ -109,7 +108,7 @@ FamixInvocationsTest >> testReceivingFormalParameter [
 FamixInvocationsTest >> testReceivingKnownClass [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANInterface.newNode()' to: #'new()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: LANNode class mooseName
 ]
 
@@ -117,23 +116,23 @@ FamixInvocationsTest >> testReceivingKnownClass [
 FamixInvocationsTest >> testReceivingKnownClass2 [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANInterface.newWorkstation()' to: #'new()'.
-	self assert: invocation notNil.
-	self assert: invocation receiver mooseName equals: #Smalltalk::LANWorkStation_class
+	self assert: invocation isNotNil.
+	self assert: invocation receiver mooseName equals: #'Smalltalk::LANWorkStation_class'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingKnownClass3 [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANInterface.newFileServer()' to: #'new()'.
-	self assert: invocation notNil.
-	self assert: invocation receiver mooseName equals: #Smalltalk::LANFileServer_class
+	self assert: invocation isNotNil.
+	self assert: invocation receiver mooseName equals: #'Smalltalk::LANFileServer_class'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingSelf [
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'output:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.accept:(Object).self'
 ]
 
@@ -141,7 +140,7 @@ FamixInvocationsTest >> testReceivingSelf [
 FamixInvocationsTest >> testReceivingSelf2 [
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'name()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.accept:(Object).self'
 ]
 
@@ -149,7 +148,7 @@ FamixInvocationsTest >> testReceivingSelf2 [
 FamixInvocationsTest >> testReceivingSelf3 [
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'send:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.accept:(Object).self'
 ]
 
@@ -157,7 +156,7 @@ FamixInvocationsTest >> testReceivingSelf3 [
 FamixInvocationsTest >> testReceivingSelf9 [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.output:(Object)' to: #'subclassResponsibility()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.output:(Object).self'
 ]
 
@@ -165,7 +164,7 @@ FamixInvocationsTest >> testReceivingSelf9 [
 FamixInvocationsTest >> testReceivingSuper [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANInterface.initialize()' to: #'initialize()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANInterface.initialize().super'
 ]
 
@@ -173,7 +172,7 @@ FamixInvocationsTest >> testReceivingSuper [
 FamixInvocationsTest >> testReceivingSuper2 [
 	| invocation |
 	invocation := self invocationFrom: (LANNode >> #printOn:) mooseName to: #'printOn:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: (LANNode mooseName , '.printOn:(Object).super') asSymbol
 ]
 
@@ -181,7 +180,7 @@ FamixInvocationsTest >> testReceivingSuper2 [
 FamixInvocationsTest >> testReceivingSuper3 [
 	| invocation |
 	invocation := self invocationFrom: (LANNode class >> #new) mooseName to: #'new()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: (LANNode class mooseName , '.new().super') asSymbol
 ]
 
@@ -189,7 +188,7 @@ FamixInvocationsTest >> testReceivingSuper3 [
 FamixInvocationsTest >> testReceivingSuper4 [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANWorkStation.name()' to: #'name()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANWorkStation.name().super'
 ]
 
@@ -197,7 +196,7 @@ FamixInvocationsTest >> testReceivingSuper4 [
 FamixInvocationsTest >> testReceivingSuper5 [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANFileServer.name()' to: #'name()'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANFileServer.name().super'
 ]
 
@@ -205,17 +204,17 @@ FamixInvocationsTest >> testReceivingSuper5 [
 FamixInvocationsTest >> testReceivingSuper6 [
 	| invocation |
 	invocation := self invocationFrom: #'Smalltalk::LANPacket.printOn:(Object)' to: #'printOn:(Object)'.
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: #'Smalltalk::LANPacket.printOn:(Object).super'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingUnknownType [
 	"self debug: #testReceivingUnknownType"
-	
+
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'isDestinationFor:(Object)'.
 
-	self assert: invocation notNil.
+	self assert: invocation isNotNil.
 	self assert: invocation receiver isNil
 ]

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FamixModelExtractionTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FamixModelExtractionTest.class.st
@@ -239,10 +239,9 @@ FamixModelExtractionTest >> testReferenceModel [
 
 { #category : #tests }
 FamixModelExtractionTest >> testUnderstands [
-
 	| aFamixClass |
 	aFamixClass := self model entityNamed: LANFileServer mooseName.
-	self assert: aFamixClass notNil.
+	self assert: aFamixClass isNotNil.
 
 	"method defined in the same class"
 	self assert: (aFamixClass understands: #'output:(Object)').

--- a/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/LANImporterTest.class.st
@@ -6,11 +6,10 @@ Class {
 
 { #category : #tests }
 LANImporterTest >> couldOnlyBeUsedForVisualWorksExtractedModeltestNamespaceInNamespace [
-	 
-	| namespace | 
-	namespace := self model allNamespaces entityNamed: #Smalltalk. 
-	self assert: namespace namespaces notEmpty. 
-	namespace := self model allNamespaces entityNamed: #'LAN'. 
+	| namespace |
+	namespace := self model allNamespaces entityNamed: #Smalltalk.
+	self assert: namespace namespaces isNotEmpty.
+	namespace := self model allNamespaces entityNamed: #LAN.
 	self assert: namespace namespaces isEmpty
 ]
 

--- a/src/Moose-Tests-SmalltalkImporter-LAN/LANMooseGroupTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/LANMooseGroupTest.class.st
@@ -141,7 +141,7 @@ LANMooseGroupTest >> testIncludes [
 
 { #category : #tests }
 LANMooseGroupTest >> testIncludesAllOf [
-	self assert:	(self model allClasses includesAllOf: self model allClasses)
+	self assert: (self model allClasses includesAll: self model allClasses)
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Replace some methods by their alias.

Some because they are more coherent whith their negative equivalent, some because the current version is or will be deprecated in Pharo. 
Also, this will help me for further cleanings.