### PR TITLE
named-entity-should-use-sourced-entity

### DIFF
--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -960,11 +960,13 @@ FamixGenerator >> defineHierarchy [
 	tMethod --|> tTypedEntity.
 	tMethod --|> tNamedEntity.
 	tMethod --|> #TOODependencyQueries.
+	tMethod withPrecedenceOf: tWithStatements.
 	
 	tMultipleFileAnchor --|> tSourceAnchor.
 	
 	tNamedEntity --|> #TDependencyQueries.
 	tNamedEntity --|> #TEntityMetaLevelDependency.
+	tNamedEntity --|> tSourceEntity.
 
 	tParameter --|> tStructuralEntity.
 	

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -11,7 +11,8 @@ Trait {
 		'#kind => FMProperty',
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
-	#traits : 'FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries',
+	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
+	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTNamedEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamedEntity.trait.st
@@ -3,7 +3,8 @@ Trait {
 	#instVars : [
 		'#name => FMProperty'
 	],
-	#traits : 'TDependencyQueries + TEntityMetaLevelDependency',
+	#traits : 'FamixTSourceEntity + TDependencyQueries + TEntityMetaLevelDependency',
+	#classTraits : 'FamixTSourceEntity classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Named'
 }
 

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -105,12 +105,6 @@ FamixTWithMethods >> numberOfConstructorMethods: aNumber [
 ]
 
 { #category : #metrics }
-FamixTWithMethods >> numberOfLinesOfCode: aNumber [
-
-	self privateState propertyAt: #numberOfLinesOfCode put: aNumber
-]
-
-{ #category : #metrics }
 FamixTWithMethods >> numberOfMessageSends [
 	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>


### PR DESCRIPTION
FamixTNamed should use FamixTSourced.

Currently, all named entity have a source because the name needs to be declared somewhere.