### PR TITLE
TAnnotationTypeAttribute-should-use-TAttribute

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAccess.class.st
@@ -24,9 +24,3 @@ FAMIXAccess class >> fromMethod [
 FAMIXAccess class >> toMethod [
 	^ self lookupSelector: #variable
 ]
-
-{ #category : #'Famix-Implementation' }
-FAMIXAccess >> printOn: aStream [
-	super printOn: aStream.
-	aStream nextPutAll: ' (Access)'
-]

--- a/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXAttribute.class.st
@@ -27,36 +27,9 @@ FAMIXAttribute >> beSharedVariable [
 	self propertyNamed: #sharedVariable put: true 
 ]
 
-{ #category : #'Famix-Extensions' }
-FAMIXAttribute >> hierarchyNestingLevel [
-	<FMProperty: #hierarchyNestingLevel type: #Number>
-	<derived>
-	<FMComment: 'Attribute hierarchy nesting level'>
-		
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self belongsTo hierarchyNestingLevel]
-]
-
-{ #category : #'Famix-Extensions' }
-FAMIXAttribute >> hierarchyNestingLevel: aNumber [
-	self privateState cacheAt: #hierarchyNestingLevel put: aNumber
-]
-
 { #category : #'Famix-Smalltalk' }
 FAMIXAttribute >> isSharedVariable [
 
 	"^ self propertyNamed: #sharedVariable ifAbsent: [false] "
 	^ self propertyNamed: #sharedVariable ifNil: [false]
-]
-
-{ #category : #'Famix-Implementation' }
-FAMIXAttribute >> printOn: aStream [ 
-	| parent |
-	parent := self belongsTo.
-	parent ifNotNil:
-		[ aStream nextPutAll: parent name.
-		aStream nextPut: $. ].
-	self name ifNotNil: [ aStream nextPutAll: self name ].
-	aStream nextPutAll: ' (Attribute)'
 ]

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -14,9 +14,3 @@ FamixJavaAccess class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #printing }
-FamixJavaAccess >> printOn: aStream [
-	super printOn: aStream.
-	aStream nextPutAll: ' (Access)'
-]

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixJavaAnnotationTypeAttribute,
-	#superclass : #FamixJavaAttribute,
+	#superclass : #FamixJavaNamedEntity,
 	#traits : 'FamixTAnnotationTypeAttribute + FamixTTypedAnnotationInstanceAttribute',
 	#classTraits : 'FamixTAnnotationTypeAttribute classTrait + FamixTTypedAnnotationInstanceAttribute classTrait',
 	#category : #'Famix-Java-Entities-Entities'
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixJavaAnnotationTypeAttribute class >> annotation [
 
-	<FMClass: #AnnotationTypeAttribute super: #FamixJavaAttribute>
+	<FMClass: #AnnotationTypeAttribute super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -14,30 +14,3 @@ FamixJavaAttribute class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #metrics }
-FamixJavaAttribute >> hierarchyNestingLevel [
-	<FMProperty: #hierarchyNestingLevel type: #Number>
-	<derived>
-	<FMComment: 'Attribute hierarchy nesting level'>
-		
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self belongsTo hierarchyNestingLevel]
-]
-
-{ #category : #metrics }
-FamixJavaAttribute >> hierarchyNestingLevel: aNumber [
-	self privateState cacheAt: #hierarchyNestingLevel put: aNumber
-]
-
-{ #category : #printing }
-FamixJavaAttribute >> printOn: aStream [ 
-	| parent |
-	parent := self belongsTo.
-	parent ifNotNil:
-		[ aStream nextPutAll: parent name.
-		aStream nextPut: $. ].
-	self name ifNotNil: [ aStream nextPutAll: self name ].
-	aStream nextPutAll: ' (Attribute)'
-]

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -136,7 +136,7 @@ FamixJavaGenerator >> defineHierarchy [
 	annotationType --|> type.
 	annotationType --|> #TAnnotationType.
 
-	annotationTypeAttribute --|> attribute.
+	annotationTypeAttribute --|> namedEntity.
 	annotationTypeAttribute --|> #TAnnotationTypeAttribute.
 	annotationTypeAttribute --|> #TTypedAnnotationInstanceAttribute.
 

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -907,6 +907,8 @@ FamixGenerator >> defineHierarchy [
 	tAnnotationInstanceAttribute --|> #TEntityMetaLevelDependency.
 	tAnnotationInstanceAttribute --|> #TDependencyQueries.
 
+	tAnnotationTypeAttribute --|> tAttribute.
+
 	tCohesionCouplingMetrics --|> tPackage.
 
 	tClass --|> tWithMethods.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -14,9 +14,3 @@ FamixStAccess class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #printing }
-FamixStAccess >> printOn: aStream [
-	super printOn: aStream.
-	aStream nextPutAll: ' (Access)'
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixStAnnotationTypeAttribute,
-	#superclass : #FamixStAttribute,
+	#superclass : #FamixStNamedEntity,
 	#traits : 'FamixTAnnotationTypeAttribute + FamixTTypedAnnotationInstanceAttribute',
 	#classTraits : 'FamixTAnnotationTypeAttribute classTrait + FamixTTypedAnnotationInstanceAttribute classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixStAnnotationTypeAttribute class >> annotation [
 
-	<FMClass: #AnnotationTypeAttribute super: #FamixStAttribute>
+	<FMClass: #AnnotationTypeAttribute super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
 	^self

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -22,23 +22,6 @@ FamixStAttribute >> beSharedVariable [
 ]
 
 { #category : #'Famix-Implementation' }
-FamixStAttribute >> hierarchyNestingLevel [
-	<FMProperty: #hierarchyNestingLevel type: #Number>
-	<derived>
-	<FMComment: 'Attribute hierarchy nesting level'>
-		
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self belongsTo hierarchyNestingLevel]
-]
-
-{ #category : #'Famix-Implementation' }
-FamixStAttribute >> hierarchyNestingLevel: aNumber [
-	self privateState cacheAt: #hierarchyNestingLevel put: aNumber
-]
-
-{ #category : #'Famix-Implementation' }
 FamixStAttribute >> isSharedVariable [
-
-	^ self propertyNamed: #sharedVariable ifNil: [false]
+	^ self propertyNamed: #sharedVariable ifNil: [ false ]
 ]

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -83,7 +83,7 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	annotationType --|> #TAnnotationType.
 	annotationType --|> #TWithAttributes.
 
-	annotationTypeAttribute --|> attribute.
+	annotationTypeAttribute --|> namedEntity.
 	annotationTypeAttribute --|> #TAnnotationTypeAttribute.
 	annotationTypeAttribute --|> #TTypedAnnotationInstanceAttribute.
 

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -20,6 +20,7 @@ Trait {
 		'#variable => FMOne type: #FamixTAccessible opposite: #incomingAccesses'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Access'
 }
 
@@ -85,6 +86,12 @@ FamixTAccess >> isWrite [
 FamixTAccess >> isWrite: anObject [
 	<generated>
 	isWrite := anObject
+]
+
+{ #category : #printing }
+FamixTAccess >> printOn: aStream [
+	super printOn: aStream.
+	aStream nextPutAll: ' (Access)'
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -15,7 +15,8 @@ Trait {
 		'#parentAnnotationInstance => FMOne type: #FamixTWithAnnotationInstanceAttributes opposite: #attributes',
 		'#value => FMProperty'
 	],
-	#traits : 'TEntityMetaLevelDependency + TDependencyQueries',
+	#traits : 'TDependencyQueries + TEntityMetaLevelDependency',
+	#classTraits : 'TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-AnnotationInstanceAttribute'
 }
 

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -16,7 +16,6 @@ Trait {
 		'#value => FMProperty'
 	],
 	#traits : 'TDependencyQueries + TEntityMetaLevelDependency',
-	#classTraits : 'TDependencyQueries classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-AnnotationInstanceAttribute'
 }
 

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -22,7 +22,6 @@ Trait {
 		'#annotationAttributeInstances => FMMany type: #FamixTTypedAnnotationInstanceAttribute opposite: #annotationTypeAttribute'
 	],
 	#traits : 'FamixTAttribute',
-	#classTraits : 'FamixTAttribute classTrait',
 	#category : #'Famix-Traits-AnnotationTypeAttribute'
 }
 

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -21,6 +21,8 @@ Trait {
 	#instVars : [
 		'#annotationAttributeInstances => FMMany type: #FamixTTypedAnnotationInstanceAttribute opposite: #annotationTypeAttribute'
 	],
+	#traits : 'FamixTAttribute',
+	#classTraits : 'FamixTAttribute classTrait',
 	#category : #'Famix-Traits-AnnotationTypeAttribute'
 }
 

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -9,7 +9,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -9,6 +9,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 
@@ -19,6 +20,22 @@ FamixTAttribute classSide >> annotation [
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
+]
+
+{ #category : #metrics }
+FamixTAttribute >> hierarchyNestingLevel [
+	<FMProperty: #hierarchyNestingLevel type: #Number>
+	<derived>
+	<FMComment: 'Attribute hierarchy nesting level'>
+		
+	^self
+		lookUpPropertyNamed: #hierarchyNestingLevel
+		computedAs: [self belongsTo hierarchyNestingLevel]
+]
+
+{ #category : #metrics }
+FamixTAttribute >> hierarchyNestingLevel: aNumber [
+	self privateState cacheAt: #hierarchyNestingLevel put: aNumber
 ]
 
 { #category : #testing }
@@ -73,4 +90,15 @@ FamixTAttribute >> parentTypeGroup [
 	<generated>
 	<navigation: 'ParentType'>
 	^ MooseGroup with: self parentType
+]
+
+{ #category : #printing }
+FamixTAttribute >> printOn: aStream [
+	self parentType
+		ifNotNil: [ :parent | 
+			aStream
+				nextPutAll: parent name;
+				nextPut: $. ].
+	self name ifNotNil: [ aStream nextPutAll: self name ].
+	aStream nextPutAll: ' (Attribute)'
 ]

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -8,7 +8,6 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 Trait {
 	#name : #FamixTClass,
 	#traits : 'FamixTInvocationsReceiver + FamixTPackageable + (FamixTType - {#queryStaticIncomingAssociations. #queryStaticOutgoingAssociations}) + FamixTWithAttributes + FamixTWithComments + FamixTWithInheritances + FamixTWithMethods + TOODependencyQueries',
-	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTPackageable classTrait + FamixTType classTrait + FamixTWithAttributes classTrait + FamixTWithComments classTrait + FamixTWithInheritances classTrait + FamixTWithMethods classTrait + TOODependencyQueries classTrait',
 	#category : #'Famix-Traits-Class'
 }
 

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#typedEntities => FMMany type: #FamixTTypedEntity opposite: #declaredType'
 	],
 	#traits : 'FamixTNamedEntity + FamixTReferenceable',
-	#classTraits : 'FamixTNamedEntity classTrait + FamixTReferenceable classTrait',
 	#category : #'Famix-Traits-Type'
 }
 

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -1,7 +1,6 @@
 Trait {
 	#name : #FamixTWithStatements,
 	#traits : 'FamixTSourceEntity + FamixTWithAccesses + FamixTWithInvocations',
-	#classTraits : 'FamixTSourceEntity classTrait + FamixTWithAccesses classTrait + FamixTWithInvocations classTrait',
 	#category : #'Famix-Traits-Behavioral'
 }
 


### PR DESCRIPTION
FamixTAnnotationTypeAttribute should use FamixTAttribute

I also removed some duplication between TAttribute and classes using this trait. 
I removed the inheritance between those two classes in the Pharo and Java model.