### PR TITLE
improve-management-of-hasClassScope

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -3,9 +3,6 @@ Class {
 	#superclass : #FAMIXStructuralEntity,
 	#traits : 'FamixTAttribute + FamixTWithClassScope',
 	#classTraits : 'FamixTAttribute classTrait + FamixTWithClassScope classTrait',
-	#instVars : [
-		'#hasClassScope'
-	],
 	#category : #'Famix-Compatibility-Entities-Entities'
 }
 
@@ -30,20 +27,6 @@ FAMIXAttribute >> beSharedVariable [
 	self propertyNamed: #sharedVariable put: true 
 ]
 
-{ #category : #accessing }
-FAMIXAttribute >> hasClassScope [
-	<FMProperty: #hasClassScope type: #Boolean>
-	<FMComment: 'True if class-side attribute'>
-
-	^ hasClassScope
-]
-
-{ #category : #accessing }
-FAMIXAttribute >> hasClassScope: aBoolean [
-
-	hasClassScope := aBoolean
-]
-
 { #category : #'Famix-Extensions' }
 FAMIXAttribute >> hierarchyNestingLevel [
 	<FMProperty: #hierarchyNestingLevel type: #Number>
@@ -59,13 +42,6 @@ FAMIXAttribute >> hierarchyNestingLevel [
 FAMIXAttribute >> hierarchyNestingLevel: aNumber [
 
 	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
-]
-
-{ #category : #initialization }
-FAMIXAttribute >> initialize [
-	super initialize.
-	hasClassScope := false.
-
 ]
 
 { #category : #'Famix-Smalltalk' }

--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -270,15 +270,15 @@ FAMIXMethod >> smalltalkClass [
 { #category : #'Famix-Smalltalk' }
 FAMIXMethod >> sourceText [
 	self flag: 'This code should be delegated to the FAMIXPharoAnchor'.
-	^ (self sourceLanguage isNotNil and: [self sourceLanguage isSmalltalk and: [ self class shouldSearchForSmalltalkCodeInImage ]])
+	^ (self sourceLanguage isNotNil and: [ self sourceLanguage isSmalltalk and: [ self class shouldSearchForSmalltalkCodeInImage ] ])
 		ifTrue: [ [ | class |
 			"take the normal class"
 			class := Smalltalk at: self parentType instanceSide name asSymbol.
-			self hasClassScope
-				ifFalse: [ class sourceCodeAt: self name asSymbol ]
-				ifTrue: [ class class sourceCodeAt: self name asSymbol ]	"dispatch on class or metaclass depending on method scope" ]
+			(self isClassSide
+				ifFalse: [ class ]
+				ifTrue: [ class class ]) sourceCodeAt: self name asSymbol	"dispatch on class or metaclass depending on method scope" ]
 				on: Error
-				do: [ super sourceText ]	"probably class is not in the system" ]
+				do: [ "probably class is not in the system" super sourceText ] ]
 		ifFalse: [ super sourceText ]
 ]
 

--- a/src/Famix-Deprecated/FamixTAttribute.extension.st
+++ b/src/Famix-Deprecated/FamixTAttribute.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #FamixTAttribute }
+
+{ #category : #'*Famix-Deprecated' }
+FamixTAttribute >> hasClassScope [
+	<FMProperty: #hasClassScope type: #Boolean>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	self
+		deprecated: 'This property is deprecated from Moose 8.0. Please use isClassSide instead.'
+		transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
+	^ self isClassSide
+]
+
+{ #category : #'*Famix-Deprecated' }
+FamixTAttribute >> hasClassScope: aBoolean [
+	self deprecated: 'This property is deprecated from Moose 8.0. Please use isClassSide instead.'.
+	^ self isClassSide: aBoolean
+]

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -3,9 +3,6 @@ Class {
 	#superclass : #FamixJavaNamedEntity,
 	#traits : 'FamixTAttribute + FamixTWithClassScope',
 	#classTraits : 'FamixTAttribute classTrait + FamixTWithClassScope classTrait',
-	#instVars : [
-		'#hasClassScope'
-	],
 	#category : #'Famix-Java-Entities-Entities'
 }
 
@@ -16,20 +13,6 @@ FamixJavaAttribute class >> annotation [
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self
-]
-
-{ #category : #accessing }
-FamixJavaAttribute >> hasClassScope [
-	<FMProperty: #hasClassScope type: #Boolean>
-	<FMComment: 'True if class-side attribute'>
-
-	^ hasClassScope
-]
-
-{ #category : #accessing }
-FamixJavaAttribute >> hasClassScope: aBoolean [
-
-	hasClassScope := aBoolean
 ]
 
 { #category : #metrics }
@@ -47,13 +30,6 @@ FamixJavaAttribute >> hierarchyNestingLevel [
 FamixJavaAttribute >> hierarchyNestingLevel: aNumber [
 
 	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
-]
-
-{ #category : #initialization }
-FamixJavaAttribute >> initialize [
-	super initialize.
-	hasClassScope := false.
-
 ]
 
 { #category : #printing }

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1002,6 +1002,9 @@ FamixGenerator >> defineProperties [
 
 	((tAccess property: #isWrite type: #Boolean) 
 		comment: 'Write access').
+		
+	((tAttribute property: #isClassSide type: #Boolean) 
+		comment: 'True if class-side attribute').
 
 	((tAnnotationInstanceAttribute property: #value type: #String)
 		comment: 'Actual value of the attribute used in an annotation').

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -3,9 +3,6 @@ Class {
 	#superclass : #FamixStNamedEntity,
 	#traits : 'FamixTAttribute + FamixTHasModifiers + FamixTWithClassScope',
 	#classTraits : 'FamixTAttribute classTrait + FamixTHasModifiers classTrait + FamixTWithClassScope classTrait',
-	#instVars : [
-		'#hasClassScope'
-	],
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 
@@ -24,20 +21,6 @@ FamixStAttribute >> beSharedVariable [
 	self propertyNamed: #sharedVariable put: true 
 ]
 
-{ #category : #testing }
-FamixStAttribute >> hasClassScope [
-	<FMProperty: #hasClassScope type: #Boolean>
-	<FMComment: 'True if class-side attribute'>
-
-	^ hasClassScope
-]
-
-{ #category : #testing }
-FamixStAttribute >> hasClassScope: aBoolean [
-
-	hasClassScope := aBoolean
-]
-
 { #category : #'Famix-Implementation' }
 FamixStAttribute >> hierarchyNestingLevel [
 	<FMProperty: #hierarchyNestingLevel type: #Number>
@@ -53,13 +36,6 @@ FamixStAttribute >> hierarchyNestingLevel [
 FamixStAttribute >> hierarchyNestingLevel: aNumber [
 
 	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
-]
-
-{ #category : #initialization }
-FamixStAttribute >> initialize [
-	super initialize.
-	hasClassScope := false.
-
 ]
 
 { #category : #'Famix-Implementation' }

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -5,9 +5,11 @@ FAMIXAttribute represents a field of a class. It is an attribute of the parent t
 Trait {
 	#name : #FamixTAttribute,
 	#instVars : [
+		'#isClassSide => FMProperty',
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 
@@ -25,6 +27,19 @@ FamixTAttribute >> isAttribute [
 
 	<generated>
 	^ true
+]
+
+{ #category : #accessing }
+FamixTAttribute >> isClassSide [
+	<FMProperty: #isClassSide type: #Boolean>
+	<FMComment: 'True if class-side attribute'>
+	^ isClassSide ifNil: [ false ]
+]
+
+{ #category : #accessing }
+FamixTAttribute >> isClassSide: anObject [
+	<generated>
+	isClassSide := anObject
 ]
 
 { #category : #printing }

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -9,7 +9,6 @@ Trait {
 		'#fileName => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
-	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,6 +12,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTSourceEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTTypedEntity)',
+	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTSourceEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTTypedEntity classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 
@@ -46,7 +47,7 @@ FamixTMethod >> cyclomaticComplexity: aNumber [
 	self privateState propertyAt: #cyclomaticComplexity put: aNumber
 ]
 
-{ #category : #testing }
+{ #category : #accessing }
 FamixTMethod >> isAbstract [
 
 	<FMProperty: #isAbstract type: #Boolean>

--- a/src/Moose-Finder/FAMIXMethod.extension.st
+++ b/src/Moose-Finder/FAMIXMethod.extension.st
@@ -3,19 +3,18 @@ Extension { #name : #FAMIXMethod }
 { #category : #'*Moose-Finder' }
 FAMIXMethod >> browseSource [
 	<menuItem: 'Source' category: 'Browse'>
-	
-	|class browser |
-	self mooseModel isSmalltalk ifTrue: [
-		class := Smalltalk at: self parentType instanceSide name asSymbol.
-		self hasClassScope
-			ifFalse: [ Smalltalk tools browser openOnClass: class selector: self name ]
-			ifTrue: [ Smalltalk tools browser openOnClass: class class selector: self name ]
-		]
-	ifFalse: [ 
-		browser := MooseNamespacesCodeBrowser new browser.
-		browser openOn: (self mooseModel allNamespaces select: #isRoot).
-		(browser pane port: #focusOnMethod) value: self.
-		 ]
+	| class browser |
+	self mooseModel isSmalltalk
+		ifTrue: [ class := Smalltalk at: self parentType instanceSide name asSymbol.
+			Smalltalk tools browser
+				openOnClass:
+					(self isClassSide
+						ifFalse: [ class ]
+						ifTrue: [ class class ])
+				selector: self name ]
+		ifFalse: [ browser := MooseNamespacesCodeBrowser new browser.
+			browser openOn: (self mooseModel allNamespaces select: #isRoot).
+			(browser pane port: #focusOnMethod) value: self ]
 ]
 
 { #category : #'*Moose-Finder' }

--- a/src/Moose-Finder/MooseBrowsers.class.st
+++ b/src/Moose-Finder/MooseBrowsers.class.st
@@ -85,7 +85,7 @@ MooseBrowsers >> codeNavigator [
 				format: #stubFormattedName;
 				tags: [ :method | 
 					col := method modifiers copy.
-					method hasClassScope ifTrue: [ col add: 'isStatic' ].
+					method isClassSide ifTrue: [ col add: 'isStatic' ].
 					method kind ifNotNil: [ :kind | col add: kind ].
 					col ];
 				dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ] ].

--- a/src/Moose-Finder/MooseCodeBrowser.class.st
+++ b/src/Moose-Finder/MooseCodeBrowser.class.st
@@ -113,45 +113,65 @@ MooseCodeBrowser >> onDetailsFromPackagesFromClassesFromMethods [
 
 { #category : #building }
 MooseCodeBrowser >> onInstVarsFromClasses [
-	browser transmit to: #instVars; from: #classes; andShow: [ :a | 
-		a list
+	browser transmit
+		to: #instVars;
+		from: #classes;
+		andShow: [ :a | 
+			a list
 				title: 'Attributes';
 				display: [ :class | class properties ];
-				format: [:attribute | attribute name ];
+				format: [ :attribute | attribute name ];
 				dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
 				tags: [ :each | 
-					(OrderedCollection 
-						with: (each hasClassScope ifTrue: [self metaString] ifFalse: [self instanceString])) 
-							addAll: each modifiers; yourself ] ]
+					(OrderedCollection
+						with:
+						(each isClassSide
+						ifTrue: [ self metaString ]
+						ifFalse: [ self instanceString ]))
+						addAll: each modifiers;
+						yourself ] ]
 ]
 
 { #category : #building }
 MooseCodeBrowser >> onMethodsFromClasses [
-	browser transmit to: #methods; from: #classes; andShow: [ :a | 
-		a list
+	browser transmit
+		to: #methods;
+		from: #classes;
+		andShow: [ :a | 
+			a list
 				title: 'Methods';
 				display: [ :class | class methods ];
 				format: #name;
 				dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
 				tags: [ :each | 
-					(OrderedCollection 
-						with: (each hasClassScope ifTrue: [self metaString] ifFalse: [self instanceString])) 
-							addAll: each modifiers; yourself ]
-		 ]
+					(OrderedCollection
+						with:
+						(each isClassSide
+						ifTrue: [ self metaString ]
+						ifFalse: [ self instanceString ]))
+						addAll: each modifiers;
+						yourself ] ]
 ]
 
 { #category : #building }
 MooseCodeBrowser >> onMethodsFromInstVars [
-	browser transmit to: #methods; from: #instVars; andShow: [ :a | 
-		a list
+	browser transmit
+		to: #methods;
+		from: #instVars;
+		andShow: [ :a | 
+			a list
 				title: 'Methods';
 				display: [ :var | var accessingMethods ];
 				format: #name;
 				dynamicActionsOnSelection: [ :list | list selection mooseFinderActions ];
 				tags: [ :each | 
-					(OrderedCollection 
-						with: (each hasClassScope ifTrue: [self metaString] ifFalse: [self instanceString])) 
-							addAll: each modifiers; yourself ] ]
+					(OrderedCollection
+						with:
+						(each isClassSide
+						ifTrue: [ self metaString ]
+						ifFalse: [ self instanceString ]))
+						addAll: each modifiers;
+						yourself ] ]
 ]
 
 { #category : #building }

--- a/src/Moose-Finder/MooseCodeNavigator.class.st
+++ b/src/Moose-Finder/MooseCodeNavigator.class.st
@@ -61,7 +61,7 @@ MooseCodeNavigator >> methodsIn: a [
 		format: #stubFormattedName;
 		tags: [ :method | 
 			col := method modifiers copy.
-			method hasClassScope ifTrue: [ col add: 'isStatic' ].
+			method isClassSide ifTrue: [ col add: 'isStatic' ].
 			method kind ifNotNil: [ :kind | col add: kind ].
 			col ];
 		dynamicActionsOnSelection: [ :list | list selection mooseInterestingEntity mooseFinderActions ]

--- a/src/Moose-SmalltalkImporter/SmalltalkImporter.class.st
+++ b/src/Moose-SmalltalkImporter/SmalltalkImporter.class.st
@@ -111,7 +111,7 @@ SmalltalkImporter >> createAttribute: name for: aClass [
 	importingContext shouldMergeClassAndMetaclass
 		ifTrue: [ attribute parentType: (self ensureClass: aClass instanceSide) ]
 		ifFalse: [ attribute parentType: (self ensureClass: aClass) ].
-	attribute hasClassScope: aClass isMeta.
+	attribute isClassSide: aClass isMeta.
 	attribute beProtected.
 	"now we use RoelTyper to see a unique type can be retrieve for this attribute: "
 	importingContext shouldComputeTypeOfAttributes
@@ -172,7 +172,7 @@ SmalltalkImporter >> createClassVarAttribute: name for: aClass [
 	attribute stub: true.
 	attribute name: name asSymbol.
 	attribute parentType: (self ensureClass: aClass instanceSide).
-	attribute hasClassScope: true.
+	attribute isClassSide: true.
 	attribute beSharedVariable.
 	attribute beProtected.
 	^ attribute

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelImporterTest.class.st
@@ -56,9 +56,7 @@ FamixReferenceModelImporterTest >> testAbstractMethodAnnotation [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessReadOnly [
-	"self debug: #testAccessReadOnly"
-	
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot.x'
 		from: #'Smalltalk::TheRoot.x()'
 		shouldBeRead: true
@@ -67,13 +65,10 @@ FamixReferenceModelImporterTest >> testAccessReadOnly [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessSharedVariableFromTheClassSide [
-	"self debug: #testaccessSharedVariableFromTheClassSide"
-
 	| classVarUniqueName accessDefinition methodUniqueName |
 	methodUniqueName := (TheRoot class >> #accessSharedVariableFromTheClassSide) mooseName.
 	classVarUniqueName := TheRoot @ #TheRootSharedVariable.
-	accessDefinition := self model allAccesses
-		select: [ :acc | acc variable mooseName = classVarUniqueName and: [ acc accessor mooseName = methodUniqueName ] ].
+	accessDefinition := self model allAccesses select: [ :acc | acc variable mooseName = classVarUniqueName and: [ acc accessor mooseName = methodUniqueName ] ].
 	self assert: accessDefinition size equals: 1.
 	self assert: (accessDefinition at: 1) isWrite
 ]
@@ -81,8 +76,6 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableFromTheClassSide [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessSharedVariableFromTheInstanceSide [
 	| accessDefinition |
-	"TheRoot>>accessSharedVariableFromTheInstanceSide
-		TheRootSharedVariable := 3"
 	accessDefinition := self model allAccesses
 		select: [ :acc | 
 			acc variable mooseName = 'Smalltalk::TheRoot.TheRootSharedVariable'
@@ -93,11 +86,8 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableFromTheInstanceSide [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessSharedVariableOfSuperclassClassSide [
-	"self debug: #testaccessSharedVariableOfSuperclassClassSide"
-
-	| instVarUniqueName accessDefinition methodUniqueName methodName |
-	methodName := #accessSharedVariableOfSuperClassClassSide.
-	methodUniqueName := (SubRootLevelOne class >> methodName) mooseName.
+	| instVarUniqueName accessDefinition methodUniqueName |
+	methodUniqueName := (SubRootLevelOne class >> #accessSharedVariableOfSuperClassClassSide) mooseName.
 	instVarUniqueName := TheRoot @ #TheRootSharedVariable.
 	accessDefinition := self model allAccesses select: [ :acc | acc variable mooseName = instVarUniqueName and: [ acc accessor mooseName = methodUniqueName ] ].
 	self assert: accessDefinition size equals: 1.
@@ -106,15 +96,12 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableOfSuperclassClassSide
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessSharedVariableOfSuperclassClassSide2 [
-	"self debug: #testaccessSharedVariableOfSuperclassClassSide"
-
-	| instVarUniqueName accessDefinition methodUniqueName methodName |
+	| instVarUniqueName accessDefinition methodUniqueName |
 	"we test
 		SubRootLevelOne class>>accessSharedVariableOfSuperSuperClassClassSide
 
 			DependentsFields := 6"
-	methodName := #accessSharedVariableOfSuperSuperClassClassSide.
-	methodUniqueName := (SubRootLevelOne class >> methodName) mooseName.
+	methodUniqueName := (SubRootLevelOne class >> #accessSharedVariableOfSuperSuperClassClassSide) mooseName.
 	instVarUniqueName := Object @ #DependentsFields.
 	accessDefinition := self model allAccesses select: [ :acc | acc variable mooseName = instVarUniqueName and: [ acc accessor mooseName = methodUniqueName ] ].
 	self assert: accessDefinition size equals: 1.
@@ -134,8 +121,7 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableOfSuperclassInstanceS
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessWriteOnly [
-	"self debug: #testAccessWriteOnly"
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot.x'
 		from: #'Smalltalk::TheRoot.x:(Object)'
 		shouldBeRead: false
@@ -144,8 +130,7 @@ FamixReferenceModelImporterTest >> testAccessWriteOnly [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingFormalParameter [
-	"self debug: #testAccessingFormalParameter"
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot.accessingArgument:(Object).anArgument'
 		from: #'Smalltalk::TheRoot.accessingArgument:(Object)'
 		shouldBeRead: true
@@ -167,30 +152,24 @@ FamixReferenceModelImporterTest >> testAccessingGlobalVariableFromInstanceSide [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingGlobalVariableHavingNamespaceNameFromInstanceSide [
-	"self debug: #testAccessingGlobalVariableFromInstanceSide"
-
-	| accessDefinition methodUniqueName methodName |
-	methodName := #accessingGlobalVariableHavingNamespaceName.
-	methodUniqueName := (TheRoot >> methodName) mooseName.
+	| accessDefinition methodUniqueName |
+	methodUniqueName := (TheRoot >> #accessingGlobalVariableHavingNamespaceName) mooseName.
 	accessDefinition := (self model entityNamed: methodUniqueName) accesses select: [ :acc | acc target mooseName = #SmalltalkGlobalVariable ].
 	self assert: accessDefinition size equals: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingImportedClassWithinReturnVariable [
-	"self debug: #testAccessingImportedClassWithinReturnVariable"
-
-	| methodName var accesses |
-	methodName := self model entityNamed: #'Smalltalk::TheRoot.returningImportedClass()'.
+	| method var accesses |
+	method := self model entityNamed: #'Smalltalk::TheRoot.returningImportedClass()'.
 	var := self model entityNamed: #'Smalltalk::TheRoot'.
-	accesses := self model allReferences select: [ :each | each source = methodName and: [ each target = var ] ].
+	accesses := self model allReferences select: [ :each | each source = method and: [ each target = var ] ].
 	self assert: accesses size equals: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingLocalVariable [
-	"self debug: #testAccessingLocalVariable"
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot.assigningLocalVariable().tmp'
 		from: #'Smalltalk::TheRoot.assigningLocalVariable()'
 		shouldBeRead: false
@@ -199,8 +178,6 @@ FamixReferenceModelImporterTest >> testAccessingLocalVariable [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingNamespace2 [
-	"self debug: #testAccessingNamespace2"
-
 	| accessDefinition |
 	accessDefinition := (self model entityNamed: 'Smalltalk::TheRoot.accessingGlobalVariableHavingNamespaceName()') accesses
 		select: [ :acc | acc target mooseName = #SmalltalkGlobalVariable ].
@@ -209,8 +186,6 @@ FamixReferenceModelImporterTest >> testAccessingNamespace2 [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingNamespaceAsGlobalVariable [
-	"self debug: #testAccessingNamespaceAsGlobalVariable"
-
 	| accessDefinition method globalVariable |
 	"TheRoot>>accessingNamespace
 		Smalltalk"
@@ -225,12 +200,9 @@ FamixReferenceModelImporterTest >> testAccessingNamespaceAsGlobalVariable [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingStubClassWithinReturnVariable [
-	"self debug: #testAccessingStubClassWithinReturnVariable"
-
-	| accessDefinition methodUniqueName methodName classUniqueName |
+	| accessDefinition methodUniqueName classUniqueName |
 	classUniqueName := String mooseName.
-	methodName := #returningStubClass.
-	methodUniqueName := (TheRoot >> methodName) mooseName.
+	methodUniqueName := (TheRoot >> #returningStubClass) mooseName.
 	accessDefinition := self model allReferences select: [ :acc | acc target mooseName = classUniqueName and: [ acc source mooseName = methodUniqueName ] ].
 	self assert: accessDefinition size equals: 1
 ]
@@ -305,10 +277,8 @@ FamixReferenceModelImporterTest >> testAnnotationTypes [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassAnnotation [
-	"self debug: #testClassAnnotation"
-
 	| definingClassName famixClass |
-	definingClassName := #Smalltalk::SubRootLevelOne mooseName.
+	definingClassName := #'Smalltalk::SubRootLevelOne' mooseName.
 	famixClass := self model entityNamed: definingClassName.
 	self assert: famixClass parentPackage name equals: #'Moose-TestResources-Reference-Core'
 ]
@@ -316,8 +286,6 @@ FamixReferenceModelImporterTest >> testClassAnnotation [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassClassAnnotation [
 	"Should work for metaclasse too"
-
-	"self debug: #testClassAnnotation"
 
 	| definingClassName famixClass |
 	definingClassName := SubRootLevelOne class mooseName.
@@ -327,17 +295,15 @@ FamixReferenceModelImporterTest >> testClassClassAnnotation [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassMetaclassInstanceVariableAndShared [
-	"self debug: #testClassMetaclassInstanceVariableAndShared"
-
 	| insVar theRoot insMetaclassVar shared theRootMeta |
 	insVar := self model entityNamed: #'Smalltalk::TheRoot.z'.
 	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot_class.mz'.
 	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot.
-	theRootMeta := self model entityNamed: #Smalltalk::TheRoot_class.
-	self deny: insVar hasClassScope.
-	self assert: insMetaclassVar hasClassScope.
-	self assert: shared hasClassScope.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	theRootMeta := self model entityNamed: #'Smalltalk::TheRoot_class'.
+	self deny: insVar isClassSide.
+	self assert: insMetaclassVar isClassSide.
+	self assert: shared isClassSide.
 	self assert: insVar belongsTo equals: theRoot.
 	self assert: insMetaclassVar belongsTo equals: theRootMeta.
 	self assert: shared belongsTo equals: theRoot.
@@ -355,8 +321,6 @@ FamixReferenceModelImporterTest >> testClassMethodAnnotation [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassReferenceFromTheInstanceSide [
-	"self debug: #testClassReferenceFromTheInstanceSide"
-
 	"TheRoot>>accessingClass
 
 		Object new"
@@ -370,15 +334,11 @@ FamixReferenceModelImporterTest >> testClassReferenceFromTheInstanceSide [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassReferencesByFullNameReified [
-	"self debug: #testClassReferencesByFullNameReified"
-
 	self assert: (self model entityNamed: TestCase class mooseName) isNotNil
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassSelfSend [
-	"self debug: #testClassSelfSend"
-
 	| invocations calleeMethodName callingMethodUniqueName |
 	"We want to represent
 	TheRoot class>>classSend
@@ -397,17 +357,15 @@ FamixReferenceModelImporterTest >> testClassSelfSend [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testConflictingInstanceVarNames [
-	"self debug: #testConflictingInstanceVarNames"
-
 	| insVar theRoot insMetaclassVar shared theRootMeta |
 	insVar := self model entityNamed: #'Smalltalk::TheRoot.instanceAndClassPotentiallyConflictingName'.
 	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot_class.instanceAndClassPotentiallyConflictingName'.
 	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot.
-	theRootMeta := self model entityNamed: #Smalltalk::TheRoot_class.
-	self deny: insVar hasClassScope.
-	self assert: insMetaclassVar hasClassScope.
-	self assert: shared hasClassScope.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	theRootMeta := self model entityNamed: #'Smalltalk::TheRoot_class'.
+	self deny: insVar isClassSide.
+	self assert: insMetaclassVar isClassSide.
+	self assert: shared isClassSide.
 	self assert: insVar belongsTo equals: theRoot.
 	self assert: insMetaclassVar belongsTo equals: theRootMeta.
 	self assert: shared belongsTo equals: theRoot
@@ -415,22 +373,19 @@ FamixReferenceModelImporterTest >> testConflictingInstanceVarNames [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testConstantMethodAnnotation [
-	| methodUniqueName method methodName |
-	methodName := #constantReturningMethod.
-	methodUniqueName := (TheRoot >> methodName) mooseName.
+	| methodUniqueName method |
+	methodUniqueName := (TheRoot >> #constantReturningMethod) mooseName.
 	method := self model entityNamed: methodUniqueName.
 	self assert: method isNil not.
 	self assert: method belongsTo equals: (self model entityNamed: TheRoot mooseName).
 	self assert: method isClassSide not.
-	self assert: method signature equals: (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: methodName).
+	self assert: method signature equals: (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: #constantReturningMethod).
 	self assert: method isPublic.
 	self assert: method isConstant
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExtendedClasses [
-	"self debug: #testExtendedClasses"
-
 	| subRootModelTwo p1 p2 subRootModelThree extensionMethod |
 	p1 := self model entityNamed: #'Moose-TestResources-Reference-PackageOne'.
 	p2 := self model entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
@@ -446,8 +401,6 @@ FamixReferenceModelImporterTest >> testExtendedClasses [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExtendedPackage [
-	"self debug: #testExtendedPackage"
-
 	| extendedClass extendedPackage |
 	extendedPackage := self model entityNamed: #'Moose-TestResources-Reference-PackageOne'.
 	extendedClass := self model entityNamed: SubRootModelTwo mooseName.
@@ -460,8 +413,6 @@ FamixReferenceModelImporterTest >> testExtendedPackage [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExtensionClasses [
-	"self debug: #testExtensionClasses"
-
 	| p1 p2 extensionClasses c3 c2 |
 	p1 := self model entityNamed: #'Moose-TestResources-Reference-PackageOne'.
 	p2 := self model entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
@@ -477,8 +428,6 @@ FamixReferenceModelImporterTest >> testExtensionClasses [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExtensionMethod [
-	"self debug: #testExtendedMethod"
-
 	| p2 extensionMethod |
 	p2 := self model entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
 	extensionMethod := self model entityNamed: (SubRootModelTwo >> #extendedMethodOne) mooseName.
@@ -489,8 +438,6 @@ FamixReferenceModelImporterTest >> testExtensionMethod [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExtensionPackage [
-	"self debug: #testExtensionPackage"
-
 	| normalClass extendedClass extensionPackage externalExtendedClass |
 	extensionPackage := self model allPackages entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
 	extendedClass := self model entityNamed: SubRootModelTwo mooseName.
@@ -513,8 +460,6 @@ FamixReferenceModelImporterTest >> testExtensionPackage [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExtensions [
-	"self debug: #testExtensions"
-
 	| normalClass extendedClass |
 	extendedClass := self model entityNamed: SubRootModelTwo mooseName.
 	normalClass := self model entityNamed: SubRootModelThree mooseName.
@@ -531,23 +476,17 @@ FamixReferenceModelImporterTest >> testExtensions [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testExternalExtension [
-	"self debug: #testExternalExtension"
 	| extensionPackage externalExtendedClass |
-	
 	extensionPackage := self model entityNamed: #'Moose-TestResources-Reference-PackageTwo'.
 	externalExtendedClass := self model entityNamed: ExternalReferenceClass mooseName.
 
-	self assert: (externalExtendedClass isStub).
+	self assert: externalExtendedClass isStub.
 	self deny: (extensionPackage classes includes: externalExtendedClass).
-	self assert: (extensionPackage extensionMethods includes:
-		(self model entityNamed: (ExternalReferenceClass>>#externalClassExtensionForTest) mooseName)).
-
+	self assert: (extensionPackage extensionMethods includes: (self model entityNamed: (ExternalReferenceClass >> #externalClassExtensionForTest) mooseName))
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testFormalParameterReified [
-	"self debug: #testFormalParameterReified"
-
 	| formalParameterName |
 	formalParameterName := #'Smalltalk::TheRoot.accessingArgument:(Object).anArgument'.
 	self assert: (self model entityNamed: formalParameterName) isNotNil
@@ -555,13 +494,12 @@ FamixReferenceModelImporterTest >> testFormalParameterReified [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testGetterMethod [
-	| methodUniqueName method methodName |
-	methodName := #x.
-	methodUniqueName := (TheRoot >> methodName) mooseName.
+	| methodUniqueName method |
+	methodUniqueName := (TheRoot >> #x) mooseName.
 	method := self model entityNamed: methodUniqueName.
 	self assert: method isNil not.
 	self assert: method isClassSide not.
-	self assert: method signature equals: (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: methodName).
+	self assert: method signature equals: (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: #x).
 	self assert: method isPublic.
 	self assert: method isPureAccessor.
 	self assert: method isGetter
@@ -569,8 +507,6 @@ FamixReferenceModelImporterTest >> testGetterMethod [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testGlobalVariableReified [
-	"self debug: #testGlobalVariableReified"
-	
 	| globalVariable |
 	globalVariable := self model entityNamed: #Transcript.
 	self assert: globalVariable isNil not
@@ -583,54 +519,51 @@ FamixReferenceModelImporterTest >> testImplicitVariableReified [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstVariableAccessInDefiningClass [
-	"self debug: #testInstVariableAccessInDefiningClass"
-	
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::SubRootLevelOne.k'
 		from: #'Smalltalk::SubRootLevelOne.accessSuperclassInstVar()'
 		shouldBeRead: false
-		hasAccessesSize: 1.
+		hasAccessesSize: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstVariableAccessInDefiningMetaclass [
-	"self debug: #testInstVariableAccessInDefiningMetaclass"
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot_class.mx'
 		from: #'Smalltalk::TheRoot_class.accessInstanceVariable()'
 		shouldBeRead: false
-		hasAccessesSize: 1.
+		hasAccessesSize: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstVariableAccessInSuperClass [
-	self 
+	self
 		privateTestAccessingVar: (TheRoot mooseNameOf: #x)
 		from: #'Smalltalk::SubRootLevelOne.accessSuperclassInstVar()'
 		shouldBeRead: true
 		hasAccessesSize: 1.
 
-	self 
+	self
 		privateTestAccessingVar: (TheRoot mooseNameOf: #y)
-		from: (SubRootLevelOne>>#accessSuperclassInstVar) mooseName
+		from: (SubRootLevelOne >> #accessSuperclassInstVar) mooseName
 		shouldBeRead: true
-		hasAccessesSize: 1.
+		hasAccessesSize: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstVariableAccessTwiceTheSameVariable [
-	self 
-		privateTestAccessingVar: SubRootLevelOne@#k
-		from: (SubRootLevelOne>>#accessTwiceTheSameVariable) mooseName
+	self
+		privateTestAccessingVar: SubRootLevelOne @ #k
+		from: (SubRootLevelOne >> #accessTwiceTheSameVariable) mooseName
 		shouldBeRead: true
-		hasAccessesSize: 2.
+		hasAccessesSize: 2
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstanceVariableReified [
 	| instVar |
 	instVar := self model entityNamed: 'Smalltalk::SubRootLevelOne.k'.
-	self deny: instVar hasClassScope.
+	self deny: instVar isClassSide.
 	self assert: instVar isProtected
 ]
 
@@ -640,13 +573,11 @@ FamixReferenceModelImporterTest >> testLocalVariableReified [
 ]
 
 { #category : #tests }
-FamixReferenceModelImporterTest >> testMetaclassAttributeHasClassScope [
-	"self debug: #testMetaclassAttributeHasClassScope"
-
+FamixReferenceModelImporterTest >> testMetaclassAttributeIsClassSide [
 	| attribute theRoot |
 	attribute := self model entityNamed: #'Smalltalk::TheRoot_class.mz'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot_class.
-	self assert: attribute hasClassScope.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot_class'.
+	self assert: attribute isClassSide.
 	self assert: attribute belongsTo equals: theRoot
 ]
 
@@ -673,7 +604,7 @@ FamixReferenceModelImporterTest >> testMethodReification [
 FamixReferenceModelImporterTest >> testOutOfModelInheritedInstanceVariableReified [
 	| instVar |
 	instVar := self model entityNamed: 'Smalltalk::Model.dependents'.
-	self deny: instVar hasClassScope.
+	self deny: instVar isClassSide.
 	self assert: instVar isProtected.
 	self assert: instVar belongsTo mooseName equals: Model mooseName
 ]
@@ -690,47 +621,41 @@ FamixReferenceModelImporterTest >> testReadAndWrite [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testReferenceBindingReified [
-	"self debug: #testReferenceBindingReified"
-	
 	| famixClass |
 	famixClass := self model entityNamed: TestRunner class mooseName.
-	self assert: famixClass isNil not
+	self assert: famixClass isNotNil
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSelfAccessInDefiningClass [
-	"self debug: #testSelfAccessInDefiningClass"
-	
 	"TheRoot>>singleSelfSend
 		self accessSharedVariableFromTheInstanceSide"
-	
-	self 
+
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot.singleSelfSend().self'
 		from: #'Smalltalk::TheRoot.singleSelfSend()'
 		shouldBeRead: true
-		hasAccessesSize: 1.
+		hasAccessesSize: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSelfAccessInDefiningClassOnClassSide [
-	"self debug: #testSelfAccessInDefiningClassOnClassSide"
-	self 
+	self
 		privateTestAccessingVar: #'Smalltalk::TheRoot_class.singleSelfSendOnClassSide().self'
 		from: #'Smalltalk::TheRoot_class.singleSelfSendOnClassSide()'
 		shouldBeRead: true
-		hasAccessesSize: 1.
+		hasAccessesSize: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSetterMethod [
-	| methodUniqueName method methodName |
-	methodName := #x:.
-	methodUniqueName := (TheRoot >> methodName) mooseName.
+	| methodUniqueName method |
+	methodUniqueName := (TheRoot >> #x:) mooseName.
 	method := self model entityNamed: methodUniqueName.
 	self assert: method isNil not.
 	self assert: method belongsTo equals: (self model entityNamed: TheRoot mooseName).
 	self assert: method isClassSide not.
-	self assert: method signature equals: (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: methodName).
+	self assert: method signature equals: (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: #x:).
 	self assert: method isPublic.
 	self assert: method isPureAccessor.
 	self assert: method isSetter
@@ -738,11 +663,9 @@ FamixReferenceModelImporterTest >> testSetterMethod [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSharedVariableReification [
-	"self debug: #testSharedVariableReification"
-
 	| shared |
 	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	self assert: shared hasClassScope.
+	self assert: shared isClassSide.
 	self assert: shared isSharedVariable.
 	self assert: shared isProtected.
 	self assert: shared belongsTo equals: (self model entityNamed: TheRoot mooseName)
@@ -750,10 +673,6 @@ FamixReferenceModelImporterTest >> testSharedVariableReification [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSingleSelfSend [
-	"self run: #testSingleSelfSend"
-
-	"self debug: #testSingleSelfSend"
-
 	| invocations calleeMethodName callingMethodUniqueName |
 	"We want to make sure that we represent well that 
 	TheRoot>>singleSelfSend
@@ -770,8 +689,6 @@ FamixReferenceModelImporterTest >> testSingleSelfSend [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSingleSelfSendOnClassSide [
-	"self debug: #testSingleSelfSendOnClassSide"
-
 	| invocations calleeMethodName callingMethodUniqueName |
 	"Want to represent
 	TheRoot class>>accessSharedVariableFromTheClassSide
@@ -788,8 +705,6 @@ FamixReferenceModelImporterTest >> testSingleSelfSendOnClassSide [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSingleSelfSendWithReturn [
-	"self debug: #testSingleSelfSendWithReturn"
-
 	| invocations calleeMethodName callingMethodUniqueName |
 	"We want to make sure that we represent well
 	TheRoot>>returningSingleSelfSend
@@ -806,8 +721,6 @@ FamixReferenceModelImporterTest >> testSingleSelfSendWithReturn [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testStubInstanceVariableReified [
-	"self debug: #testStubInstanceVariableReified"
-
 	| instVar |
 	instVar := self model entityNamed: 'Smalltalk::Model.dependents'.
 	self deny: instVar isNil.
@@ -831,8 +744,6 @@ FamixReferenceModelImporterTest >> testStubSharedVariableAccessShortName [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testStubSharedVariableReified [
-	"self debug: #testStubSharedVariableReified"
-
 	| classVar |
 	classVar := self model entityNamed: 'Smalltalk::Object.DependentsFields'.
 	self deny: classVar isNil.
@@ -843,8 +754,6 @@ FamixReferenceModelImporterTest >> testStubSharedVariableReified [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSubRootLevelOneInheritsFromTheRoot [
-	"self debug: #testSubRootLevelOneInheritsFromTheRoot"
-
 	| referenceModelSubRootLevelOne |
 	referenceModelSubRootLevelOne := self model entityNamed: referenceModelSubRootLevelOneName.
 	self assert: referenceModelSubRootLevelOne superInheritances size equals: 1.
@@ -856,51 +765,42 @@ FamixReferenceModelImporterTest >> testSubRootLevelOneInheritsFromTheRoot [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testTheRootInheritsFromUIModel [
-	"self debug: #testTheRootInheritsFromUIModel"
-
 	| referenceModelTheRoot |
 	referenceModelTheRoot := self model entityNamed: referenceModelTheRootName.
 	self assert: (referenceModelTheRoot superInheritances at: 1) superclass name equals: Model name.
 	self assert: referenceModelTheRoot subInheritances size equals: 3.
 	self assert: (referenceModelTheRoot subInheritances at: 1) superclass name equals: TheRoot name.
-	self
-		assert:
-			((referenceModelTheRoot subInheritances collect: [ :each | each subclass name ]) includes: SubRootLevelOne name)
+	self assert: ((referenceModelTheRoot subInheritances collect: [ :each | each subclass name ]) includes: SubRootLevelOne name)
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testUnknownVariableAccess [
-	"self debug: #testUnknownVariableAccess"
-	self 
-		privateTestAccessingVar: #'undeclaredStubInstVar'
+	self
+		privateTestAccessingVar: #undeclaredStubInstVar
 		from: #'Smalltalk::TheRoot.accessingUnknowVariable()'
 		shouldBeRead: true
-		hasAccessesSize: 1.
+		hasAccessesSize: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testUnknownVariableReified [
-	"self debug: #testUnknownVariableReified"
 	self deny: (self model entityNamed: #undeclaredStubInstVar) isNil
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testUsedClassReified [
-	"self debug: #testUsedClassReified"
 	| className famixClass |
 	className := Object mooseName.
-	famixClass := self model entityNamed: className ifAbsent: [nil].
+	famixClass := self model entityNamed: className ifAbsent: [ nil ].
 	self assert: famixClass isNil not.
-	self assert: famixClass isStub.
+	self assert: famixClass isStub
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testUsedClassReifiedWithinReturn [
-	"self debug: #testUsedClassReifiedWithinReturn"
-	
 	| className famixClass |
 	className := String class mooseName.
 	famixClass := self model entityNamed: className.
-	self assert: famixClass isNil not.
-	self assert: famixClass isStub.
+	self assert: famixClass isNotNil.
+	self assert: famixClass isStub
 ]

--- a/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-Core/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
@@ -50,8 +50,8 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassAttributeHas
 
 	| attribute theRoot |
 	attribute := self model entityNamed: #'Smalltalk::TheRoot.x'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot.
-	self assert: attribute hasClassScope not.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	self assert: attribute isClassSide not.
 	self assert: attribute belongsTo equals: theRoot
 ]
 
@@ -63,10 +63,10 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassMetaclassIns
 	insVar := self model entityNamed: #'Smalltalk::TheRoot.z'.
 	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot.CIV#mz'.
 	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot.
-	self deny: insVar hasClassScope.
-	self assert: insMetaclassVar hasClassScope.
-	self assert: shared hasClassScope.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	self deny: insVar isClassSide.
+	self assert: insMetaclassVar isClassSide.
+	self assert: shared isClassSide.
 	self assert: insVar belongsTo equals: theRoot.
 	self assert: insMetaclassVar belongsTo equals: theRoot.
 	self assert: shared belongsTo equals: theRoot.
@@ -83,10 +83,10 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testConflictingInstan
 	insVar := self model entityNamed: #'Smalltalk::TheRoot.instanceAndClassPotentiallyConflictingName'.
 	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot.CIV#instanceAndClassPotentiallyConflictingName'.
 	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot.
-	self deny: insVar hasClassScope.
-	self assert: insMetaclassVar hasClassScope.
-	self assert: shared hasClassScope.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	self deny: insVar isClassSide.
+	self assert: insMetaclassVar isClassSide.
+	self assert: shared isClassSide.
 	self assert: insVar belongsTo equals: theRoot.
 	self assert: insMetaclassVar belongsTo equals: theRoot.
 	self assert: shared belongsTo equals: theRoot
@@ -104,13 +104,11 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testInstanceAndClassS
 ]
 
 { #category : #tests }
-FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassAttributeHasClassScope [
-	"self debug: #testMetaclassAttributeHasClassScope"
-
+FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassAttributeIsClassSide [
 	| attribute theRoot |
 	attribute := self model entityNamed: #'Smalltalk::TheRoot.CIV#mz'.
-	theRoot := self model entityNamed: #Smalltalk::TheRoot.
-	self assert: attribute hasClassScope.
+	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	self assert: attribute isClassSide.
 	self assert: attribute belongsTo equals: theRoot
 ]
 
@@ -164,7 +162,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testSharedVariableRei
 
 	| shared |
 	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	self assert: shared hasClassScope.
+	self assert: shared isClassSide.
 	self assert: shared isSharedVariable.
 	self assert: shared isProtected.
 	self assert: shared belongsTo equals: (self model entityNamed: TheRoot mooseName)

--- a/src/Moose-Tests-SmalltalkImporter-LAN/FamixModelExtractionTest.class.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/FamixModelExtractionTest.class.st
@@ -133,11 +133,11 @@ FamixModelExtractionTest >> testInheritedAttributes [
 	inheritedAtts := msePrinterClass inheritedAttributes.
 	self assert: msePrinterClass superclassHierarchy size equals: 5.
 	self assert: inheritedAtts size equals: (self totalNumberOfAttributesFor: LANPrintServer superclass).
-	self assert: (inheritedAtts reject: [ :each | each hasClassScope ]) size equals: 5.
+	self assert: (inheritedAtts reject: [ :each | each isClassSide ]) size equals: 5.
 	self assert: (inheritedAtts includes: nodeName).
 	self assert: (inheritedAtts includes: nextNode).
 	self assert: (inheritedAtts includes: serverType).
-	self assert: (inheritedAtts select: [ :each | each hasClassScope ]) size equals: 1
+	self assert: (inheritedAtts select: [ :each | each isClassSide ]) size equals: 1
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Improve #hasClassScope management

- Add #isClassSide to FamixTAttribute through the generator
- Deprecate #hasClassScope(:) 
- Update the senders of #hasClassScope(:)
- Remove old useless comments