### PR TITLE
Update MooseEasy to v3 branch

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -70,7 +70,7 @@ BaselineOfMoose >> mooseEasy: spec [
 	spec
 		baseline: 'MooseEasy'
 		with: [
-		spec repository: 'github://moosetechnology/Moose-Easy:v2/src' ]
+		spec repository: 'github://moosetechnology/Moose-Easy:v3/src' ]
 ]
 
 { #category : #dependencies }


### PR DESCRIPTION
I created a V3 branch of Moose Easy were I migrated the code to run on Pharo 11 (and Moose 11). Here is the update of the branch to load in Moose