### PR TITLE
Update Baseline for Moose-Easy

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -89,7 +89,7 @@ BaselineOfMoose >> mooseAlgos: spec [
 
 { #category : #dependencies }
 BaselineOfMoose >> mooseEasy: spec [
-	spec baseline: 'MooseEasy' with: [ spec repository: 'github://moosetechnology/Moose-Easy:v1.x.x/src' ]
+	spec baseline: 'MooseEasy' with: [ spec repository: 'github://moosetechnology/Moose-Easy:v2/src' ]
 ]
 
 { #category : #dependencies }


### PR DESCRIPTION
MooseEasy was broken in Moose9 because of modification in Spec
I have created a v2 version of Moose-Easy with the support of Moose9
Can we change the baseline of Moose (Moose9) to download the correct version of Moose-Easy?