### PR TITLE
Update continuous.yml

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -19,7 +19,7 @@ jobs:
       PROJECT_NAME: Moose9-development
     strategy:
       matrix:
-        smalltalk: [ Pharo64-9.0, Pharo64-10 ]
+        smalltalk: [ Pharo64-9.0 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pharo10.yml
+++ b/.github/workflows/pharo10.yml
@@ -1,25 +1,18 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Continuous-development
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the development branch
 on:
   push:
     branches:
       - development
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 0 * * *'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Moose9-development
+      PROJECT_NAME: Moose-on-Pharo10
     strategy:
       matrix:
-        smalltalk: [ Pharo64-9.0 ]
+        smalltalk: [ Pharo64-10 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Remove Pharo10 from continous.
Pharo 10 will be run in a different workflow, so it does not override the Moose9-development  ressource