### PR TITLE
Avoid tab multiplication in inspector

### DIFF
--- a/src/Moose-Finder/MooseObject.extension.st
+++ b/src/Moose-Finder/MooseObject.extension.st
@@ -51,15 +51,24 @@ MooseObject >> gtInspectorActionOpenInMoose [
 
 { #category : #'*Moose-Finder' }
 MooseObject >> gtInspectorPresentationsIn: composite inContext: aGTInspector [
-	| pragmas |
-	[self mooseDescription] on: NotFound do: [ super gtInspectorPresentationsIn: composite inContext: aGTInspector.
-		^ self ].
+	| pragmas acceptedPragmas |
+	[ self mooseDescription ]
+		on: NotFound
+		do: [ super gtInspectorPresentationsIn: composite inContext: aGTInspector.
+			^ self ].
 	pragmas := Pragma
 		allNamed: #moosePresentationOrder:
 		from: self mooseInterestingEntity class
 		to: Object
 		sortedUsing: [ :x :y | (x argumentAt: 1) < (y argumentAt: 1) ].
+	acceptedPragmas := OrderedCollection new.
 	pragmas
+		do: [ :pragma | 
+			(acceptedPragmas
+				anySatisfy:
+					[ :alreadyAcceptedPragma | alreadyAcceptedPragma method origin = pragma method origin and: [ alreadyAcceptedPragma method selector = pragma method selector ] ])
+				ifFalse: [ acceptedPragmas add: pragma ] ].
+	acceptedPragmas
 		do: [ :eachPragma | 
 			(eachPragma methodSelector findTokens: $:) size = 1
 				ifTrue: [ self mooseInterestingEntity


### PR DESCRIPTION
The inspector shows multiple times the same tabs and it is super annoying.
So, I propose this simple fix.

before: 
![image](https://user-images.githubusercontent.com/6225039/96975125-64d5d380-151a-11eb-933f-a1c8048102d0.png)

after: 
![image](https://user-images.githubusercontent.com/6225039/96975170-6e5f3b80-151a-11eb-8784-f248540fb91c.png)
