### PR TITLE
Remove old gt method

### DIFF
--- a/src/Moose-Finder/Object.extension.st
+++ b/src/Moose-Finder/Object.extension.st
@@ -59,19 +59,6 @@ Object >> mooseFinderEvaluatorIn: composite [
 ]
 
 { #category : #'*Moose-Finder' }
-Object >> mooseFinderExampleSourceIn: composite inContext: aFinder [
-	<moosePresentationOrder: 10>
-	| previousRawSelection |
-	aFinder panes size > 1
-		ifTrue: [ 
-			previousRawSelection := (aFinder panes reversed second port: #rawSelection) value.
-			previousRawSelection isGTExample
-				ifTrue: [ (previousRawSelection gtDisplaySourceIn: composite) 
-					title: 'E.g. source';
-					titleIcon: MooseIcons mooseSourceText ] ]
-]
-
-{ #category : #'*Moose-Finder' }
 Object >> mooseFinderMetaIn: composite [
 	<moosePresentationOrder: 1000>
 	(self mooseInterestingEntity gtInspectorMetaIn: composite)


### PR DESCRIPTION
#mooseFinderExampleSourceIn:inContext:
Not useful anymore and a source for bugs.