### PR TITLE
Ask the user to choose a metamodel before importing a model from MSE

### DIFF
--- a/src/Moose-Finder/FamixRepTestModel.extension.st
+++ b/src/Moose-Finder/FamixRepTestModel.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixRepTestModel }
+
+{ #category : #'*Moose-Finder' }
+FamixRepTestModel class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTagTestModel.extension.st
+++ b/src/Moose-Finder/FamixTagTestModel.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTagTestModel }
+
+{ #category : #'*Moose-Finder' }
+FamixTagTestModel class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTest1Model.extension.st
+++ b/src/Moose-Finder/FamixTest1Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTest1Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTest1Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTest2Model.extension.st
+++ b/src/Moose-Finder/FamixTest2Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTest2Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTest2Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTest3Model.extension.st
+++ b/src/Moose-Finder/FamixTest3Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTest3Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTest3Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTest4Model.extension.st
+++ b/src/Moose-Finder/FamixTest4Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTest4Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTest4Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTest5Model.extension.st
+++ b/src/Moose-Finder/FamixTest5Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTest5Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTest5Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTestComposed1Model.extension.st
+++ b/src/Moose-Finder/FamixTestComposed1Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTestComposed1Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTestComposed1Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTestComposed2Model.extension.st
+++ b/src/Moose-Finder/FamixTestComposed2Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTestComposed2Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTestComposed2Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTestComposed3Model.extension.st
+++ b/src/Moose-Finder/FamixTestComposed3Model.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTestComposed3Model }
+
+{ #category : #'*Moose-Finder' }
+FamixTestComposed3Model class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTestComposedComposedModel.extension.st
+++ b/src/Moose-Finder/FamixTestComposedComposedModel.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTestComposedComposedModel }
+
+{ #category : #'*Moose-Finder' }
+FamixTestComposedComposedModel class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/FamixTestComposedModel.extension.st
+++ b/src/Moose-Finder/FamixTestComposedModel.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FamixTestComposedModel }
+
+{ #category : #'*Moose-Finder' }
+FamixTestComposedModel class >> isTestModel [
+	^ true
+]

--- a/src/Moose-Finder/MPImportMSECommand.class.st
+++ b/src/Moose-Finder/MPImportMSECommand.class.st
@@ -6,11 +6,13 @@ Class {
 
 { #category : #hooks }
 MPImportMSECommand >> execute [
-	[ MooseModel new
-		importFromMSE;
-		ifNotEmpty: [ :model | 
-			model install.
-			self addModel: model ] ] fork
+	[ self modelClass
+		ifNotNil: [ :modelClass | 
+			modelClass new
+				importFromMSE;
+				ifNotEmpty: [ :model | 
+					model install.
+					self addModel: model ] ] ] fork
 ]
 
 { #category : #hooks }
@@ -21,4 +23,15 @@ MPImportMSECommand >> icon [
 { #category : #hooks }
 MPImportMSECommand >> label [
 	^ 'Import model from MSE file'
+]
+
+{ #category : #hooks }
+MPImportMSECommand >> modelClass [
+	| modelClasses |
+	modelClasses := MooseModel withAllSubclasses
+		reject: [ :model | model isDeprecated or: [ model isTestModel ] ].
+	^ UIManager default
+		chooseFrom: (modelClasses collect: [ :model | model name ])
+		values: modelClasses
+		title: 'Please select a metamodel'
 ]

--- a/src/Moose-Finder/MooseModel.extension.st
+++ b/src/Moose-Finder/MooseModel.extension.st
@@ -142,6 +142,11 @@ MooseModel >> importFromMSE [
 ]
 
 { #category : #'*Moose-Finder' }
+MooseModel class >> isTestModel [
+	^ false
+]
+
+{ #category : #'*Moose-Finder' }
 MooseModel class >> menuBrowseMetaOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'MetaBrowser')


### PR DESCRIPTION
Providing a list of available MM, ask the user to choose one before importing fom MSE.
Probably not the more elegant way to discriminate MM classes, but it does the job.