### PR TITLE
generalize-isRoot-to-be-understood-by-all-entities

### DIFF
--- a/src/Famix-Test1-Tests/MooseEntityWithTest1ModelTest.class.st
+++ b/src/Famix-Test1-Tests/MooseEntityWithTest1ModelTest.class.st
@@ -9,3 +9,9 @@ MooseEntityWithTest1ModelTest >> testIsContainerEntity [
 	self assert: c1 isContainerEntity.
 	self deny: a1 isContainerEntity
 ]
+
+{ #category : #tests }
+MooseEntityWithTest1ModelTest >> testIsRoot [
+	self assert: c1 isRoot.
+	self deny: m1 isRoot
+]

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -10,6 +10,7 @@ Trait {
 		'#parentScope => FMOne type: #FamixTScopingEntity opposite: #childScopes'
 	],
 	#traits : '(FamixTNamedEntity + TOODependencyQueries withPrecedenceOf: TOODependencyQueries)',
+	#classTraits : '(FamixTNamedEntity classTrait + TOODependencyQueries classTrait withPrecedenceOf: TOODependencyQueries classTrait)',
 	#category : #'Famix-Traits-ScopingEntity'
 }
 
@@ -67,11 +68,6 @@ FamixTScopingEntity >> childScopes: anObject [
 
 	<generated>
 	childScopes value: anObject
-]
-
-{ #category : #accessing }
-FamixTScopingEntity >> isRoot [
-	^ self parentScope isNil
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTUnknownVariable.trait.st
+++ b/src/Famix-Traits/FamixTUnknownVariable.trait.st
@@ -1,7 +1,6 @@
 Trait {
 	#name : #FamixTUnknownVariable,
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Traits'
 }
 

--- a/src/Moose-Core-Tests/MooseEntityTest.class.st
+++ b/src/Moose-Core-Tests/MooseEntityTest.class.st
@@ -31,6 +31,17 @@ MooseEntityTest >> testBookmark [
 ]
 
 { #category : #tests }
+MooseEntityTest >> testIsRoot [
+	| entity |
+	entity := self actualClass new.
+	entity stub parents willReturn: {  }.
+	self assert: entity isRoot.
+	
+	entity stub parents willReturn: { MooseEntity new }.
+	self deny: entity isRoot
+]
+
+{ #category : #tests }
 MooseEntityTest >> testIsStub [
 	self deny: self actualClass new isStub.
 	self

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -191,6 +191,13 @@ MooseEntity >> isLinkedTo: anEntity dependancyDirection: aDirectionStrategy in: 
 ]
 
 { #category : #testing }
+MooseEntity >> isRoot [
+	"Return true if the entity is not contained in any other entity."
+
+	^ self parents isEmpty
+]
+
+{ #category : #testing }
 MooseEntity >> isStub [ 
 	^ self privateState isStub
 ]

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -311,7 +311,7 @@ MooseModel >> allBookmarks [
 
 { #category : #accessing }
 MooseModel >> allRootContainers [
-	^ self allModelContainers select: [ :each | each parents isEmpty ]
+	^ self allModelContainers select: #isRoot
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Generalize #isRoot

#isRoot was only implemented on TScopingEntities. IT can be useful for more kind of entites thus we generalized it on MooseEntity using MooseQuery.
Also added tests and use it MooseModel>>#allRootContainers