### PR TITLE
2275-Add-a-test-ensuring-we-dont-have-methods-overriding-generated-methods-with-the-same-AST

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -25,11 +25,6 @@ FAMIXAccess class >> toMethod [
 	^ self lookupSelector: #variable
 ]
 
-{ #category : #testing }
-FAMIXAccess >> isAccess [
-	^true
-]
-
 { #category : #'Famix-Implementation' }
 FAMIXAccess >> printOn: aStream [
 	super printOn: aStream.

--- a/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXFunction.class.st
@@ -25,11 +25,6 @@ FAMIXFunction >> container: anObject [
 	^ self functionOwner: anObject
 ]
 
-{ #category : #'Famix-Implementation' }
-FAMIXFunction >> isFunction [
-	^true.
-]
-
 { #category : #testing }
 FAMIXFunction >> isPrivate [
 	^ self isPublic not

--- a/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXInvocation.class.st
@@ -80,11 +80,6 @@ FAMIXInvocation >> isASureInvocation [
 ]
 
 { #category : #'Famix-Implementation' }
-FAMIXInvocation >> isInvocation [ 	
-	^true
-]
-
-{ #category : #'Famix-Implementation' }
 FAMIXInvocation >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $#.

--- a/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXNamespace.class.st
@@ -146,11 +146,6 @@ FAMIXNamespace >> instability: aNumber [
 ]
 
 { #category : #'Famix-Implementation' }
-FAMIXNamespace >> isNamespace [
-	^ true
-]
-
-{ #category : #'Famix-Implementation' }
 FAMIXNamespace >> methods [
 	^ self privateState 
 			cacheAt: #methods 

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -80,11 +80,6 @@ FamixJavaInvocation >> isASureInvocation [
 	^ invoRVar isNotNil and: [ invoRVar class = FamixJavaClass or: [ invoRVar isImplicitVariable and: [ invoRVar isSelf or: [ invoRVar isSuper ] ] ] ]
 ]
 
-{ #category : #testing }
-FamixJavaInvocation >> isInvocation [ 	
-	^true
-]
-
 { #category : #printing }
 FamixJavaInvocation >> printOn: aStream [
 	super printOn: aStream.

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -190,11 +190,6 @@ FamixJavaNamespace >> instability: aNumber [
 	self privateState propertyAt: #instability put: aNumber
 ]
 
-{ #category : #testing }
-FamixJavaNamespace >> isNamespace [
-	^ true
-]
-
 { #category : #'Famix-Extensions-metrics' }
 FamixJavaNamespace >> martinCohesion [
 	"Computing cohesion as described by Robert C. Martin"

--- a/src/Famix-MetamodelBuilder-Tests/CompiledMethod.extension.st
+++ b/src/Famix-MetamodelBuilder-Tests/CompiledMethod.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*Famix-MetamodelBuilder-Tests' }
+CompiledMethod >> isEquivalentToGeneratedMethodOfTrait [
+	"To know if a method is equivalent to one generated in a trait, we look if the trait composition have the method. If it has it, we take its AST, remove the generated pragma and compare the AST to the one of the receiver."
+
+	| traitMethodAST |
+	traitMethodAST := (self methodClass traitComposition compiledMethodAt: self selector ifAbsent: [ ^ false ]) ast copy.
+	(traitMethodAST pragmaNamed: #generated ifAbsent: [ ^ false ]) removeFromTree.
+	^ traitMethodAST = self ast
+]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -20,6 +20,20 @@ FmxMBGeneratorTest >> testGenerateMooseModelSubclass [
 ]
 
 { #category : #tests }
+FmxMBGeneratorTest >> testGeneratedClassesDoNotOverrideMethodsWithGeneratedPragmaToAddVersionWithTheSameAST [
+	| duplicatedMethods |
+	duplicatedMethods := SystemNavigation default allClasses iterator
+		| #hasTraitComposition selectIt
+		| #isMetamodelEntity selectIt
+		| [ :class | class localMethods , class class localMethods ] flatCollectIt
+		| [ :method | method pragmas anySatisfy: [ :pragma | pragma selector = #generated ] ] rejectIt
+		| #isEquivalentToGeneratedMethodOfTrait selectIt
+		> Array.
+		
+	self assertEmpty: duplicatedMethods
+]
+
+{ #category : #tests }
 FmxMBGeneratorTest >> testGeneratorsAreUpToDate [
 	FamixMetamodelGenerator generatorsToKeepUpToDate
 		do: [ :mm | 

--- a/src/Famix-MetamodelBuilder-Tests/RBPragmaNode.extension.st
+++ b/src/Famix-MetamodelBuilder-Tests/RBPragmaNode.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RBPragmaNode }
+
+{ #category : #'*Famix-MetamodelBuilder-Tests' }
+RBPragmaNode >> removeFromTree [
+	self parent removePragma: self
+]


### PR DESCRIPTION
Add test to ensure we don't have hand written methods equivalent to generated methods in the image. 

Fixes #2275