### PR TITLE
add-possibility-to-remove-attributes-from-private-state

### DIFF
--- a/src/Moose-Core/MooseDevelopmentState.class.st
+++ b/src/Moose-Core/MooseDevelopmentState.class.st
@@ -191,6 +191,17 @@ MooseDevelopmentState >> propertyAt: name put: value [
 
 ]
 
+{ #category : #'accessing attributes' }
+MooseDevelopmentState >> removeAttribute: aSymbol [
+	| each |
+	1 to: attributes size do: [ :n | 
+		each := attributes at: n.
+		aSymbol == each key
+			ifTrue: [ attributes := attributes copyWithout: each.
+				^ true ] ].
+	^ false
+]
+
 { #category : #'accessing properties' }
 MooseDevelopmentState >> removeProperty: name [
 	propertyCache removeKey: name ifAbsent: [ ]

--- a/src/Moose-Core/MooseEntityState.class.st
+++ b/src/Moose-Core/MooseEntityState.class.st
@@ -176,6 +176,11 @@ MooseEntityState >> propertyAt: name put: value [
 	self subclassResponsibility.
 ]
 
+{ #category : #'accessing-attributes' }
+MooseEntityState >> removeAttribute: aSymbol [
+	self subclassResponsibility
+]
+
 { #category : #accessing }
 MooseEntityState >> removeProperty: aKey [ 
 	self subclassResponsibility

--- a/src/Moose-Core/MooseMemoryEfficientState.class.st
+++ b/src/Moose-Core/MooseMemoryEfficientState.class.st
@@ -136,6 +136,16 @@ MooseMemoryEfficientState >> propertyAt: name put: value [
 	^ propertyCache at: name put: value
 ]
 
+{ #category : #'accessing attributes' }
+MooseMemoryEfficientState >> removeAttribute: aSymbol [
+	| each |
+	1 to: attributes size do: [ :n | 
+		aSymbol == (each := attributes at: n) key
+			ifTrue: [ attributes := attributes copyWithout: each.
+				^ true ] ].
+	^ false
+]
+
 { #category : #'accessing properties' }
 MooseMemoryEfficientState >> removeProperty: name [
 	propertyCache removeKey: name ifAbsent: [  ]

--- a/src/Moose-Core/MooseMinimalState.class.st
+++ b/src/Moose-Core/MooseMinimalState.class.st
@@ -149,6 +149,11 @@ MooseMinimalState >> propertyAt: name put: value [
 	self nullStateError
 ]
 
+{ #category : #'accessing-attributes' }
+MooseMinimalState >> removeAttribute: aSymbol [
+	self nullStateError
+]
+
 { #category : #accessing }
 MooseMinimalState >> removeProperty: name [
 ]


### PR DESCRIPTION
Add a way to remove attributes from private state.This help when playing with a model during dev