### PR TITLE
Sort Iceberg repositories

### DIFF
--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -95,7 +95,7 @@ BaselineOfMoose >> registerMooseWelcomeBrowser [
 BaselineOfMoose >> registerToIceberg [
 
 	Smalltalk
-		at: #MooseWelcomeBrowser
+		at: #MooseConfiguration
 		ifPresent: [ :mooseConfiguration |
 		mooseConfiguration registerToIceberg ]
 ]

--- a/src/BaselineOfMoose/BaselineOfMoose.class.st
+++ b/src/BaselineOfMoose/BaselineOfMoose.class.st
@@ -19,11 +19,14 @@ BaselineOfMoose >> baseline: spec [
 			mooseIDE: spec.
 
 		spec
-			package: 'Moose-Configuration' with: [ spec requires: #( 'Famix' 'FamixTagging' 'FamixReplication' 'MooseIDE' ) ];
-			package: 'Moose-WelcomeBrowser' with: [ spec requires: #( 'Moose-Configuration' ) ].
+			package: 'Moose-Configuration' with: [
+				spec requires:
+						#( 'Famix' 'FamixTagging' 'FamixReplication' 'MooseIDE' ) ];
+			package: 'Moose-WelcomeBrowser'
+			with: [ spec requires: #( 'Moose-Configuration' ) ].
 
 		self groups: spec.
-		spec postLoadDoIt: #registerMooseWelcomeBrowser ]
+		spec postLoadDoIt: #installMooseConfigurations ]
 ]
 
 { #category : #dependencies }
@@ -59,6 +62,13 @@ BaselineOfMoose >> groups: spec [
 	spec group: 'Metamodel' with: #( 'Famix' )
 ]
 
+{ #category : #actions }
+BaselineOfMoose >> installMooseConfigurations [
+
+	self registerMooseWelcomeBrowser.
+	self registerToIceberg
+]
+
 { #category : #dependencies }
 BaselineOfMoose >> mooseIDE: spec [
 
@@ -75,9 +85,17 @@ BaselineOfMoose >> projectClass [
 
 { #category : #actions }
 BaselineOfMoose >> registerMooseWelcomeBrowser [
-	"For Pharo 11 and after"
 
 	Smalltalk
 		at: #MooseWelcomeBrowser
 		ifPresent: [ :mooseWelcome | mooseWelcome register ]
+]
+
+{ #category : #actions }
+BaselineOfMoose >> registerToIceberg [
+
+	Smalltalk
+		at: #MooseWelcomeBrowser
+		ifPresent: [ :mooseConfiguration |
+		mooseConfiguration registerToIceberg ]
 ]

--- a/src/Moose-Configuration/MooseConfiguration.class.st
+++ b/src/Moose-Configuration/MooseConfiguration.class.st
@@ -31,3 +31,23 @@ MooseConfiguration class >> mooseSettingsOn: aBuilder [
 		label: 'Moose';
 		description: 'Moose settings'
 ]
+
+{ #category : #iceberg }
+MooseConfiguration class >> registerToIceberg [
+
+	Iceberg announcer
+		when: IceRepositoryCreated
+		send: #sortIcebergRepositories
+		to: self.
+
+	Iceberg announcer
+		when: IceRepositoryModified
+		send: #sortIcebergRepositories
+		to: self
+]
+
+{ #category : #iceberg }
+MooseConfiguration class >> sortIcebergRepositories [
+
+	IceRepository registry sort: #isMissing ascending , #name ascending
+]


### PR DESCRIPTION
This will sort repositories by:
- Cloned repositories before  'Local repository missing'
- Name

Register MooseConfiguration to Iceberg announcements, so this sorting will happen each time a repo is added or modified (cloned).

Fix #2539 