### PR TITLE
multiple-file-anchor-should-be-a-source-anchor

### DIFF
--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -964,6 +964,8 @@ FamixGenerator >> defineHierarchy [
 	tMethod --|> tNamedEntity.
 	tMethod --|> #TOODependencyQueries.
 	tMethod withPrecedenceOf: tTypedEntity.
+	
+	tMultipleFileAnchor --|> tSourceAnchor.
 
 	tParameter --|> tStructuralEntity.
 	

--- a/src/Famix-Test1-Tests/FamixMultipleFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixMultipleFileAnchorTest.class.st
@@ -36,6 +36,16 @@ FamixMultipleFileAnchorTest >> testAllSourceAnchors [
 ]
 
 { #category : #tests }
+FamixMultipleFileAnchorTest >> testAllSourceAnchorsDo [
+	| res |
+	res := OrderedCollection new.
+	multipleFileAnchor allSourceAnchorsDo: [ :each | res add: each ].
+
+	self assert: res size equals: 2.
+	res do: [ :each | self assert: each isFileAnchor ]
+]
+
+{ #category : #tests }
 FamixMultipleFileAnchorTest >> testContainerFiles [
 	| anchor |
 	anchor := self actualClass new

--- a/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
@@ -27,6 +27,15 @@ FamixSourceAnchorTest >> testAllSourceAnchors [
 ]
 
 { #category : #tests }
+FamixSourceAnchorTest >> testAllSourceAnchorsDo [
+	| anchor res |
+	anchor := self actualClass new.
+	res := OrderedCollection new.
+	anchor allSourceAnchorsDo: [ :each | res add: each ].
+	self assertCollection: res hasSameElements: {anchor}
+]
+
+{ #category : #tests }
 FamixSourceAnchorTest >> testEntity [
 	| anchor m1 m2 |
 	anchor := self actualClass new.

--- a/src/Famix-Test1-Tests/FamixWithSourceAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixWithSourceAnchorTest.class.st
@@ -46,6 +46,22 @@ FamixWithSourceAnchorTest >> testAllSourceAnchors [
 ]
 
 { #category : #tests }
+FamixWithSourceAnchorTest >> testAllSourceAnchorsDo [
+	| res multipleFileAnchor |
+	multipleFileAnchor := FamixTest1MultipleFileAnchor model: model.
+	1 to: 3 do: [ :each | multipleFileAnchor addFileAnchorWithPath: 'aFileName' , each asString ].
+
+	m3 sourceAnchor: multipleFileAnchor.
+
+
+	res := OrderedCollection new.
+	m3 allSourceAnchorsDo: [ :each | res add: each ].
+
+	self assert: res size equals: 3.
+	res do: [ :each | self assert: each isFileAnchor ]
+]
+
+{ #category : #tests }
 FamixWithSourceAnchorTest >> testAllSourceAnchorsWithMultipleFileAnchor [
 	| multipleFileAnchor |
 	self assertEmpty: m3 allSourceAnchors.

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -9,7 +9,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTSourceEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTTypedEntity)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTSourceEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTTypedEntity classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -3,6 +3,8 @@ Trait {
 	#instVars : [
 		'#fileAnchors => FMProperty'
 	],
+	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -23,6 +23,11 @@ FamixTSourceAnchor >> allSourceAnchors [
 	^ { self }
 ]
 
+{ #category : #enumerating }
+FamixTSourceAnchor >> allSourceAnchorsDo: aBlock [
+	^ aBlock value: self
+]
+
 { #category : #accessing }
 FamixTSourceAnchor >> completeText [
 	"The complete text of a FileAnchor contains all the code of the file pointed by the source anchor. On the contrary the #sourceText return only the pant of the file concerned by the entity. For example a FAMIXFileAnchon knows the start line and end line of the source anchor into the file."

--- a/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceAnchor.trait.st
@@ -22,6 +22,11 @@ FamixTWithSourceAnchor >> allSourceAnchors [
 		ifNotNil: #allSourceAnchors
 ]
 
+{ #category : #enumerating }
+FamixTWithSourceAnchor >> allSourceAnchorsDo: aBlock [
+	^ self sourceAnchor ifNotNil: [ :sa | sa allSourceAnchorsDo: aBlock ]
+]
+
 { #category : #metrics }
 FamixTWithSourceAnchor >> computeNumberOfLinesOfCode [
 	self hasSourceAnchor ifTrue: [ ^ self sourceAnchor lineCount ].


### PR DESCRIPTION
Make multiple file anchor use source anchor. 

Also add some API to make their use easier.