### PR TITLE
make-deprecated-properties-derived-to-not-export-them-in-MSE

### DIFF
--- a/src/Famix-Deprecated/FamixTAttribute.extension.st
+++ b/src/Famix-Deprecated/FamixTAttribute.extension.st
@@ -4,6 +4,7 @@ Extension { #name : #FamixTAttribute }
 FamixTAttribute >> hasClassScope [
 	<FMProperty: #hasClassScope type: #Boolean>
 	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	<derived>
 	self
 		deprecated: 'This property is deprecated from Moose 8.0. Please use isClassSide instead.'
 		transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.

--- a/src/Famix-Deprecated/FamixTMethod.extension.st
+++ b/src/Famix-Deprecated/FamixTMethod.extension.st
@@ -4,6 +4,7 @@ Extension { #name : #FamixTMethod }
 FamixTMethod >> hasClassScope [
 	<FMProperty: #hasClassScope type: #Boolean>
 	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
+	<derived>
 	self deprecated: 'This property is deprecated from Moose 7.0. Please use isClassSide instead.' transformWith: '`@receiver hasClassScope' -> '`@receiver isClassSide'.
 	^ self isClassSide
 ]


### PR DESCRIPTION
Make deprecated properties derived to not export them in a MSE.