### PR TITLE
fix bug navigation allDeclaredProperties

### DIFF
--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -171,7 +171,11 @@ MooseObject class >> superclassesAndFamixTraits [
 
 { #category : #'meta information' }
 MooseObject >> allDeclaredProperties [
-	^ self class allDeclaredProperties
+	"Do not use the class side version
+
+This method allows us to look for its properties in the metadescription.
+And, the metadescription might be different in the instance and in the class side since we can define for each instance its metamodel (with more or less properties)"
+	^ self mooseDescription allProperties
 ]
 
 { #category : #'meta information' }


### PR DESCRIPTION
In the flow this method is used to gather the properties on an entity in the metamodel.
However, by executing it on the classside, it will look for the metamodel of the class side instance (instance of class), with the not correct metamodel nor properties.... 