### PR TITLE
allModelPackages-should-not-sort-enitites

### DIFF
--- a/src/Famix-Test1-Tests/MooseModelTest1lTest.class.st
+++ b/src/Famix-Test1-Tests/MooseModelTest1lTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MooseAbstractGroupWithTest1ModelTest,
+	#name : #MooseModelTest1lTest,
 	#superclass : #FamixTest1SimpleModelTest,
 	#instVars : [
 		'a2'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #running }
-MooseAbstractGroupWithTest1ModelTest >> setUp [
+MooseModelTest1lTest >> setUp [
 	super setUp.
 	a2 := FamixTest1Attribute named: 'attribute2' model: model.
 
@@ -20,31 +20,36 @@ MooseAbstractGroupWithTest1ModelTest >> setUp [
 ]
 
 { #category : #tests }
-MooseAbstractGroupWithTest1ModelTest >> testAllBehaviourals [
+MooseModelTest1lTest >> testAllBehaviourals [
 	self assertCollection: model allBehaviourals hasSameElements: {m1 . m2 . m3}
 ]
 
 { #category : #tests }
-MooseAbstractGroupWithTest1ModelTest >> testAllContainers [
+MooseModelTest1lTest >> testAllContainers [
 	self assertCollection: model allContainers hasSameElements: { c1. c2. m1. m2. m3 }
 ]
 
 { #category : #tests }
-MooseAbstractGroupWithTest1ModelTest >> testAllModelBehaviourals [
+MooseModelTest1lTest >> testAllModelBehaviourals [
 	self assertCollection: model allModelBehaviourals hasSameElements: {m1 . m2}
 ]
 
 { #category : #tests }
-MooseAbstractGroupWithTest1ModelTest >> testAllModelContainers [
+MooseModelTest1lTest >> testAllModelContainers [
 	self assertCollection: model allModelContainers hasSameElements: {c1 . m1 . m2}
 ]
 
 { #category : #tests }
-MooseAbstractGroupWithTest1ModelTest >> testAllModelStructuralEntities [
+MooseModelTest1lTest >> testAllModelStructuralEntities [
 	self assertCollection: model allModelStructuralEntities hasSameElements: { a1 }
 ]
 
 { #category : #tests }
-MooseAbstractGroupWithTest1ModelTest >> testAllStructuralEntities [
+MooseModelTest1lTest >> testAllRootContainers [
+	self assertCollection: model allRootContainers hasSameElements: {c1}
+]
+
+{ #category : #tests }
+MooseModelTest1lTest >> testAllStructuralEntities [
 	self assertCollection: model allStructuralEntities hasSameElements: {a1 . a2}
 ]

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTNamedEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamedEntity.trait.st
@@ -4,7 +4,6 @@ Trait {
 		'#name => FMProperty'
 	],
 	#traits : 'FamixTSourceEntity + TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'FamixTSourceEntity classTrait + TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Named'
 }
 

--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -172,13 +172,9 @@ MooseAbstractGroup >> allModelNamespaces [
 { #category : #'*Famix-Traits' }
 MooseAbstractGroup >> allModelPackages [
 	<navigation: 'All model packages'>
-
-	^ self privateState cacheAt: 'All model packages'
-		ifAbsentPut: [
-			MooseGroup
-				withAll: ((self allPackages reject: [:each | each isStub]) sorted:
-																		[:p1 :p2 | p1 name < p2 name] )
-				withDescription: 'All model packages' ]
+	^ self privateState
+		cacheAt: 'All model packages'
+		ifAbsentPut: [ MooseGroup withAll: (self allPackages reject: #isStub) withDescription: 'All model packages' ]
 ]
 
 { #category : #'*Famix-Traits' }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -309,10 +309,9 @@ MooseModel >> allBookmarks [
 	^ MooseGroup withAll: (self entityCache select: [ :group | group asMooseGroup isBookmarked ]) withDescription: 'Bookmarks'
 ]
 
-{ #category : #'dead code' }
-MooseModel >> allContainersWithDeadCode [
-	<navigation: 'All containers with dead code'>
-	^ self allModelContainers select: #isDead
+{ #category : #accessing }
+MooseModel >> allRootContainers [
+	^ self allModelContainers select: [ :each | each parents isEmpty ]
 ]
 
 { #category : #actions }
@@ -343,6 +342,11 @@ MooseModel >> cacheMooseGroups [
 { #category : #'dead code' }
 MooseModel >> computeAllBehaviouralsWithDeadCode [
 	^ self allModelBehaviourals select: #isDead
+]
+
+{ #category : #metrics }
+MooseModel >> computeNumberOfLinesOfCode [
+	^ self allRootContainers sum: #numberOfLinesOfCode
 ]
 
 { #category : #'dead code' }
@@ -586,7 +590,7 @@ MooseModel >> name: aStringOrSymbol [
 			self announcer announce: (MooseEntityRenamed new oldName: oldName) ]
 ]
 
-{ #category : #'Famix-Extensions' }
+{ #category : #metrics }
 MooseModel >> numberOfClasses [
 	<FMProperty: #numberOfClasses type: #Number>
 	<FMComment: 'The number of classes'>
@@ -596,7 +600,14 @@ MooseModel >> numberOfClasses [
 		computedAs: [ self allClasses size ]
 ]
 
-{ #category : #'Famix-Extensions' }
+{ #category : #metrics }
+MooseModel >> numberOfLinesOfCode [
+	<FMProperty: #numberOfLinesOfCode type: #Number>
+	<FMComment: 'The number of lines of code of the project.'>
+	^ self lookUpPropertyNamed: #numberOfLinesOfCode computedAs: [ self computeNumberOfLinesOfCode ]
+]
+
+{ #category : #metrics }
 MooseModel >> numberOfLinesOfCodePerClass [
 	<FMProperty: #numberOfLinesOfCodePerClass type: #Number>
 	<FMComment: 'The number of lines of code per class in the model'>


### PR DESCRIPTION
#allModelPackages should not sort entities.

It is not the responsibility of the model to sort entities.