### PR TITLE
Minor refactors

### DIFF
--- a/src/Moose-Finder/MooseImportFromSmalltalkForm.class.st
+++ b/src/Moose-Finder/MooseImportFromSmalltalkForm.class.st
@@ -1,3 +1,6 @@
+"
+I am a form that allows user to import smalltalk packages as Moose model objects.
+"
 Class {
 	#name : #MooseImportFromSmalltalkForm,
 	#superclass : #MooseImportForm,
@@ -106,11 +109,12 @@ MooseImportFromSmalltalkForm >> importerClass [
 
 { #category : #layout }
 MooseImportFromSmalltalkForm >> importerClassLayout [
+
 	^ SpPanedLayout newHorizontal
-		add: 'Importer: ';
-		position: 1.5 / 5;
-		add: #importerDroplist;
-		yourself
+		  add: 'Importer: ';
+		  positionOfSlider: 1.5 / 5;
+		  add: #importerDroplist;
+		  yourself
 ]
 
 { #category : #initialization }
@@ -203,11 +207,12 @@ MooseImportFromSmalltalkForm >> invocationStrategyLayout [
 
 { #category : #layout }
 MooseImportFromSmalltalkForm >> metamodelFactoryLayout [
+
 	^ SpPanedLayout newHorizontal
-		add: 'Metamodel factory: ';
-		position: 1.5 / 5;
-		add: #factoryDroplist;
-		yourself
+		  add: 'Metamodel factory: ';
+		  positionOfSlider: 1.5 / 5;
+		  add: #factoryDroplist;
+		  yourself
 ]
 
 { #category : #accessing }

--- a/src/Moose-Finder/MooseSmalltalkPackagesSelector.class.st
+++ b/src/Moose-Finder/MooseSmalltalkPackagesSelector.class.st
@@ -1,17 +1,19 @@
+"
+I am an small tool that allows to the user to select the packages that want to import. I am called in `MooseImportFromSmalltalkForm`.
+My instance variable importer is an instance of `MooseImportFromSmalltalkForm`. It is set at the moment if my creation. See `MooseImportFromSmalltalkForm>>#initializePackagesButton`
+"
 Class {
 	#name : #MooseSmalltalkPackagesSelector,
 	#superclass : #MiPresenter,
 	#instVars : [
 		'importer',
-		'acceptButton',
-		'cancelButton',
 		'chosenPackagesFilteringList',
 		'allPackagesFilteringList'
 	],
 	#category : #'Moose-Finder-Import'
 }
 
-{ #category : #accessing }
+{ #category : #specs }
 MooseSmalltalkPackagesSelector class >> defaultSpec [
 
 	^ SpBoxLayout newHorizontal
@@ -42,21 +44,34 @@ MooseSmalltalkPackagesSelector >> initializePresenters [
 
 	super initializePresenters.
 	allPackagesFilteringList := self newFilteringList
-		               items: RPackage organizer packageNames;
-		               yourself.
+		                            items: RPackage organizer packageNames;
+		                            yourself.
 	allPackagesFilteringList listPresenter
 		beMultipleSelection;
 		sortingBlock: #yourself ascending;
 		selectItems: importer packages;
 		whenSelectionChangedDo: [ 
-			chosenPackagesFilteringList items: allPackagesFilteringList listPresenter selectedItems ].
+			chosenPackagesFilteringList items:
+					allPackagesFilteringList listPresenter selectedItems ].
 	chosenPackagesFilteringList := self newFilteringList
-		                  items: allPackagesFilteringList listPresenter selectedItems;
-		                  yourself.
-	chosenPackagesFilteringList listPresenter sortingBlock: #yourself ascending
+		                               items:
+			                               allPackagesFilteringList
+				                               listPresenter selectedItems;
+		                               yourself.
+	chosenPackagesFilteringList listPresenter sortingBlock:
+		#yourself ascending
+]
+
+{ #category : #initialization }
+MooseSmalltalkPackagesSelector >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 450 @ 400
 ]
 
 { #category : #'accessing model' }
 MooseSmalltalkPackagesSelector >> setModelBeforeInitialization: anImportPresenter [
+
 	importer := anImportPresenter
 ]


### PR DESCRIPTION
For `MooseSmaltalkPackagesSelector `:
- Changed MooseSmaltalkPackagesSelector window size.
- Deleted never used instance variables 'acceptButton', 'cancelButton from MooseSmaltalkPackagesSelector.
- Added class comment for MooseSmaltalkPackagesSelector.
- Changed protocol of class side method defaultSpec from accessing to spec to be consistent with its super-class.

For `MooseImportFromSmalltalkForm`:
- Added class comment for MooseImportFromSmalltalkForm.
- Replaced the call to a deprecated method to its new version (position: to positionOfSlider:).