### PR TITLE
update-roassal-baseline

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -109,5 +109,5 @@ BaselineOfMoose >> roassal2: spec [
 		baseline: 'Roassal2'
 		with: [ spec
 				loads: 'Minimal';
-				repository: 'github://ObjectProfile/Roassal2:004ab6f3dfd41cf06526c57115ee42cc921e7668/src' ]
+				repository: 'github://ObjectProfile/Roassal2:614d7b80eebf6af33a777cec55ecc1c6a7a65482/src' ]
 ]


### PR DESCRIPTION
Update Roassal baseline 
to get Athens github repository instead of smalltalkhub