### PR TITLE
Add the pharo.version file in the releases to help the Pharo Launcher

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,6 +35,7 @@ jobs:
           mv /home/runner/.smalltalkCI/_builds/* .
           mv TravisCI.image $PROJECT_NAME.image
           mv TravisCI.changes $PROJECT_NAME.changes
+          echo ${${{ matrix.smalltalk }}: -3} | sed -e 's/\.//g' > pharo.version
           zip -r $PROJECT_NAME.zip $PROJECT_NAME.image $PROJECT_NAME.changes *.sources pharo.version
           ls
       

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,7 +35,7 @@ jobs:
           mv /home/runner/.smalltalkCI/_builds/* .
           mv TravisCI.image $PROJECT_NAME.image
           mv TravisCI.changes $PROJECT_NAME.changes
-          echo ${${{ matrix.smalltalk }}: -3} | sed -e 's/\.//g' > pharo.version
+          echo ${${{ matrix.smalltalk }}} | sed -e 's/\.//g' > pharo.version
           zip -r $PROJECT_NAME.zip $PROJECT_NAME.image $PROJECT_NAME.changes *.sources pharo.version
           ls
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           mv /home/runner/.smalltalkCI/_builds/* .
           mv TravisCI.image $PROJECT_NAME.image
           mv TravisCI.changes $PROJECT_NAME.changes
+          echo ${${{ matrix.smalltalk }}} | sed -e 's/\.//g' > pharo.version
           zip -r $PROJECT_NAME.zip $PROJECT_NAME.image $PROJECT_NAME.changes *.sources pharo.version
           ls
           


### PR DESCRIPTION
Pharo Launcher uses the pharo.version files to determine which VM to use.
This PR aims to add the pharo.version files in our GitHub releases to help the Launcher