### PR TITLE
add missing label hook to open a playground

### DIFF
--- a/src/Famix-Deprecated/MoosePanelCommand.extension.st
+++ b/src/Famix-Deprecated/MoosePanelCommand.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #MoosePanelCommand }
+
+{ #category : #'*Famix-Deprecated' }
+MoosePanelCommand >> abstractTag [
+	"Say that this class will not taken into consideration when querying command hierarchy"
+
+	self deprecated: 'Implement #isAbstract class side instead of relying on this method.'
+]
+
+{ #category : #'*Famix-Deprecated' }
+MoosePanelCommand class >> isAbstractCommand [
+	self deprecated: 'Implement #isAbstract instead.'.
+	^ self selectors includes: #abstractTag
+]

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#entities => FMMany type: #FamixTWithFiles opposite: #containerFiles'
 	],
 	#traits : 'FamixTFileSystemEntity',
-	#classTraits : 'FamixTFileSystemEntity classTrait',
 	#category : #'Famix-Traits-File'
 }
 

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -18,7 +18,6 @@ Trait {
 		'#sender => FMOne type: #FamixTWithInvocations opposite: #outgoingInvocations'
 	],
 	#traits : 'FamixTAssociation',
-	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Invocation'
 }
 

--- a/src/Moose-Finder/MPImportCommand.class.st
+++ b/src/Moose-Finder/MPImportCommand.class.st
@@ -4,14 +4,13 @@ Class {
 	#category : #'Moose-Finder'
 }
 
+{ #category : #testing }
+MPImportCommand class >> isAbstract [
+	^ self = MPImportCommand
+]
+
 { #category : #hooks }
 MPImportCommand >> category [
 
 	^ 'Import'
-]
-
-{ #category : #hooks }
-MPImportCommand >> label [
-
-	^ 'Moose Playground'
 ]

--- a/src/Moose-Finder/MPImportCommand.class.st
+++ b/src/Moose-Finder/MPImportCommand.class.st
@@ -9,3 +9,9 @@ MPImportCommand >> category [
 
 	^ 'Import'
 ]
+
+{ #category : #hooks }
+MPImportCommand >> label [
+
+	^ 'Moose Playground'
+]

--- a/src/Moose-Finder/MoosePanelCommand.class.st
+++ b/src/Moose-Finder/MoosePanelCommand.class.st
@@ -9,17 +9,12 @@ Class {
 
 { #category : #accessing }
 MoosePanelCommand class >> allCommands [
-	^ self allSubclasses reject: #isAbstractCommand
+	^ self allSubclasses reject: #isAbstract
 ]
 
 { #category : #testing }
-MoosePanelCommand class >> isAbstractCommand [
-	^ self selectors includes: #abstractTag
-]
-
-{ #category : #accessing }
-MoosePanelCommand >> abstractTag [
-	"Say that this class will not taken into consideration when querying command hierarchy"
+MoosePanelCommand class >> isAbstract [
+	^ self = MoosePanelCommand
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Not sure whether this is the right branch to PR to.

On a fresh Moose 8 image, it's not possible to open a playground via the key bind nor clicks in world menu.
This should fix that.