### PR TITLE
2260-Optimize-hasSourceText-to-not-read-full-files

### DIFF
--- a/src/Famix-Deprecated/FamixTFileAnchor.extension.st
+++ b/src/Famix-Deprecated/FamixTFileAnchor.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FamixTFileAnchor }
+
+{ #category : #'*Famix-Deprecated' }
+FamixTFileAnchor >> hasSourceText [
+	self deprecated: 'Use #hasSource instead' transformWith: '`@receiver hasSourceText' -> '`@receiver hasSource'.
+	^ self hasSource
+]

--- a/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
@@ -50,6 +50,16 @@ FamixAbstractFileAnchorTest >> testFileNameHasOnlySlashes [
 ]
 
 { #category : #tests }
+FamixAbstractFileAnchorTest >> testHasSource [
+	| anchor |
+	anchor := self anchorForClassTest.
+	self assert: anchor hasSource.
+
+	anchor fileName: 'banana'.
+	self deny: anchor hasSource
+]
+
+{ #category : #tests }
 FamixAbstractFileAnchorTest >> testIsFileAnchor [
 	self assert: self actualClass new isFileAnchor
 ]

--- a/src/Famix-Test1-Tests/FamixFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixFileAnchorTest.class.st
@@ -21,8 +21,9 @@ FamixFileAnchorTest >> anchorForClassTest [
 		startColumn: 0;
 		endLine: 21;
 		endColumn: 2;
+		fileName: 'test.java';
 		yourself.
-	anchor stub fileReference willReturn: file.
+	anchor stub rootFolder willReturn: file parent.
 	^ anchor
 ]
 

--- a/src/Famix-Test1-Tests/FamixIndexedFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixIndexedFileAnchorTest.class.st
@@ -19,8 +19,9 @@ FamixIndexedFileAnchorTest >> anchorForClassTest [
 	anchor := self actualClass new
 		startPos: 50;
 		endPos: 253;
+		fileName: 'test.java';
 		yourself.
-	anchor stub fileReference willReturn: file.
+	anchor stub rootFolder willReturn: file parent.
 	^ anchor
 ]
 

--- a/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceAnchorTest.class.st
@@ -77,7 +77,7 @@ FamixSourceAnchorTest >> testImportFileAnchors [
 	self assertEmpty: aMethod sourceAnchor completeText.
 	self assertEmpty: aMethod sourceText.
 	self assert: aMethod sourceAnchor lineCount equals: 28.
-	self deny: aMethod sourceAnchor hasSourceText.
+	self deny: aMethod sourceAnchor hasSource.
 	self assert: aMethod numberOfLinesOfCode equals: 28.
 	self shouldnt: [ model allMethods collect: #numberOfLinesOfCode ] raise: Error.
 	self shouldnt: [ model allClasses collect: #numberOfLinesOfCode ] raise: Error

--- a/src/Famix-Test1-Tests/FamixSourceTextAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixSourceTextAnchorTest.class.st
@@ -8,3 +8,10 @@ Class {
 FamixSourceTextAnchorTest >> actualClass [
 	^ FamixTest1SourceTextAnchor
 ]
+
+{ #category : #tests }
+FamixSourceTextAnchorTest >> testHasSource [
+	self deny: self actualClass new hasSource.
+	self deny: (self actualClass source: '') hasSource.
+	self assert: (self actualClass source: 'source') hasSource
+]

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -101,8 +101,8 @@ FamixTFileAnchor >> fileReference [
 ]
 
 { #category : #accessing }
-FamixTFileAnchor >> hasSourceText [
-	^ self completeText isNotEmpty
+FamixTFileAnchor >> hasSource [
+	^ self sourcesAreReadable
 ]
 
 { #category : #testing }
@@ -123,10 +123,9 @@ FamixTFileAnchor >> isFileAnchor [
 
 { #category : #accessing }
 FamixTFileAnchor >> lineCount [
-	^ self hasSourceText 
+	^ self hasSource
 		ifTrue: [ self sourceText lineCount ]
 		ifFalse: [ self notExistentMetricValue ]
-	
 ]
 
 { #category : #printing }

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#startLine => FMProperty'
 	],
 	#traits : 'FamixTFileAnchor',
+	#classTraits : 'FamixTFileAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 
@@ -91,7 +92,7 @@ FamixTFileNavigation >> lineCount [
 	(endLine isNotNil and: [ startLine isNotNil ]) ifTrue: [ ^ endLine - startLine + 1 ].
 
 	"if no start/end position, use the comple text ..."
-	^ self hasSourceText
+	^ self hasSource
 		ifTrue: [ self completeText lineCount ]
 		ifFalse: [ self notExistentMetricValue ]
 ]

--- a/src/Famix-Traits/FamixTHasImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTHasImmediateSource.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#source => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 
@@ -31,6 +32,11 @@ FamixTHasImmediateSource classSide >> source: aString model: aMooseModel [
 	^ (self source: aString)
 		mooseModel: aMooseModel;
 		yourself
+]
+
+{ #category : #testing }
+FamixTHasImmediateSource >> hasSource [
+	^ self source isEmptyOrNil not
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -5,7 +5,6 @@ Trait {
 		'#startPos => FMProperty'
 	],
 	#traits : 'FamixTFileAnchor',
-	#classTraits : 'FamixTFileAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -4,6 +4,7 @@ Trait {
 		'#fileAnchors => FMProperty'
 	],
 	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
 	#category : #'Famix-Traits-SourceAnchor'
 }
 
@@ -89,6 +90,11 @@ FamixTMultipleFileAnchor >> fileName [
 	"for compatibility with FAMIXFileAnchor, guard condition not needed: it has atleast one file anchor"
 
 	^ self fileAnchors anyOne fileName
+]
+
+{ #category : #testing }
+FamixTMultipleFileAnchor >> hasSource [
+	^ self fileAnchors anySatisfy: #hasSource
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -59,6 +59,11 @@ FamixTSourceAnchor >> element: anObject [
 ]
 
 { #category : #testing }
+FamixTSourceAnchor >> hasSource [
+	^ self explicitRequirement
+]
+
+{ #category : #testing }
 FamixTSourceAnchor >> isFileAnchor [
 	^ false
 ]


### PR DESCRIPTION
Optimize #hasSourceText

- Rename #hasSourceText to #hasSource because it checks if the source is here, not if the source text is available.
- Optimize by not reading full files
- Add tests
Fixes #117