### PR TITLE
Declare Moose-Finder dependency to Glamour-Tools

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -26,7 +26,7 @@ BaselineOfMoose >> baseline: spec [
 				spec requires:
 						#( 'Famix' 'FamixTagging' 'FamixReplication' 'FamixPresentation'
 						   'MooseAlgos' 'Moose-RoassalPaintings'
-						   'NeoCSV' 'Merlin' ) ];
+						   'NeoCSV' 'Merlin' 'Glamour-Tools' ) ];
 			package: 'Moose-MenuBar'
 			with: [ spec requires: #( 'Moose-Finder' ) ];
 			package: 'Moose-Configuration';


### PR DESCRIPTION
This is needed in Midas (and should not)