### PR TITLE
1205-SourceAnchorisFile-is-a-bad-name

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXSourceAnchor.class.st
@@ -21,8 +21,3 @@ FAMIXSourceAnchor >> belongsTo [
 	"define container relationship on element (compatibility)"
 	^ self element
 ]
-
-{ #category : #testing }
-FAMIXSourceAnchor >> isFile [
-	^ false
-]

--- a/src/Famix-Deprecated/FamixTSourceAnchor.extension.st
+++ b/src/Famix-Deprecated/FamixTSourceAnchor.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FamixTSourceAnchor }
+
+{ #category : #'*Famix-Deprecated' }
+FamixTSourceAnchor >> isFile [
+	self deprecated: 'Use #isFileAnchor instead' transformWith: '`@receiver isFile' -> '`@receiver isFileAnchor'.
+	^ self isFileAnchor
+]

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -14,8 +14,3 @@ FamixJavaSourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #testing }
-FamixJavaSourceAnchor >> isFile [
-	^ false
-]

--- a/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
@@ -51,7 +51,7 @@ FamixAbstractFileAnchorTest >> testFileNameHasOnlySlashes [
 
 { #category : #tests }
 FamixAbstractFileAnchorTest >> testIsFileAnchor [
-	^ self assert: self actualClass new isFileAnchor
+	self assert: self actualClass new isFileAnchor
 ]
 
 { #category : #tests }

--- a/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
@@ -85,7 +85,7 @@ FamixSourceAnchorTest >> testImportFileAnchors [
 
 { #category : #tests }
 FamixSourceAnchorTest >> testIsFileAnchor [
-	^ self deny: self actualClass new isFileAnchor
+	self deny: self actualClass new isFileAnchor
 ]
 
 { #category : #tests }

--- a/src/Famix-Test1-Tests/FamixSourceTextAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceTextAnchorTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #FamixSourceTextAnchorTest,
+	#superclass : #FamixSourceAnchorTest,
+	#category : #'Famix-Test1-Tests-SourceAnchor'
+}
+
+{ #category : #helpers }
+FamixSourceTextAnchorTest >> actualClass [
+	^ FamixTest1SourceTextAnchor
+]

--- a/src/Famix-Test1-Tests/FamixWithImmediateSourceTest.class.st
+++ b/src/Famix-Test1-Tests/FamixWithImmediateSourceTest.class.st
@@ -27,9 +27,8 @@ FamixWithImmediateSourceTest >> setUp [
 ]
 
 { #category : #tests }
-FamixWithImmediateSourceTest >> testIsFile [
-
-	self deny: anchor isFile
+FamixWithImmediateSourceTest >> testIsFileAnchor [
+	self deny: anchor isFileAnchor
 ]
 
 { #category : #tests }

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -9,7 +9,6 @@ Trait {
 		'#fileName => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
-	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -9,6 +9,7 @@ Trait {
 		'#fileName => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 
@@ -97,11 +98,6 @@ FamixTFileAnchor >> fileReference [
 { #category : #accessing }
 FamixTFileAnchor >> hasSourceText [
 	^ self completeText isNotEmpty
-]
-
-{ #category : #testing }
-FamixTFileAnchor >> isFile [
-	^ true
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTHasImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTHasImmediateSource.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#source => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
-	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 

--- a/src/Famix-Traits/FamixTHasImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTHasImmediateSource.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#source => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 
@@ -31,12 +32,6 @@ FamixTHasImmediateSource classSide >> source: aString model: aMooseModel [
 	^ (self source: aString)
 		mooseModel: aMooseModel;
 		yourself
-]
-
-{ #category : #accessing }
-FamixTHasImmediateSource >> isFile [
-
-	^ false
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#typedEntities => FMMany type: #FamixTTypedEntity opposite: #declaredType'
 	],
 	#traits : 'FamixTNamedEntity + FamixTReferenceable',
-	#classTraits : 'FamixTNamedEntity classTrait + FamixTReferenceable classTrait',
 	#category : #'Famix-Traits-Type'
 }
 

--- a/src/Moose-Finder/FamixTWithSourceAnchor.extension.st
+++ b/src/Moose-Finder/FamixTWithSourceAnchor.extension.st
@@ -4,8 +4,7 @@ Extension { #name : #FamixTWithSourceAnchor }
 FamixTWithSourceAnchor >> mooseFinderParentFolderIn: composite [
 	<moosePresentationOrder: 10>
 	self sourceAnchor ifNil: [ ^ self ].
-	self sourceAnchor isFile
-		ifFalse: [ ^ self ].
+	self sourceAnchor isFileAnchor ifFalse: [ ^ self ].
 	(self sourceAnchor fileReference parent gtInspectorItemsIn: composite) titleIcon: MooseIcons mooseFolder
 ]
 


### PR DESCRIPTION
Deprecate #isFile in favore of #isFileAnchor.

Fixes #1205
Fixes #2122