### PR TITLE
Update continuous.yml

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -19,7 +19,7 @@ jobs:
       PROJECT_NAME: Moose9-development
     strategy:
       matrix:
-        smalltalk: [ Pharo64-9.0 ]
+        smalltalk: [ Pharo64-9.0, Pharo64-10 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add Pharo 10 to CI.
We do not make it mandatory, it is just a way to follow Moose compatibility with Pharo 10.