### PR TITLE
add-dependencies-detector-to-find-dependencies-within-a-group-of-dependencies

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXMethod.class.st
@@ -68,23 +68,6 @@ FAMIXMethod >> hasInnerClassImplementingMethods [
 	^ self innerClassesImplementingMethods isNotEmpty
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXMethod >> hierarchyNestingLevel [
-	<FMProperty: #hierarchyNestingLevel type: #Number>
-	<derived>
-	<FMComment: 'The nesting level in the hierarchy'>
-	
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self belongsTo hierarchyNestingLevel]
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXMethod >> hierarchyNestingLevel: aNumber [
-
-	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
-]
-
 { #category : #'Famix-Java' }
 FAMIXMethod >> implementMethod [
 	^ self belongsTo implementedInterfaces

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -57,23 +57,6 @@ FamixJavaMethod >> hasInnerClassImplementingMethods [
 	^ self innerClassesImplementingMethods isNotEmpty
 ]
 
-{ #category : #metrics }
-FamixJavaMethod >> hierarchyNestingLevel [
-	<FMProperty: #hierarchyNestingLevel type: #Number>
-	<derived>
-	<FMComment: 'The nesting level in the hierarchy'>
-	
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self belongsTo hierarchyNestingLevel]
-]
-
-{ #category : #metrics }
-FamixJavaMethod >> hierarchyNestingLevel: aNumber [
-
-	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
-]
-
 { #category : #'Famix-Java' }
 FamixJavaMethod >> implementMethod [
 	^ self belongsTo implementedInterfaces

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -968,11 +968,15 @@ FamixGenerator >> defineHierarchy [
 	tNamedEntity --|> #TEntityMetaLevelDependency.
 	tNamedEntity --|> tSourceEntity.
 
+	tPackage --|> tScopingEntity.
+
 	tParameter --|> tStructuralEntity.
 	
 	tReference --|> tAssociation.
 
-	tScopingEntity  --|> #TOODependencyQueries.
+	tScopingEntity --|> tNamedEntity.
+	tScopingEntity --|> #TOODependencyQueries.
+	tScopingEntity withPrecedenceOf: #TOODependencyQueries.
 	
 	tStructuralEntity --|> tNamedEntity.
 	tStructuralEntity --|> tAccessible.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -64,23 +64,6 @@ FamixStMethod >> hasEmptyBody [
 	^ self numberOfAccesses = 0 and: [ self numberOfOutgoingInvocations = 0 ]
 ]
 
-{ #category : #'Famix-Extensions-metrics-support' }
-FamixStMethod >> hierarchyNestingLevel [
-	<FMProperty: #hierarchyNestingLevel type: #Number>
-	<derived>
-	<FMComment: 'The nesting level in the hierarchy'>
-	
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self belongsTo hierarchyNestingLevel]
-]
-
-{ #category : #'Famix-Extensions-metrics-support' }
-FamixStMethod >> hierarchyNestingLevel: aNumber [
-
-	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
-]
-
 { #category : #initialization }
 FamixStMethod >> initialize [
 	super initialize.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -30,11 +30,6 @@ FamixStNamespace >> abstractness [
 ]
 
 { #category : #'Famix-Extensions-nav All Dependencies' }
-FamixStNamespace >> isNamespace [
-	^ true
-]
-
-{ #category : #'Famix-Extensions-nav All Dependencies' }
 FamixStNamespace >> mooseNameOn: aStream [ 
 	| parent |
 	parent := self belongsTo.

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -14,3 +14,13 @@ FamixTest1Association class >> annotation [
 	<generated>
 	^self
 ]
+
+{ #category : #accessing }
+FamixTest1Association >> source [
+	^ nil
+]
+
+{ #category : #accessing }
+FamixTest1Association >> target [
+	^ nil
+]

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -72,8 +72,8 @@ TEntityMetaLevelDependencyTest >> testAllOutgoingAssociationTypes [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllParentTypes [
-	self assertCollection: c1 allParentTypes hasSameElements: {FamixTWithTypes . FamixTPackage}.
-	self assertCollection: m1 allParentTypes hasSameElements: {FamixTest1Class . FamixTWithMethods . FamixTWithTypes . FamixTPackage}
+	self assertCollection: c1 allParentTypes hasSameElements: {FamixTWithTypes . FamixTPackage . FamixTScopingEntity}.
+	self assertCollection: m1 allParentTypes hasSameElements: {FamixTest1Class . FamixTWithMethods . FamixTWithTypes . FamixTPackage . FamixTScopingEntity}
 ]
 
 { #category : #tests }

--- a/src/Famix-Test3-Entities/FamixTest3Access.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Access.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #FamixTest3Access,
+	#superclass : #FamixTest3Entity,
+	#traits : 'FamixTAccess',
+	#classTraits : 'FamixTAccess classTrait',
+	#category : #'Famix-Test3-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest3Access class >> annotation [
+
+	<FMClass: #Access super: #FamixTest3Entity>
+	<package: #'Famix-Test3-Entities'>
+	<generated>
+	^self
+]

--- a/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #FamixTest3Attribute,
+	#superclass : #FamixTest3Entity,
+	#traits : 'FamixTAttribute',
+	#classTraits : 'FamixTAttribute classTrait',
+	#category : #'Famix-Test3-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest3Attribute class >> annotation [
+
+	<FMClass: #Attribute super: #FamixTest3Entity>
+	<package: #'Famix-Test3-Entities'>
+	<generated>
+	^self
+]

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -21,7 +21,21 @@ FamixTest3Entity class >> metamodel [
 ]
 
 { #category : #testing }
+FamixTest3Entity >> isAccess [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
 FamixTest3Entity >> isAssociation [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
+FamixTest3Entity >> isAttribute [
 
 	<generated>
 	^ false
@@ -56,7 +70,21 @@ FamixTest3Entity >> isMethod [
 ]
 
 { #category : #testing }
+FamixTest3Entity >> isPackage [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
 FamixTest3Entity >> isReference [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
+FamixTest3Entity >> isStructuralEntity [
 
 	<generated>
 	^ false

--- a/src/Famix-Test3-Entities/FamixTest3Package.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Package.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #FamixTest3Package,
+	#superclass : #FamixTest3Entity,
+	#traits : 'FamixTPackage',
+	#classTraits : 'FamixTPackage classTrait',
+	#category : #'Famix-Test3-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest3Package class >> annotation [
+
+	<FMClass: #Package super: #FamixTest3Entity>
+	<package: #'Famix-Test3-Entities'>
+	<generated>
+	^self
+]

--- a/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
@@ -21,7 +21,21 @@ FamixTest3TypeGroup class >> metamodel [
 ]
 
 { #category : #testing }
+FamixTest3TypeGroup >> isAccess [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
 FamixTest3TypeGroup >> isAssociation [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
+FamixTest3TypeGroup >> isAttribute [
 
 	<generated>
 	^ false
@@ -56,7 +70,21 @@ FamixTest3TypeGroup >> isMethod [
 ]
 
 { #category : #testing }
+FamixTest3TypeGroup >> isPackage [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
 FamixTest3TypeGroup >> isReference [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
+FamixTest3TypeGroup >> isStructuralEntity [
 
 	<generated>
 	^ false

--- a/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
+++ b/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
@@ -11,29 +11,22 @@ Class {
 }
 
 { #category : #running }
-FamixDependencyDetectorTest >> addConnections [
-	FamixTest3Invocation source: self method1 target: {self method2} model: model.
-	FamixTest3Invocation source: self method2 target: {self method1} model: model.
-	FamixTest3Access source: self method1 target: self attribute3
-]
-
-{ #category : #running }
-FamixDependencyDetectorTest >> attribute3 [
+FamixDependencyDetectorTest >> a3 [
 	^ model entityNamed: 'Class3.attribute3'
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> class1 [
+FamixDependencyDetectorTest >> c1 [
 	^ model entityNamed: 'Class1'
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> class2 [
+FamixDependencyDetectorTest >> c2 [
 	^ model entityNamed: 'Class2'
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> class3 [
+FamixDependencyDetectorTest >> c3 [
 	^ model entityNamed: 'Class3'
 ]
 
@@ -51,28 +44,28 @@ FamixDependencyDetectorTest >> createTestEntities: counter [
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> method1 [
+FamixDependencyDetectorTest >> m1 [
 	^ model entityNamed: 'Class1.method1'
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> method2 [
+FamixDependencyDetectorTest >> m2 [
 	^ model entityNamed: 'Class2.method2'
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> package1 [
-	^ model entityNamed: 'package1'
+FamixDependencyDetectorTest >> p1 [
+	^ model entityNamed: #p1
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> package2 [
-	^ model entityNamed: 'package2'
+FamixDependencyDetectorTest >> p2 [
+	^ model entityNamed: #p2
 ]
 
 { #category : #helpers }
-FamixDependencyDetectorTest >> package3 [
-	^ model entityNamed: 'package3'
+FamixDependencyDetectorTest >> p3 [
+	^ model entityNamed: #p3
 ]
 
 { #category : #running }
@@ -80,35 +73,37 @@ FamixDependencyDetectorTest >> setUp [
 	super setUp.
 	model := FamixTest3Model new.
 	1 to: 3 do: [ :number | self createTestEntities: number ].
-	self addConnections
+	FamixTest3Invocation source: self m1 target: {self m2} model: model.
+	FamixTest3Invocation source: self m2 target: {self m1} model: model.
+	FamixTest3Access source: self m1 target: self a3
 ]
 
 { #category : #'tests-clients' }
 FamixDependencyDetectorTest >> testClientClassesFromMethods [
-	self assertCollection: (self class2 allClientsIn: model allModelMethods) hasSameElements: {self method1}
+	self assertCollection: (self c2 allClientsIn: model allModelMethods) hasSameElements: {self m1}
 ]
 
 { #category : #'tests-clients' }
 FamixDependencyDetectorTest >> testClientMethodFromPackages [
-	self assertCollection: (self method2 allClientsIn: model allModelPackages) hasSameElements: {self package1}
+	self assertCollection: (self m2 allClientsIn: model allModelPackages) hasSameElements: {self p1}
 ]
 
 { #category : #'tests-clients' }
 FamixDependencyDetectorTest >> testClientsMethodFromClasses [
-	self assertCollection: (self method2 allClientsIn: model allModelClasses) hasSameElements: { self class1 }
+	self assertCollection: (self m2 allClientsIn: model allModelClasses) hasSameElements: { self c1 }
 ]
 
 { #category : #'tests-providers' }
 FamixDependencyDetectorTest >> testProviderClassesToMethods [
-	self assertCollection: (self class1 allProvidersIn: model allModelMethods) hasSameElements: { self method2 }
+	self assertCollection: (self c1 allProvidersIn: model allModelMethods) hasSameElements: { self m2 }
 ]
 
 { #category : #'tests-providers' }
 FamixDependencyDetectorTest >> testProviderMethodToClasses [
-	self assertCollection: (self method1 allProvidersIn: model allModelClasses) hasSameElements: { self class3 . self class2 }
+	self assertCollection: (self m1 allProvidersIn: model allModelClasses) hasSameElements: { self c3 . self c2 }
 ]
 
 { #category : #'tests-providers' }
 FamixDependencyDetectorTest >> testProviderMethodToPackages [
-	self assertCollection: (self method1 allProvidersIn: model allModelPackages) hasSameElements: {self package2 . self package3}
+	self assertCollection: (self m1 allProvidersIn: model allModelPackages) hasSameElements: {self p2 . self p3}
 ]

--- a/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
+++ b/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
@@ -1,0 +1,114 @@
+"
+test that when entities passed a scope, they reply their outgoing or incoming according to that scope.
+"
+Class {
+	#name : #FamixDependencyDetectorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'model'
+	],
+	#category : #'Famix-Test3-Tests'
+}
+
+{ #category : #running }
+FamixDependencyDetectorTest >> addConnections [
+	FamixTest3Invocation source: self method1 target: {self method2} model: model.
+	FamixTest3Invocation source: self method2 target: {self method1} model: model.
+	FamixTest3Access source: self method1 target: self attribute3
+]
+
+{ #category : #running }
+FamixDependencyDetectorTest >> attribute3 [
+	^ model entityNamed: 'Class3.attribute3'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> class1 [
+	^ model entityNamed: 'Class1'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> class2 [
+	^ model entityNamed: 'Class2'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> class3 [
+	^ model entityNamed: 'Class3'
+]
+
+{ #category : #running }
+FamixDependencyDetectorTest >> createTestEntities: counter [
+	| package class method attribute |
+	package := FamixTest3Package named: 'package' , counter asString model: model.
+	class := FamixTest3Class named: 'Class' , counter asString model: model.
+	method := FamixTest3Method named: 'method' , counter asString model: model.
+	attribute := FamixTest3Attribute named: 'attribute' , counter asString model: model.
+
+	package addChildEntity: class.
+	method parentType: class.
+	attribute parentType: class
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> method1 [
+	^ model entityNamed: 'Class1.method1'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> method2 [
+	^ model entityNamed: 'Class2.method2'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> package1 [
+	^ model entityNamed: 'package1'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> package2 [
+	^ model entityNamed: 'package2'
+]
+
+{ #category : #helpers }
+FamixDependencyDetectorTest >> package3 [
+	^ model entityNamed: 'package3'
+]
+
+{ #category : #running }
+FamixDependencyDetectorTest >> setUp [
+	super setUp.
+	model := FamixTest3Model new.
+	1 to: 3 do: [ :number | self createTestEntities: number ].
+	self addConnections
+]
+
+{ #category : #'tests-clients' }
+FamixDependencyDetectorTest >> testClientClassesFromMethods [
+	self assertCollection: (self class2 allClientsIn: model allModelMethods) hasSameElements: {self method1}
+]
+
+{ #category : #'tests-clients' }
+FamixDependencyDetectorTest >> testClientMethodFromPackages [
+	self assertCollection: (self method2 allClientsIn: model allModelPackages) hasSameElements: {self package1}
+]
+
+{ #category : #'tests-clients' }
+FamixDependencyDetectorTest >> testClientsMethodFromClasses [
+	self assertCollection: (self method2 allClientsIn: model allModelClasses) hasSameElements: { self class1 }
+]
+
+{ #category : #'tests-providers' }
+FamixDependencyDetectorTest >> testProviderClassesToMethods [
+	self assertCollection: (self class1 allProvidersIn: model allModelMethods) hasSameElements: { self method2 }
+]
+
+{ #category : #'tests-providers' }
+FamixDependencyDetectorTest >> testProviderMethodToClasses [
+	self assertCollection: (self method1 allProvidersIn: model allModelClasses) hasSameElements: { self class3 . self class2 }
+]
+
+{ #category : #'tests-providers' }
+FamixDependencyDetectorTest >> testProviderMethodToPackages [
+	self assertCollection: (self method1 allProvidersIn: model allModelPackages) hasSameElements: {self package2 . self package3}
+]

--- a/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
+++ b/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
@@ -55,17 +55,17 @@ FamixDependencyDetectorTest >> m2 [
 
 { #category : #helpers }
 FamixDependencyDetectorTest >> p1 [
-	^ model entityNamed: #p1
+	^ model entityNamed: 'package1'
 ]
 
 { #category : #helpers }
 FamixDependencyDetectorTest >> p2 [
-	^ model entityNamed: #p2
+	^ model entityNamed: 'package2'
 ]
 
 { #category : #helpers }
 FamixDependencyDetectorTest >> p3 [
-	^ model entityNamed: #p3
+	^ model entityNamed: 'package3'
 ]
 
 { #category : #running }

--- a/src/Famix-Test3-Tests/FamixTest3MooseQueryTest.class.st
+++ b/src/Famix-Test3-Tests/FamixTest3MooseQueryTest.class.st
@@ -61,7 +61,7 @@ FamixTest3MooseQueryTest >> testAtScopeWithNonMatchingEntitiesDo [
 
 { #category : #tests }
 FamixTest3MooseQueryTest >> testChildrenTypes [
-	self assertCollection: self c1 childrenTypes hasSameElements: {FamixTAttribute . FamixTMethod. FamixTest3Method}
+	self assertCollection: self c1 childrenTypes hasSameElements: {FamixTAttribute . FamixTMethod . FamixTest3Attribute . FamixTest3Method}
 ]
 
 { #category : #tests }

--- a/src/Famix-TestGenerators/FamixTest3Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest3Generator.class.st
@@ -9,7 +9,10 @@ Class {
 		'reference',
 		'invocation',
 		'classEntitygroup',
-		'typeGroup'
+		'typeGroup',
+		'attribute',
+		'access',
+		'package'
 	],
 	#category : #'Famix-TestGenerators'
 }
@@ -31,9 +34,12 @@ FamixTest3Generator >> defineClasses [
 
 	super defineClasses.
 
+	access := builder newClassNamed: #Access.
+	attribute := builder newClassNamed: #Attribute.
 	classEntity := builder newClassNamed: #Class.
 	classEntitygroup := classEntity withGroup.
 	method := builder newClassNamed: #Method.
+	package := builder newClassNamed: #Package.
 	type := builder newClassNamed: #Type.
 	typeGroup := type withGroup.
 	primitiveType := builder newClassNamed: #PrimitiveType.
@@ -48,6 +54,10 @@ FamixTest3Generator >> defineHierarchy [
 
 	super defineHierarchy.
 
+	access --|> #TAccess.
+
+	attribute --|> #TAttribute.
+	
 	type --|> namedEntity.
 	type --|> #TType.
 
@@ -56,6 +66,8 @@ FamixTest3Generator >> defineHierarchy [
 
 	method --|> namedEntity.
 	method --|> #TMethod.
+	
+	package --|> #TPackage.
 	
 	primitiveType --|> type.
 	primitiveType --|> #TWithTypes.

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -24,7 +24,6 @@ Trait {
 		'#previous => FMOne type: #FamixTAssociation opposite: #next'
 	],
 	#traits : 'FamixTSourceEntity + TAssociationMetaLevelDependency',
-	#classTraits : 'FamixTSourceEntity classTrait + TAssociationMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Association'
 }
 

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -24,6 +24,7 @@ Trait {
 		'#previous => FMOne type: #FamixTAssociation opposite: #next'
 	],
 	#traits : 'FamixTSourceEntity + TAssociationMetaLevelDependency',
+	#classTraits : 'FamixTSourceEntity classTrait + TAssociationMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Association'
 }
 
@@ -49,6 +50,13 @@ FamixTAssociation classSide >> source: anEntity target: anotherEntity model: aMo
 	^ (self source: anEntity target: anotherEntity)
 		mooseModel: aMooseModel;
 		yourself
+]
+
+{ #category : #printing }
+FamixTAssociation >> gtDisplayOn: aStream [
+	self source gtDisplayOn: aStream.
+	aStream nextPutAll: ' -> '.
+	self target gtDisplayOn: aStream
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,6 +12,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
+	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 
@@ -44,6 +45,23 @@ FamixTMethod >> cyclomaticComplexity [
 FamixTMethod >> cyclomaticComplexity: aNumber [
 
 	self privateState propertyAt: #cyclomaticComplexity put: aNumber
+]
+
+{ #category : #metrics }
+FamixTMethod >> hierarchyNestingLevel [
+	<FMProperty: #hierarchyNestingLevel type: #Number>
+	<derived>
+	<FMComment: 'The nesting level in the hierarchy'>
+	
+	^self
+		lookUpPropertyNamed: #hierarchyNestingLevel
+		computedAs: [self belongsTo hierarchyNestingLevel]
+]
+
+{ #category : #metrics }
+FamixTMethod >> hierarchyNestingLevel: aNumber [
+
+	self privateState propertyAt: #hierarchyNestingLevel put: aNumber
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -10,7 +10,6 @@ Trait {
 		'#packageOwner => FMOne type: #FamixTWithPackages opposite: #packages'
 	],
 	#traits : 'FamixTScopingEntity',
-	#classTraits : 'FamixTScopingEntity classTrait',
 	#category : #'Famix-Traits-Package'
 }
 

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -9,6 +9,8 @@ Trait {
 		'#childEntities => FMMany type: #FamixTPackageable opposite: #parentPackage',
 		'#packageOwner => FMOne type: #FamixTWithPackages opposite: #packages'
 	],
+	#traits : 'FamixTScopingEntity',
+	#classTraits : 'FamixTScopingEntity classTrait',
 	#category : #'Famix-Traits-Package'
 }
 

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -10,7 +10,6 @@ Trait {
 		'#parentScope => FMOne type: #FamixTScopingEntity opposite: #childScopes'
 	],
 	#traits : '(FamixTNamedEntity + TOODependencyQueries withPrecedenceOf: TOODependencyQueries)',
-	#classTraits : '(FamixTNamedEntity classTrait + TOODependencyQueries classTrait withPrecedenceOf: TOODependencyQueries classTrait)',
 	#category : #'Famix-Traits-ScopingEntity'
 }
 

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -9,7 +9,8 @@ Trait {
 		'#childScopes => FMMany type: #FamixTScopingEntity opposite: #parentScope',
 		'#parentScope => FMOne type: #FamixTScopingEntity opposite: #childScopes'
 	],
-	#traits : 'TOODependencyQueries',
+	#traits : '(FamixTNamedEntity + TOODependencyQueries withPrecedenceOf: TOODependencyQueries)',
+	#classTraits : '(FamixTNamedEntity classTrait + TOODependencyQueries classTrait withPrecedenceOf: TOODependencyQueries classTrait)',
 	#category : #'Famix-Traits-ScopingEntity'
 }
 

--- a/src/FamixTestGenerator/FamixTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTestAndTraitGenerator.class.st
@@ -18,19 +18,19 @@ FamixTestAndTraitGenerator >> computeAddMethodNameFrom: aSlot [
 	| normalizedName pieces lowerCasePieces |
 	pieces := aSlot name cutCamelCase.
 	lowerCasePieces := OrderedCollection new.
-	pieces do: [ :e | lowerCasePieces add: e asLowercase  ].
+	pieces do: [ :e | lowerCasePieces add: e asLowercase ].
 	pieces removeAll.
 	normalizedName := aSlot name.
-	( lowerCasePieces includes: 'children' ) ifTrue: [ lowerCasePieces := lowerCasePieces copyReplaceAll: {'children'}  with: {'child'}. 
-		normalizedName := (String streamContents: [ :aStream | 
-	lowerCasePieces do: [:element | aStream nextPutAll: element asCamelCase] ]).
-		normalizedName := normalizedName copyReplaceAll: normalizedName first asCollection  with: normalizedName first asLowercase asCollection  ].
+	(lowerCasePieces includes: 'children')
+		ifTrue: [ lowerCasePieces := lowerCasePieces copyReplaceAll: {'children'} with: {'child'}.
+			normalizedName := String streamContents: [ :aStream | lowerCasePieces do: [ :element | aStream nextPutAll: element asCamelCase ] ].
+			normalizedName := normalizedName copyReplaceAll: normalizedName first asCollection with: normalizedName first asLowercase asCollection ].
 	(normalizedName endsWith: 'sses')
 		ifTrue: [ normalizedName := normalizedName withoutSuffix: 'es' ]
-		ifFalse: [ (normalizedName endsWith: 'ies')
-				ifTrue: [ normalizedName := (normalizedName withoutSuffix: 'ies') , 'y' ]
-				ifFalse: [ normalizedName := normalizedName withoutSuffix: 's' ] ].
-	^ 'add' , normalizedName capitalized, ':'
+		ifFalse: [ normalizedName := (normalizedName endsWith: 'ies')
+				ifTrue: [ (normalizedName withoutSuffix: 'ies') , 'y' ]
+				ifFalse: [ normalizedName withoutSuffix: 's' ] ].
+	^ 'add' , normalizedName capitalized , ':'
 ]
 
 { #category : #accessing }

--- a/src/Moose-Core/FamixDependenciesDetector.class.st
+++ b/src/Moose-Core/FamixDependenciesDetector.class.st
@@ -1,0 +1,130 @@
+"
+Description
+--------------------
+
+I am a detector to compute dependencies at all possible scopes for a give moose group. For famix entities, it collects the dependencies of an entity at all the scopes of entities in the group.
+
+Since tags can contain themselves recursively, we need to see if the any one has an incoming connection from the current entity.
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	dependencies:					<aCollection>				The list of found dependencies.
+	directionStrategy:				<aDirectionStrategy>		A strategy managing the direction of dependencies (incoming or outgoing).
+	entity:							<anEntity>					The origin entityx for which we are looking at for dependencies.
+	mooseModel:						<aMooseModel>				The moose model in which are the entities to look for. This is useful for example when using tags.
+	potentialDependencies:		<aCollection>				A collection containing all the potential dependencies in which we are looking for.
+"
+Class {
+	#name : #FamixDependenciesDetector,
+	#superclass : #Object,
+	#instVars : [
+		'entity',
+		'directionStrategy',
+		'mooseModel',
+		'potentialDependencies',
+		'dependencies'
+	],
+	#category : #'Moose-Core-Dependencies'
+}
+
+{ #category : #public }
+FamixDependenciesDetector class >> computeClientsOf: aMooseEntity from: aMooseGroup in: aMooseModel [
+	^ self new
+		directionStrategy: FamixDependenciesDetectorClientsStrategy;
+		entity: aMooseEntity;
+		potentialDependencies: aMooseGroup;
+		mooseModel: aMooseModel;
+		detectDependencies
+]
+
+{ #category : #public }
+FamixDependenciesDetector class >> computeProvidersOf: aMooseEntity from: aMooseGroup in: aMooseModel [
+	^ self new
+		directionStrategy: FamixDependenciesDetectorProvidersStrategy;
+		entity: aMooseEntity;
+		potentialDependencies: aMooseGroup;
+		mooseModel: aMooseModel;
+		detectDependencies
+]
+
+{ #category : #'links-computation' }
+FamixDependenciesDetector >> detectDependencies [
+	"this code will be further simplied in the later version. right now, committing it in this state to have a working version."
+
+	dependencies := Set new.
+
+	self entity detectDependenciesUsing: self.
+
+	^ dependencies
+]
+
+{ #category : #'links-computation' }
+FamixDependenciesDetector >> detectDependenciesAtAllScopesOfPossibleDependencies [
+	"this method computes dependencies at all possible scopes for a give moose group. For FAMIX entities, it collects the dependencies of the recevier at all the scopes of entities in the group. Tags contain themselves recursively, hence we need to see if the any one has an incoming connection from the current entity"
+
+	| dependenciesAssociations |
+	dependenciesAssociations := self directionStrategy dependenciesOf: self entity.
+	self selectMatchingEntitiesFrom: ((potentialDependencies collectAsSet: #class) flatCollect: [ :aScope | dependenciesAssociations atScope: aScope ])
+]
+
+{ #category : #'links-computation' }
+FamixDependenciesDetector >> detectDependenciesFrom: aCollection [
+	"see if all possible levels of each entity in the moose group contain a link from me"
+
+	self selectMatchingEntitiesFrom: (aCollection select: [ :each | each isLinkedTo: self entity dependancyDirection: self directionStrategy in: self mooseModel ])
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> directionStrategy [
+	^ directionStrategy
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> directionStrategy: aDirectionStrategy [
+	directionStrategy := aDirectionStrategy
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> entity [
+	^ entity
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> entity: anEntity [
+	entity := anEntity
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> mooseModel [
+	^ mooseModel
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> mooseModel: aMooseModel [
+	mooseModel := aMooseModel
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> potentialDependencies [
+	^ potentialDependencies
+]
+
+{ #category : #accessing }
+FamixDependenciesDetector >> potentialDependencies: aCollection [
+	potentialDependencies := aCollection asSet
+]
+
+{ #category : #'links-computation' }
+FamixDependenciesDetector >> removeFromPotentialDependencies: aCollection [
+	potentialDependencies removeAllFoundIn: aCollection
+]
+
+{ #category : #'links-computation' }
+FamixDependenciesDetector >> selectMatchingEntitiesFrom: aCollection [
+	| toAdd |
+	toAdd := aCollection intersection: potentialDependencies.
+	dependencies addAll: toAdd.
+	potentialDependencies removeAll: toAdd
+]

--- a/src/Moose-Core/FamixDependenciesDetectorClientsStrategy.class.st
+++ b/src/Moose-Core/FamixDependenciesDetectorClientsStrategy.class.st
@@ -1,0 +1,21 @@
+"
+Description
+--------------------
+
+I am a strategy managing for a FamixDependenciesDetector everything related to direction of dependencies when we look for clients of an entity (incoming dependencies).
+"
+Class {
+	#name : #FamixDependenciesDetectorClientsStrategy,
+	#superclass : #FamixDependenciesDetectorDirectionStrategy,
+	#category : #'Moose-Core-Dependencies'
+}
+
+{ #category : #accessing }
+FamixDependenciesDetectorClientsStrategy class >> dependenciesAtReceiverScopeOf: anEntity [
+	^ anEntity allClients
+]
+
+{ #category : #accessing }
+FamixDependenciesDetectorClientsStrategy class >> dependenciesOf: aMooseEntity [
+	^ aMooseEntity queryIncomingDependencies
+]

--- a/src/Moose-Core/FamixDependenciesDetectorDirectionStrategy.class.st
+++ b/src/Moose-Core/FamixDependenciesDetectorDirectionStrategy.class.st
@@ -1,0 +1,23 @@
+"
+Description
+--------------------
+
+I am an abstract class defining the basic API my subclasses should respond to. 
+
+My role is to manage for a FamixDependencyDetector, everything specific to the direction of dependencies.
+"
+Class {
+	#name : #FamixDependenciesDetectorDirectionStrategy,
+	#superclass : #Object,
+	#category : #'Moose-Core-Dependencies'
+}
+
+{ #category : #accessing }
+FamixDependenciesDetectorDirectionStrategy class >> dependenciesAtReceiverScopeOf: enEntity [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FamixDependenciesDetectorDirectionStrategy class >> dependenciesOf: aMooseEntity [
+	^ self subclassResponsibility
+]

--- a/src/Moose-Core/FamixDependenciesDetectorProvidersStrategy.class.st
+++ b/src/Moose-Core/FamixDependenciesDetectorProvidersStrategy.class.st
@@ -1,0 +1,21 @@
+"
+Description
+--------------------
+
+I am a strategy managing for a FamixDependenciesDetector everything related to direction of dependencies when we look for providiers of an entity (outgoing dependencies).
+"
+Class {
+	#name : #FamixDependenciesDetectorProvidersStrategy,
+	#superclass : #FamixDependenciesDetectorDirectionStrategy,
+	#category : #'Moose-Core-Dependencies'
+}
+
+{ #category : #accessing }
+FamixDependenciesDetectorProvidersStrategy class >> dependenciesAtReceiverScopeOf: anEntity [
+	^ anEntity allProviders
+]
+
+{ #category : #accessing }
+FamixDependenciesDetectorProvidersStrategy class >> dependenciesOf: aMooseEntity [
+	^ aMooseEntity queryOutgoingDependencies
+]

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -214,7 +214,7 @@ MooseAbstractGroup >> collect: aBlock [
 	^ self entities collect: aBlock
 ]
 
-{ #category : #enumeration }
+{ #category : #enumerating }
 MooseAbstractGroup >> collect: aBlock as: aClass [
 	"Evaluate aBlock with each of the receiver's elements as the argument.  
 	Collect the resulting values into an instance of aClass. Answer the resulting collection."
@@ -287,7 +287,7 @@ MooseAbstractGroup >> do: aBlock [
 	^self entityStorage do: aBlock
 ]
 
-{ #category : #enumeration }
+{ #category : #enumerating }
 MooseAbstractGroup >> do: aBlock displayingProgress: aString [
 	^ self entityStorage do: aBlock displayingProgress: aString
 ]

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -86,6 +86,64 @@ MooseEntity class >> usedStatefulTraits [
 	^ self cache at: #usedStatefulTraits ifAbsentPut: [ super usedStatefulTraits ]
 ]
 
+{ #category : #dependencies }
+MooseEntity >> addAllChildrenDependenciesThrough: aDirectionStrategy in: aCollection [
+	aCollection addAll: (aDirectionStrategy dependenciesAtReceiverScopeOf: self).
+	self children do: [ :each | each addAllChildrenDependenciesThrough: aDirectionStrategy in: aCollection ].
+	^ aCollection
+]
+
+{ #category : #dependencies }
+MooseEntity >> allChildrenDependenciesThrough: aDirectionStrategy [
+	^ self addAllChildrenDependenciesThrough: aDirectionStrategy in: OrderedCollection new
+]
+
+{ #category : #dependencies }
+MooseEntity >> allClientsIn: aMooseGroup [
+	"Detect all the clients who are present in the Moose group. 
+	For example, if I have a method as client that is not present in this group, but its parent class is present, I'll select it. But in case the method is present, I'll select the method.
+	This is useful when creating visualizations in order to select the dependencies within the entities present in the visualization."
+
+	^ self allClientsIn: aMooseGroup forModel: self mooseModel
+]
+
+{ #category : #dependencies }
+MooseEntity >> allClientsIn: aMooseGroup forModel: aMooseModel [
+	"Detect all the clients who are present in the Moose group for a given model (this is useful when using tags).
+	For example, if I have a method as client that is not present in this group, but its parent class is present, I'll select it. But in case the method is present, I'll select the method.
+	This is useful when creating visualizations in order to select the dependencies within the entities present in the visualization."
+
+	^ FamixDependenciesDetector computeClientsOf: self from: aMooseGroup in: aMooseModel
+]
+
+{ #category : #dependencies }
+MooseEntity >> allProvidersIn: aMooseGroup [
+	"Detect all the providers who are present in the Moose group. 
+	For example, if I have a method as client that is not present in this group, but its parent class is present, I'll select it. But in case the method is present, I'll select the method.
+	This is useful when creating visualizations in order to select the dependencies within the entities present in the visualization."
+
+	^ self allProvidersIn: aMooseGroup forModel: self mooseModel
+]
+
+{ #category : #dependencies }
+MooseEntity >> allProvidersIn: aMooseGroup forModel: aMooseModel [
+	"Detect all the providers who are present in the Moose group for a given model (this is useful when using tags).
+	For example, if I have a method as client that is not present in this group, but its parent class is present, I'll select it. But in case the method is present, I'll select the method.
+	This is useful when creating visualizations in order to select the dependencies within the entities present in the visualization."
+
+	^ FamixDependenciesDetector computeProvidersOf: self from: aMooseGroup in: aMooseModel
+]
+
+{ #category : #dependencies }
+MooseEntity >> detectDependenciesUsing: aDetector [
+	| potentialTags |
+	potentialTags := aDetector potentialDependencies select: #isTag.
+	aDetector
+		detectDependenciesFrom: potentialTags;
+		removeFromPotentialDependencies: potentialTags;
+		detectDependenciesAtAllScopesOfPossibleDependencies
+]
+
 { #category : #properties }
 MooseEntity >> handleFameProperty: aSymbol value: anObject [
 	
@@ -114,6 +172,24 @@ MooseEntity >> isDead [
 	<derived>
 	<MSEComment: 'Is the entity dead (not invoked in the system)'>
 	^ false
+]
+
+{ #category : #dependencies }
+MooseEntity >> isInListOfPossibleLinks: aCollection forModel: aMooseModel [
+	^ aCollection includes: self
+]
+
+{ #category : #dependencies }
+MooseEntity >> isLinkedTo: anEntity dependancyDirection: aDirectionStrategy in: aMooseModel [
+	"find if the specified entities is to linked to this entity at all possible levels in the direction specified by the strategy. All possible levels self, all children and all parents. It is important to see in the all parents because an entity can contain itself"
+
+	| allRecursiveLinks allLinksWithParents |
+	self flag: #todo.	"currenltly, dependencies of self and children are collected, we should rather collect dependencies of self only and concatenate it with the list of children. Like that ugly code in detector will be avoided."
+	allRecursiveLinks := self allChildrenDependenciesThrough: aDirectionStrategy.
+	allLinksWithParents := allRecursiveLinks
+		addAll: (allRecursiveLinks flatCollect: #allParents);
+		yourself.
+	^ anEntity isInListOfPossibleLinks: allLinksWithParents forModel: aMooseModel
 ]
 
 { #category : #testing }

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -183,12 +183,10 @@ MooseEntity >> isInListOfPossibleLinks: aCollection forModel: aMooseModel [
 MooseEntity >> isLinkedTo: anEntity dependancyDirection: aDirectionStrategy in: aMooseModel [
 	"find if the specified entities is to linked to this entity at all possible levels in the direction specified by the strategy. All possible levels self, all children and all parents. It is important to see in the all parents because an entity can contain itself"
 
-	| allRecursiveLinks allLinksWithParents |
-	self flag: #todo.	"currenltly, dependencies of self and children are collected, we should rather collect dependencies of self only and concatenate it with the list of children. Like that ugly code in detector will be avoided."
-	allRecursiveLinks := self allChildrenDependenciesThrough: aDirectionStrategy.
-	allLinksWithParents := allRecursiveLinks
-		addAll: (allRecursiveLinks flatCollect: #allParents);
-		yourself.
+	| allLinksWithParents |
+	allLinksWithParents := self allChildrenDependenciesThrough: aDirectionStrategy.
+	allLinksWithParents addAll: (allLinksWithParents flatCollect: #allParents).
+
 	^ anEntity isInListOfPossibleLinks: allLinksWithParents forModel: aMooseModel
 ]
 

--- a/src/Moose-Core/MooseModelRoot.class.st
+++ b/src/Moose-Core/MooseModelRoot.class.st
@@ -7,7 +7,6 @@ Class {
 	#name : #MooseModelRoot,
 	#superclass : #Object,
 	#classInstVars : [
-		'instance',
 		'root'
 	],
 	#category : #'Moose-Core'


### PR DESCRIPTION
Add an algo to be able to find dependencies within a subpart of the model.

Also improve base traits.