### PR TITLE
when-setting-a-source-language-to-model-set-model-to-source-language

### DIFF
--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTNamedEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamedEntity.trait.st
@@ -4,7 +4,6 @@ Trait {
 		'#name => FMProperty'
 	],
 	#traits : 'FamixTSourceEntity + TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'FamixTSourceEntity classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Named'
 }
 

--- a/src/Famix-Traits/MooseModel.extension.st
+++ b/src/Famix-Traits/MooseModel.extension.st
@@ -101,6 +101,7 @@ MooseModel >> sourceLanguage [
 ]
 
 { #category : #'*Famix-Traits' }
-MooseModel >> sourceLanguage: aSymbol [
-	self privateState attributeAt: #sourceLanguage put: aSymbol
+MooseModel >> sourceLanguage: aFamixSourceLanguage [
+	self privateState attributeAt: #sourceLanguage put: aFamixSourceLanguage.
+	aFamixSourceLanguage mooseModel: self
 ]


### PR DESCRIPTION
Set the moose model of source languages.

When setting the source language of a moose model, set links in both ways.